### PR TITLE
fix(entry): skip broken symlinks during selection

### DIFF
--- a/src/entry_reasoning_pipeline.py
+++ b/src/entry_reasoning_pipeline.py
@@ -56,6 +56,9 @@ def _extract_for_selection(proj_dir, tmp_root):
         for fname in files:
             src_path = os.path.join(root, fname)
             src_rel = os.path.relpath(src_path, proj_dir)
+            if not os.path.isfile(src_path):
+                logging.debug("Skipping non-file source path during entry selection: %s", src_rel)
+                continue
             ext = fname.rsplit(".", 1)[-1] if "." in fname else ""
             lang_key = EXT_TO_LANG.get(ext)
             if not lang_key or _is_test_file(src_rel):


### PR DESCRIPTION
## Summary

- Entry-point selection previously attempted to open every discovered source-looking path directly.
- When the source tree contained a broken symlink with a supported extension, that `open()` call raised `FileNotFoundError` and aborted the run before selection completed.
- Skip paths that are not regular files before extraction. Valid symlinks to regular files are still processed.

## Verification

- `.venv/bin/python -m py_compile src/entry_reasoning_pipeline.py`
- Verified `_extract_for_selection()` completes on a synthetic source tree containing a broken `.h` symlink and a valid `.c` source file.
