### PR TITLE
Support macOS install compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,10 @@ fi
 
 # ---------- Python packages ----------
 echo "[..] installing Python dependencies"
-python3 -m pip install openai
+if ! python3 -m pip install openai; then
+    echo "[..] pip install failed; syncing Python dependencies with uv"
+    uv sync --locked
+fi
 
 # ---------- unzip ----------
 if command -v unzip &>/dev/null; then


### PR DESCRIPTION
## Summary

- Keep the existing `pip install openai` path as the first install attempt.
- Fall back to `uv sync --locked` when pip installation fails.
- Improve compatibility with macOS setups where Homebrew-managed Python environments reject direct package installation through pip.

## Test

- `bash -n install.sh`