### PR TITLE
fix: opencode subprocess timeout + DeepSeek dashboard cache accounting

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,3 +20,8 @@ MAX_SPC_ITER = 5
 GRANULARITY = 40
 MAX_WORKERS = 10
 OPENCODE_MAX_RETRIES = 5
+# Hard cap on ONE `opencode run` subprocess. A model connection that dies
+# silently (e.g. through a forward proxy) otherwise hangs the pipeline forever —
+# opencode has no model-call timeout of its own. On expiry the child is killed
+# and the call raises CalledProcessError, which the callers' retry paths handle.
+OPENCODE_TIMEOUT_SECONDS = int(os.environ.get("OPENCODE_TIMEOUT_SECONDS", "1800"))

--- a/dashboard.py
+++ b/dashboard.py
@@ -239,6 +239,12 @@ class State:
                     # OpenAI shape (svip compat path or older runs)
                     inp = usage.get("prompt_tokens", 0) or 0
                     out = usage.get("completion_tokens", 0) or 0
+                    # DeepSeek reports cache as flat fields; prompt_tokens is the
+                    # TOTAL (hit + miss). Split into disjoint in:new / in:read.
+                    hit = usage.get("prompt_cache_hit_tokens")
+                    if hit is not None:
+                        cr = hit
+                        inp = usage.get("prompt_cache_miss_tokens", inp - hit)
                 self.totals["input"] += inp
                 self.totals["output"] += out
                 self.totals["cache_read"] += cr
@@ -307,10 +313,19 @@ class State:
         if not (inp or out):
             return  # not a response payload
         self.opencode_calls += 1
-        cr = (usage.get("cache_read_input_tokens")
-              or _get_nested(usage, "prompt_tokens_details", "cached_tokens")
-              or _get_nested(usage, "input_tokens_details", "cached_tokens")
-              or 0)
+        # DeepSeek (openai-compat) reports cache as flat top-level fields, and
+        # prompt_tokens is the TOTAL (hit + miss). Split it into the disjoint
+        # in:new / in:read the rest of the dashboard assumes — otherwise the
+        # cached half is double-counted and the hit rate reads low.
+        hit = usage.get("prompt_cache_hit_tokens")
+        if hit is not None:
+            cr = hit
+            inp = usage.get("prompt_cache_miss_tokens", inp - hit)
+        else:
+            cr = (usage.get("cache_read_input_tokens")
+                  or _get_nested(usage, "prompt_tokens_details", "cached_tokens")
+                  or _get_nested(usage, "input_tokens_details", "cached_tokens")
+                  or 0)
         cw = (usage.get("cache_creation_input_tokens")
               or usage.get("claude_cache_creation_5_m_tokens")
               or 0)

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -166,6 +166,7 @@ def _retry_create(client, model, messages):
                     f"Rate limited after {_MAX_RATE_LIMIT_RETRIES} retries: {exc}"
                 ) from exc
             wait = min(2 ** (rate_limit_attempts - 1) * 5, 300) + random.uniform(1, 10)
+            logging.warning(f"LLM rate-limited, sleeping {wait:.1f}s (attempt {rate_limit_attempts})")
             time.sleep(wait)
         except Exception as exc:
             transient_attempts += 1
@@ -174,6 +175,9 @@ def _retry_create(client, model, messages):
                     f"LLM request failed after {_MAX_LLM_RETRIES} retries: {exc}"
                 ) from exc
             wait = min(2 ** (transient_attempts - 1) * 5, 60) + random.uniform(1, 3)
+            logging.warning(
+                f"LLM error ({type(exc).__name__}: {str(exc)[:120]}), "
+                f"sleeping {wait:.1f}s (attempt {transient_attempts})")
             time.sleep(wait)
 
 

--- a/src/opencode_trace.py
+++ b/src/opencode_trace.py
@@ -1,8 +1,10 @@
+import logging
 import os
 import subprocess
 import threading
 from dataclasses import dataclass
 
+from config import OPENCODE_TIMEOUT_SECONDS
 from .trace_writer import (
     new_event_id,
     record_trace_event,
@@ -202,7 +204,27 @@ def run_opencode_traced(
     log_thread = None
     try:
         proc, log_thread = _start_opencode_process(proj_dir, work_dir, event_id, command, opencode_log_path)
-        exit_code = proc.wait()
+        try:
+            exit_code = proc.wait(timeout=OPENCODE_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            # A model connection that dies silently (e.g. through a forward proxy)
+            # leaves opencode waiting forever — it has no model-call timeout of its
+            # own. Kill it and surface a CalledProcessError so the caller's retry
+            # path takes over instead of the whole pipeline hanging.
+            logging.warning(
+                "opencode %s timed out after %ds, killing: %s",
+                stage, OPENCODE_TIMEOUT_SECONDS, " ".join(command),
+            )
+            proc.terminate()
+            try:
+                exit_code = proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                exit_code = proc.wait()
+            if not exit_code:
+                exit_code = -15  # killed-on-timeout must never record as success
+            error = f"timeout after {OPENCODE_TIMEOUT_SECONDS}s"
+            raise subprocess.CalledProcessError(exit_code, command)
         if log_thread:
             log_thread.join()
         if exit_code != 0:
@@ -210,7 +232,7 @@ def run_opencode_traced(
         return subprocess.CompletedProcess(command, exit_code)
     except subprocess.CalledProcessError as exc:
         exit_code = exc.returncode
-        error = str(exc)
+        error = error or str(exc)
         raise
     finally:
         if log_thread and log_thread.is_alive():


### PR DESCRIPTION
Two small, independent robustness fixes (no behavior change to the happy path).

### opencode hard timeout (`ffda7c9`)
A model connection that dies silently (e.g. through a forward proxy) left
`opencode run` waiting forever — opencode has no model-call timeout, and
`run_opencode_traced` waited unboundedly, so the whole pipeline could hang for
hours. Add `proc.wait(timeout=OPENCODE_TIMEOUT_SECONDS)` (new config knob,
default 1800s, env-overridable): on expiry the child is terminated/killed, the
call raises `CalledProcessError` (already handled by callers retry paths) and the
trace records it as `error` — so a wedged call self-heals instead of hanging.
Also: the previously-silent `RateLimitError` / generic-`Exception` retry branches
in `_retry_create` now log a warning with wait time + attempt, so a retrying
client no longer looks like a dead process.

### dashboard DeepSeek cache accounting (`3e38310`)
DeepSeek’s OpenAI-compatible API reports prompt caching as two flat top-level
fields — `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` — with
`prompt_tokens` being the TOTAL (hit + miss). The dashboard only knew the
Anthropic shape (`cache_read_input_tokens`) and the nested OpenAI shape
(`prompt_tokens_details.cached_tokens`), so DeepSeek runs recorded `cache_read=0`
and counted the whole prompt as `in:new` — the displayed hit rate collapsed while
the API was actually serving ~96%. Both ingest paths now prefer the flat fields
and split the total into disjoint `in:new` (miss) / `in:read` (hit). The
Anthropic path is unchanged.

Files: `config.py`, `src/opencode_trace.py`, `src/llm_client.py`, `dashboard.py`
(+52 / −6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)