### PR TITLE
fix: Replace relative paths with absolute paths in OpenCode call comm…

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,7 +148,7 @@ def _run_opencode_step(proj_dir, work_dir, script_dir, log_file,
         try:
             subprocess.run(
                 ["opencode", "run", "--model", f"openrouter/{LLM_MODEL}",
-                 "--file", f"fm_agent/{md_name}", "--", prompt],
+                 "--file", os.path.join(proj_dir, "fm_agent", md_name), "--", prompt],
                 cwd=proj_dir, check=True, stdout=log_file, stderr=log_file,
             )
         except subprocess.CalledProcessError as e:
@@ -257,7 +257,7 @@ def run_pipeline(proj_dir):
             prompt = ("Continue where you left off. The previous run was interrupted by a network error. "
                       f"Check what has already been done and only complete the remaining steps. {fm_reminder}")
         try:
-            subprocess.run(["opencode", "run", "--model", f"openrouter/{LLM_MODEL}", "--file", "fm_agent/workflow_setup_extract.md", "--", prompt], cwd=proj_dir, check=True, stdout=log_file, stderr=log_file)
+            subprocess.run(["opencode", "run", "--model", f"openrouter/{LLM_MODEL}", "--file", os.path.join(proj_dir, "fm_agent", "workflow_setup_extract.md"), "--", prompt], cwd=proj_dir, check=True, stdout=log_file, stderr=log_file)
         except subprocess.CalledProcessError as e:
             logging.warning(f"Stage 2 attempt {attempt}: opencode exited with code {e.returncode}")
 
@@ -421,7 +421,7 @@ def run_pipeline(proj_dir):
                         )
                     proc = subprocess.Popen(
                         ["opencode", "run", "--model", f"openrouter/{LLM_MODEL}",
-                         "--file", "fm_agent/workflow_spec_step4_batch.md",
+                         "--file", os.path.join(proj_dir, "fm_agent", "workflow_spec_step4_batch.md"),
                          "--", prompt],
                         cwd=proj_dir, stdout=log_file, stderr=log_file,
                     )

--- a/src/verification.py
+++ b/src/verification.py
@@ -319,7 +319,7 @@ def _validate_single_bug(result_json_rel, proj_dir, work_dir=None):
         with open(log_path, "a") as log_file:
             subprocess.run(
                 ["opencode", "run", "--model", f"openrouter/{LLM_MODEL}",
-                 "--file", prompt_filename,
+                 "--file", prompt_path,
                  "--", "Follow the instructions in the attached file"],
                 cwd=proj_dir, check=True,
                 stdout=log_file, stderr=log_file,


### PR DESCRIPTION
When using OpenCode 1.14.48 (tested), running the program would encounter the problem below:
```
[Pipeline] Stage 2/5: Understanding codebase and extracting functions ...
[Pipeline] Stage 2 failed to produce phases.json (attempt 1/5). Retrying in 10s...
[Pipeline] Stage 2 failed to produce phases.json (attempt 2/5). Retrying in 10s...
```
while the fm_agent.log reads:
```
Error: File not found: fm_agent/workflow_setup_extract.md
```
And after downgrading to OpenCode 1.14.40, the problem was resolved.

So I can infer that OpenCode changed its behavior on paths in the newest release.

This pull request made 4 changes:

`main.py` line 151, 247, 411

`verification.py` line 322