### PR TITLE
feat(extract): add codegraph backend for Python

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,5 +82,13 @@ fi
 echo "[..] installing/updating oh-my-openagent"
 bunx oh-my-openagent install --no-tui --claude=no --gemini=no --copilot=no
 
+# ---------- codegraph ----------
+if command -v codegraph &>/dev/null; then
+    echo "[ok] codegraph found: $(codegraph --version 2>/dev/null || echo 'unknown version')"
+else
+    echo "[..] installing codegraph"
+    bun install -g @colbymchenry/codegraph
+fi
+
 echo ""
 echo "=== all dependencies installed ==="

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from src.opencode_trace import (
     start_opencode_traced,
 )
 from src.incremental_reasoner import run_incremental_pipeline
+from src.languages.codegraph import try_codegraph_init
 import os
 import sys
 import argparse
@@ -130,27 +131,6 @@ def _get_phase_files(phases_data, phase_num, input_dir):
                         phase_files.append(os.path.relpath(fpath, input_dir))
     return phase_files
 
-
-def _try_codegraph_init(proj_dir):
-    """Run `codegraph init` in proj_dir if codegraph is installed and the index
-    does not yet exist. Silently skips when codegraph is not installed so that
-    the pipeline falls back to the regex-based extractor without any error."""
-    db_path = os.path.join(proj_dir, ".codegraph", "codegraph.db")
-    if os.path.exists(db_path):
-        return
-    try:
-        subprocess.run(["codegraph", "--version"], capture_output=True, check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return
-    print("[Pipeline] Building codegraph index (this runs once per project)...")
-    result = subprocess.run(
-        ["codegraph", "init"], cwd=proj_dir, capture_output=True, text=True
-    )
-    if result.returncode == 0:
-        print("[Pipeline] codegraph index built.")
-    else:
-        logging.warning("codegraph init failed (non-fatal, falling back to regex): %s",
-                        result.stderr[:300])
 
 
 def _clean_previous_run(work_dir):
@@ -625,7 +605,7 @@ def run_pipeline(proj_dir, resume=False, required_source_files=None):
     # Build codegraph index if codegraph is installed and index not yet present.
     # Both run_extraction (Stage 2) and generate_topdown_layers (Stage 3) will
     # automatically use the index when it exists.
-    _try_codegraph_init(proj_dir)
+    try_codegraph_init(proj_dir)
 
     # Run function extraction using extract.py
     # force=False on resume preserves already-specced extracted files; on a fresh

--- a/main.py
+++ b/main.py
@@ -131,6 +131,28 @@ def _get_phase_files(phases_data, phase_num, input_dir):
     return phase_files
 
 
+def _try_codegraph_init(proj_dir):
+    """Run `codegraph init` in proj_dir if codegraph is installed and the index
+    does not yet exist. Silently skips when codegraph is not installed so that
+    the pipeline falls back to the regex-based extractor without any error."""
+    db_path = os.path.join(proj_dir, ".codegraph", "codegraph.db")
+    if os.path.exists(db_path):
+        return
+    try:
+        subprocess.run(["codegraph", "--version"], capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return
+    print("[Pipeline] Building codegraph index (this runs once per project)...")
+    result = subprocess.run(
+        ["codegraph", "init"], cwd=proj_dir, capture_output=True, text=True
+    )
+    if result.returncode == 0:
+        print("[Pipeline] codegraph index built.")
+    else:
+        logging.warning("codegraph init failed (non-fatal, falling back to regex): %s",
+                        result.stderr[:300])
+
+
 def _clean_previous_run(work_dir):
     """Remove the fm_agent working directory from the previous pipeline run."""
     if os.path.isdir(work_dir):
@@ -599,6 +621,11 @@ def run_pipeline(proj_dir, resume=False, required_source_files=None):
     )
     if forced:
         print(f"[Pipeline] Forced {len(forced)} required source file(s) into phases.json: {', '.join(forced)}")
+
+    # Build codegraph index if codegraph is installed and index not yet present.
+    # Both run_extraction (Stage 2) and generate_topdown_layers (Stage 3) will
+    # automatically use the index when it exists.
+    _try_codegraph_init(proj_dir)
 
     # Run function extraction using extract.py
     # force=False on resume preserves already-specced extracted files; on a fresh

--- a/src/extract.py
+++ b/src/extract.py
@@ -664,7 +664,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     with open(phases_path, 'r') as f:
         phases_data = json.load(f)
 
-    _backend_funcs, _backend_langs = batch_extract_all(proj_dir)
+    backend_funcs, backend_langs = batch_extract_all(proj_dir)
 
     # Build source file list from phases.json
     source_files = []
@@ -707,8 +707,8 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
             dir_name = src_base
         out_dir = os.path.join(output_base, src_dir, dir_name) if src_dir else os.path.join(output_base, dir_name)
 
-        if src_path in _backend_funcs:
-            funcs = _backend_funcs[src_path]
+        if src_path in backend_funcs:
+            funcs = backend_funcs[src_path]
         else:
             funcs = extract_functions_from_file(src_path, lang_key)
         if not funcs:
@@ -740,7 +740,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         return written, skipped
 
     # --- Validation (Step 2) ---
-    validation_failures = _validate_extraction(output_base, backend_langs=_backend_langs)
+    validation_failures = _validate_extraction(output_base, backend_langs=backend_langs)
     if validation_failures:
         logging.warning(
             f"Validation: {len(validation_failures)} file(s) do not contain exactly one function."

--- a/src/extract.py
+++ b/src/extract.py
@@ -664,7 +664,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     with open(phases_path, 'r') as f:
         phases_data = json.load(f)
 
-    backend_funcs, backend_langs = batch_extract_all(proj_dir)
+    registry_funcs, registry_langs = batch_extract_all(proj_dir)
 
     # Build source file list from phases.json
     source_files = []
@@ -707,8 +707,8 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
             dir_name = src_base
         out_dir = os.path.join(output_base, src_dir, dir_name) if src_dir else os.path.join(output_base, dir_name)
 
-        if src_path in backend_funcs:
-            funcs = backend_funcs[src_path]
+        if src_path in registry_funcs:
+            funcs = registry_funcs[src_path]
         else:
             funcs = extract_functions_from_file(src_path, lang_key)
         if not funcs:
@@ -740,7 +740,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         return written, skipped
 
     # --- Validation (Step 2) ---
-    validation_failures = _validate_extraction(output_base, backend_langs=backend_langs)
+    validation_failures = _validate_extraction(output_base, registry_langs=registry_langs)
     if validation_failures:
         logging.warning(
             f"Validation: {len(validation_failures)} file(s) do not contain exactly one function."
@@ -759,7 +759,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     return written, skipped
 
 
-def _validate_extraction(extracted_dir, backend_langs=None):
+def _validate_extraction(extracted_dir, registry_langs=None):
     """Re-parse every extracted file and verify each contains exactly one function.
 
     Files for languages that returned data from their REGISTRY backend are skipped:
@@ -776,7 +776,7 @@ def _validate_extraction(extracted_dir, backend_langs=None):
             lang_key = EXT_TO_LANG.get(ext)
             if not lang_key:
                 continue
-            if backend_langs and lang_key in backend_langs:
+            if registry_langs and lang_key in registry_langs:
                 continue
             fpath = os.path.join(root, fname)
             funcs = extract_functions_from_file(fpath, lang_key)

--- a/src/extract.py
+++ b/src/extract.py
@@ -747,7 +747,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         return written, skipped
 
     # --- Validation (Step 2) ---
-    validation_failures = _validate_extraction(output_base)
+    validation_failures = _validate_extraction(output_base, cg=_cg)
     if validation_failures:
         logging.warning(
             f"Validation: {len(validation_failures)} file(s) do not contain exactly one function."
@@ -766,17 +766,26 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     return written, skipped
 
 
-def _validate_extraction(extracted_dir):
+def _validate_extraction(extracted_dir, cg=None):
     """Re-parse every extracted file and verify each contains exactly one function.
+
+    When cg is provided, files for codegraph-supported languages are skipped:
+    codegraph writes exactly one function body per file by construction (one DB
+    node → one line-range slice → one write), so regex re-parsing adds no safety
+    and produces false negatives for forms the regex cannot recognise (async def,
+    class methods, arrow functions).
 
     Returns a list of (file_path, function_count) for files that fail validation.
     """
+    from src.extractors.codegraph import CODEGRAPH_SUPPORTED
     failures = []
     for root, _, files in os.walk(extracted_dir):
         for fname in files:
             ext = fname.rsplit('.', 1)[-1] if '.' in fname else ''
             lang_key = EXT_TO_LANG.get(ext)
             if not lang_key:
+                continue
+            if cg and lang_key in CODEGRAPH_SUPPORTED:
                 continue
             fpath = os.path.join(root, fname)
             funcs = extract_functions_from_file(fpath, lang_key)

--- a/src/extract.py
+++ b/src/extract.py
@@ -6,8 +6,7 @@ import shutil
 import logging
 
 from src.file_utils import is_file_ready
-from src.languages.codegraph import CodeGraphExtractor
-from src.languages.registry import REGISTRY
+from src.languages.registry import batch_extract_all
 
 LANG_CONFIG = {
     "cpp": {
@@ -665,13 +664,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     with open(phases_path, 'r') as f:
         phases_data = json.load(f)
 
-    # Try codegraph backend; pre-fetch all functions indexed by abs filepath.
-    # Falls back to regex extraction per-file when codegraph is unavailable or
-    # the language has no entry in REGISTRY.
-    _cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    _cg_funcs = {}  # {abs_filepath: [(name, body)]}
-    if _cg:
-        _cg_funcs = _cg.get_all_functions(REGISTRY.keys(), proj_dir)
+    _backend_funcs, _backend_langs = batch_extract_all(proj_dir)
 
     # Build source file list from phases.json
     source_files = []
@@ -714,8 +707,8 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
             dir_name = src_base
         out_dir = os.path.join(output_base, src_dir, dir_name) if src_dir else os.path.join(output_base, dir_name)
 
-        if _cg and lang_key in REGISTRY and src_path in _cg_funcs:
-            funcs = _cg_funcs[src_path]
+        if src_path in _backend_funcs:
+            funcs = _backend_funcs[src_path]
         else:
             funcs = extract_functions_from_file(src_path, lang_key)
         if not funcs:
@@ -747,7 +740,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         return written, skipped
 
     # --- Validation (Step 2) ---
-    validation_failures = _validate_extraction(output_base, cg=_cg)
+    validation_failures = _validate_extraction(output_base, backend_langs=_backend_langs)
     if validation_failures:
         logging.warning(
             f"Validation: {len(validation_failures)} file(s) do not contain exactly one function."
@@ -766,14 +759,13 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     return written, skipped
 
 
-def _validate_extraction(extracted_dir, cg=None):
+def _validate_extraction(extracted_dir, backend_langs=None):
     """Re-parse every extracted file and verify each contains exactly one function.
 
-    When cg is provided, files for codegraph-supported languages are skipped:
-    codegraph writes exactly one function body per file by construction (one DB
-    node → one line-range slice → one write), so regex re-parsing adds no safety
-    and produces false negatives for forms the regex cannot recognise (async def,
-    class methods, arrow functions).
+    Files for languages that returned data from their REGISTRY backend are skipped:
+    those backends write exactly one function body per file by construction, so
+    regex re-parsing adds no safety and produces false negatives for forms the
+    regex cannot recognise (async def, class methods, arrow functions).
 
     Returns a list of (file_path, function_count) for files that fail validation.
     """
@@ -784,7 +776,7 @@ def _validate_extraction(extracted_dir, cg=None):
             lang_key = EXT_TO_LANG.get(ext)
             if not lang_key:
                 continue
-            if cg and lang_key in REGISTRY:
+            if backend_langs and lang_key in backend_langs:
                 continue
             fpath = os.path.join(root, fname)
             funcs = extract_functions_from_file(fpath, lang_key)

--- a/src/extract.py
+++ b/src/extract.py
@@ -6,7 +6,8 @@ import shutil
 import logging
 
 from src.file_utils import is_file_ready
-from src.languages.codegraph import CodeGraphExtractor, CODEGRAPH_SUPPORTED
+from src.languages.codegraph import CodeGraphExtractor
+from src.languages.registry import REGISTRY
 
 LANG_CONFIG = {
     "cpp": {
@@ -666,12 +667,12 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
 
     # Try codegraph backend; pre-fetch all functions indexed by abs filepath.
     # Falls back to regex extraction per-file when codegraph is unavailable or
-    # the language is not yet in CODEGRAPH_SUPPORTED.
+    # the language has no entry in REGISTRY.
     _cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     _cg_funcs = {}  # {abs_filepath: [(name, body)]}
     if _cg:
-        for _lang in CODEGRAPH_SUPPORTED:
-            _cg_funcs.update(_cg.get_functions_by_file(_lang, proj_dir))
+        for _lang, _handler in REGISTRY.items():
+            _cg_funcs.update(_handler.batch_extract(_cg, proj_dir))
 
     # Build source file list from phases.json
     source_files = []
@@ -714,7 +715,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
             dir_name = src_base
         out_dir = os.path.join(output_base, src_dir, dir_name) if src_dir else os.path.join(output_base, dir_name)
 
-        if _cg and lang_key in CODEGRAPH_SUPPORTED and src_path in _cg_funcs:
+        if _cg and lang_key in REGISTRY and src_path in _cg_funcs:
             funcs = _cg_funcs[src_path]
         else:
             funcs = extract_functions_from_file(src_path, lang_key)
@@ -784,7 +785,7 @@ def _validate_extraction(extracted_dir, cg=None):
             lang_key = EXT_TO_LANG.get(ext)
             if not lang_key:
                 continue
-            if cg and lang_key in CODEGRAPH_SUPPORTED:
+            if cg and lang_key in REGISTRY:
                 continue
             fpath = os.path.join(root, fname)
             funcs = extract_functions_from_file(fpath, lang_key)

--- a/src/extract.py
+++ b/src/extract.py
@@ -6,6 +6,7 @@ import shutil
 import logging
 
 from src.file_utils import is_file_ready
+from src.languages.codegraph import CodeGraphExtractor, CODEGRAPH_SUPPORTED
 
 LANG_CONFIG = {
     "cpp": {
@@ -666,7 +667,6 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     # Try codegraph backend; pre-fetch all functions indexed by abs filepath.
     # Falls back to regex extraction per-file when codegraph is unavailable or
     # the language is not yet in CODEGRAPH_SUPPORTED.
-    from src.extractors.codegraph import CodeGraphExtractor, CODEGRAPH_SUPPORTED
     _cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     _cg_funcs = {}  # {abs_filepath: [(name, body)]}
     if _cg:
@@ -777,7 +777,6 @@ def _validate_extraction(extracted_dir, cg=None):
 
     Returns a list of (file_path, function_count) for files that fail validation.
     """
-    from src.extractors.codegraph import CODEGRAPH_SUPPORTED
     failures = []
     for root, _, files in os.walk(extracted_dir):
         for fname in files:

--- a/src/extract.py
+++ b/src/extract.py
@@ -663,6 +663,16 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     with open(phases_path, 'r') as f:
         phases_data = json.load(f)
 
+    # Try codegraph backend; pre-fetch all functions indexed by abs filepath.
+    # Falls back to regex extraction per-file when codegraph is unavailable or
+    # the language is not yet in CODEGRAPH_SUPPORTED.
+    from src.extractors.codegraph import CodeGraphExtractor, CODEGRAPH_SUPPORTED
+    _cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    _cg_funcs = {}  # {abs_filepath: [(name, body)]}
+    if _cg:
+        for _lang in CODEGRAPH_SUPPORTED:
+            _cg_funcs.update(_cg.get_functions_by_file(_lang, proj_dir))
+
     # Build source file list from phases.json
     source_files = []
     for phase in phases_data.get("phases", []):
@@ -704,7 +714,10 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
             dir_name = src_base
         out_dir = os.path.join(output_base, src_dir, dir_name) if src_dir else os.path.join(output_base, dir_name)
 
-        funcs = extract_functions_from_file(src_path, lang_key)
+        if _cg and lang_key in CODEGRAPH_SUPPORTED and src_path in _cg_funcs:
+            funcs = _cg_funcs[src_path]
+        else:
+            funcs = extract_functions_from_file(src_path, lang_key)
         if not funcs:
             logging.warning(f"No functions extracted from {src_rel}")
             continue

--- a/src/extract.py
+++ b/src/extract.py
@@ -671,8 +671,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     _cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     _cg_funcs = {}  # {abs_filepath: [(name, body)]}
     if _cg:
-        for _lang, _handler in REGISTRY.items():
-            _cg_funcs.update(_handler.batch_extract(_cg, proj_dir))
+        _cg_funcs = _cg.get_all_functions(REGISTRY.keys(), proj_dir)
 
     # Build source file list from phases.json
     source_files = []

--- a/src/extractors/codegraph.py
+++ b/src/extractors/codegraph.py
@@ -1,0 +1,143 @@
+"""
+CodeGraph backend for FM-Agent function extraction and call graph building.
+
+Requires the user to have run `codegraph init` in the project directory first,
+which produces `.codegraph/codegraph.db` (SQLite).
+
+To add support for a new language: add its FM-Agent lang_key to CODEGRAPH_SUPPORTED.
+No other changes are needed in extract.py or generate_topdown_layers.py.
+"""
+
+import os
+import sqlite3
+from collections import defaultdict
+
+# Languages currently routed through the codegraph backend.
+# One language is added per PR; all other languages continue to use the
+# existing regex fallback automatically.
+CODEGRAPH_SUPPORTED = {
+    "python",
+}
+
+# Maps FM-Agent lang_key → the language string stored in codegraph's SQLite
+# nodes.language column. Only includes languages that codegraph actually supports.
+# ArkTS is omitted (not supported by codegraph).
+# CUDA maps to "c" because codegraph treats .cu files as C.
+_CG_LANG = {
+    "python":     "python",
+    "go":         "go",
+    "rust":       "rust",
+    "c":          "c",
+    "cpp":        "cpp",
+    "cuda":       "c",
+    "java":       "java",
+    "javascript": "javascript",
+    "typescript": "typescript",
+}
+
+
+class CodeGraphExtractor:
+    """Query a codegraph SQLite database to extract functions and call edges."""
+
+    def __init__(self, db_path: str):
+        self._db = db_path
+
+    @classmethod
+    def from_proj_dir(cls, proj_dir: str):
+        """Return an extractor if .codegraph/codegraph.db exists, else None.
+
+        Checks both proj_dir itself and its parent directory, because
+        generate_topdown_layers() receives work_dir (fm_agent/) as its
+        proj_dir argument, while codegraph init runs in the real project root.
+        """
+        for candidate in [proj_dir, os.path.dirname(os.path.abspath(proj_dir))]:
+            db_path = os.path.join(candidate, ".codegraph", "codegraph.db")
+            if os.path.exists(db_path):
+                return cls(db_path)
+        return None
+
+    def get_functions_by_file(self, lang_key: str, proj_dir: str = None) -> dict:
+        """Return {abs_filepath: [(func_name, body_text), ...]} for all files.
+
+        body_text is the raw source lines for that function, matching the format
+        that extract_functions_from_file returns.
+
+        proj_dir must be supplied so that the relative file paths stored by
+        codegraph can be resolved to absolute paths for opening and for dict
+        key lookup in run_extraction.
+        """
+        cg_lang = _CG_LANG.get(lang_key)
+        if not cg_lang:
+            return {}
+
+        conn = sqlite3.connect(self._db)
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT name, file_path, start_line, end_line
+            FROM nodes
+            WHERE kind IN ('function', 'method') AND language = ?
+            ORDER BY file_path, start_line
+            """,
+            (cg_lang,),
+        )
+        rows = cur.fetchall()
+        conn.close()
+
+        by_file = defaultdict(list)
+        for name, file_path, start_line, end_line in rows:
+            by_file[file_path].append((name, int(start_line), int(end_line)))
+
+        result = {}
+        for file_path, funcs in by_file.items():
+            abs_path = os.path.join(proj_dir, file_path) if proj_dir else file_path
+            try:
+                with open(abs_path, "r", errors="replace") as f:
+                    all_lines = f.readlines()
+            except OSError:
+                continue
+
+            file_funcs = []
+            for name, start_line, end_line in funcs:
+                # codegraph uses 1-indexed lines, end_line is inclusive
+                body_lines = all_lines[start_line - 1 : end_line]
+                body = "".join(body_lines)
+                if not body.endswith("\n"):
+                    body += "\n"
+                file_funcs.append((name, body))
+
+            result[abs_path] = file_funcs
+
+        return result
+
+    def get_call_edges(self, lang_key: str) -> dict:
+        """Return {(caller_stem, caller_basename): {callee_stem, ...}} for the given language.
+
+        caller_stem / callee_stem are plain function names (fqn.split('::')[-1]).
+        caller_basename is os.path.basename(caller_file_path), used to disambiguate
+        same-name functions defined in different files.
+        """
+        cg_lang = _CG_LANG.get(lang_key)
+        if not cg_lang:
+            return {}
+
+        conn = sqlite3.connect(self._db)
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT s.name, s.file_path, t.name
+            FROM edges e
+            JOIN nodes s ON e.source = s.id
+            JOIN nodes t ON e.target = t.id
+            WHERE e.kind = 'calls' AND s.language = ?
+            """,
+            (cg_lang,),
+        )
+        rows = cur.fetchall()
+        conn.close()
+
+        result = defaultdict(set)
+        for caller, caller_file, callee in rows:
+            key = (caller, os.path.basename(caller_file))
+            result[key].add(callee)
+        return dict(result)

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -108,8 +108,6 @@ _COMMON_EXTRA_KEYWORDS = {
 }
 
 
-
-
 def _detect_lang_from_ext(filepath):
     """Detect the language key from a file's extension."""
     base = os.path.basename(filepath)

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -289,23 +289,17 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
     callers_map = defaultdict(set)  # fqn -> set of caller fqns (within phase)
     all_callees_map = defaultdict(set)  # fqn -> set of callee fqns (any phase)
 
-    # Try codegraph backend for call edges; merge all supported languages.
-    # Falls back to regex scanning per-file when unavailable or language not
-    # yet in REGISTRY.
+    # Try codegraph backend for call edges; falls back to regex per-file when
+    # unavailable or the language is not yet in REGISTRY.
     _cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    _cg_edges = {}  # {(caller_stem, caller_basename): {callee_stem}}
+    _cg_edges = {}
     if _cg:
         _cg_langs = {
             _detect_lang_from_ext(fp)
             for fp, _ in phase_files
             if _detect_lang_from_ext(fp) in REGISTRY
         }
-        for _lang in _cg_langs:
-            for key, callees in REGISTRY[_lang].call_edges(_cg).items():
-                if key in _cg_edges:
-                    _cg_edges[key] |= callees
-                else:
-                    _cg_edges[key] = set(callees)
+        _cg_edges = _cg.get_all_call_edges(_cg_langs)
 
     for filepath, module_name in phase_files:
         fqn = fqn_map[filepath]

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -288,8 +288,8 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
     callers_map = defaultdict(set)  # fqn -> set of caller fqns (within phase)
     all_callees_map = defaultdict(set)  # fqn -> set of callee fqns (any phase)
 
-    _phase_langs = {_detect_lang_from_ext(fp) for fp, _ in phase_files if _detect_lang_from_ext(fp)}
-    _backend_edges, _backend_langs = call_edges_all(proj_dir, _phase_langs)
+    phase_langs = {_detect_lang_from_ext(fp) for fp, _ in phase_files if _detect_lang_from_ext(fp)}
+    backend_edges, backend_langs = call_edges_all(proj_dir, phase_langs)
 
     for filepath, module_name in phase_files:
         fqn = fqn_map[filepath]
@@ -299,9 +299,9 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
         keywords = _get_keywords_for_lang(lang_key)
 
         caller_stem = fqn.split("::")[-1]
-        if lang_key in _backend_langs:
+        if lang_key in backend_langs:
             caller_module = fqn.split("::")[-2]
-            called_stems = _backend_edges.get((caller_stem, caller_module), set()) & known_stems
+            called_stems = backend_edges.get((caller_stem, caller_module), set()) & known_stems
         else:
             try:
                 with open(filepath, "r", errors="replace") as f:

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from collections import defaultdict
 
 from src.extract import EXT_TO_LANG, LANG_CONFIG
-from src.languages.codegraph import CodeGraphExtractor, CODEGRAPH_SUPPORTED
+from src.languages.codegraph import CodeGraphExtractor
+from src.languages.registry import REGISTRY
 
 
 # ---------------------------------------------------------------------------
@@ -304,17 +305,17 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
 
     # Try codegraph backend for call edges; merge all supported languages.
     # Falls back to regex scanning per-file when unavailable or language not
-    # yet in CODEGRAPH_SUPPORTED.
+    # yet in REGISTRY.
     _cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     _cg_edges = {}  # {(caller_stem, caller_basename): {callee_stem}}
     if _cg:
         _cg_langs = {
             _detect_lang_from_ext(fp)
             for fp, _ in phase_files
-            if _detect_lang_from_ext(fp) in CODEGRAPH_SUPPORTED
+            if _detect_lang_from_ext(fp) in REGISTRY
         }
         for _lang in _cg_langs:
-            for key, callees in _cg.get_call_edges(_lang).items():
+            for key, callees in REGISTRY[_lang].call_edges(_cg).items():
                 if key in _cg_edges:
                     _cg_edges[key] |= callees
                 else:
@@ -328,7 +329,7 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
         keywords = _get_keywords_for_lang(lang_key)
 
         caller_stem = fqn.split("::")[-1]
-        if _cg_edges and lang_key in CODEGRAPH_SUPPORTED:
+        if _cg_edges and lang_key in REGISTRY:
             source_basename = _fqn_to_source_basename(fqn)
             called_stems = _cg_edges.get((caller_stem, source_basename), set()) & known_stems
         else:

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -109,20 +109,6 @@ _COMMON_EXTRA_KEYWORDS = {
 }
 
 
-def _fqn_to_source_basename(fqn):
-    """Derive the original source file basename from an FQN.
-
-    The second-to-last FQN part is the extracted-function directory name,
-    which was built from the source basename by replacing the last '.' with '-'.
-    Example: 'utils-py::process' -> 'utils-py' -> 'utils.py'
-             'src::utils-py::process' -> 'utils-py' -> 'utils.py'
-    """
-    parts = fqn.split("::")
-    module_part = parts[-2]
-    last_dash = module_part.rfind("-")
-    if last_dash < 0:
-        return module_part
-    return module_part[:last_dash] + "." + module_part[last_dash + 1:]
 
 
 def _detect_lang_from_ext(filepath):
@@ -330,8 +316,8 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
 
         caller_stem = fqn.split("::")[-1]
         if _cg_edges and lang_key in REGISTRY:
-            source_basename = _fqn_to_source_basename(fqn)
-            called_stems = _cg_edges.get((caller_stem, source_basename), set()) & known_stems
+            caller_module = fqn.split("::")[-2]
+            called_stems = _cg_edges.get((caller_stem, caller_module), set()) & known_stems
         else:
             try:
                 with open(filepath, "r", errors="replace") as f:

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from collections import defaultdict
 
 from src.extract import EXT_TO_LANG, LANG_CONFIG
-from src.languages.codegraph import CodeGraphExtractor
-from src.languages.registry import REGISTRY
+from src.languages.registry import call_edges_all
 
 
 # ---------------------------------------------------------------------------
@@ -289,17 +288,8 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
     callers_map = defaultdict(set)  # fqn -> set of caller fqns (within phase)
     all_callees_map = defaultdict(set)  # fqn -> set of callee fqns (any phase)
 
-    # Try codegraph backend for call edges; falls back to regex per-file when
-    # unavailable or the language is not yet in REGISTRY.
-    _cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    _cg_edges = {}
-    if _cg:
-        _cg_langs = {
-            _detect_lang_from_ext(fp)
-            for fp, _ in phase_files
-            if _detect_lang_from_ext(fp) in REGISTRY
-        }
-        _cg_edges = _cg.get_all_call_edges(_cg_langs)
+    _phase_langs = {_detect_lang_from_ext(fp) for fp, _ in phase_files if _detect_lang_from_ext(fp)}
+    _backend_edges, _backend_langs = call_edges_all(proj_dir, _phase_langs)
 
     for filepath, module_name in phase_files:
         fqn = fqn_map[filepath]
@@ -309,9 +299,9 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
         keywords = _get_keywords_for_lang(lang_key)
 
         caller_stem = fqn.split("::")[-1]
-        if _cg_edges and lang_key in REGISTRY:
+        if lang_key in _backend_langs:
             caller_module = fqn.split("::")[-2]
-            called_stems = _cg_edges.get((caller_stem, caller_module), set()) & known_stems
+            called_stems = _backend_edges.get((caller_stem, caller_module), set()) & known_stems
         else:
             try:
                 with open(filepath, "r", errors="replace") as f:

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -107,6 +107,22 @@ _COMMON_EXTRA_KEYWORDS = {
 }
 
 
+def _fqn_to_source_basename(fqn):
+    """Derive the original source file basename from an FQN.
+
+    The second-to-last FQN part is the extracted-function directory name,
+    which was built from the source basename by replacing the last '.' with '-'.
+    Example: 'utils-py::process' -> 'utils-py' -> 'utils.py'
+             'src::utils-py::process' -> 'utils-py' -> 'utils.py'
+    """
+    parts = fqn.split("::")
+    module_part = parts[-2]
+    last_dash = module_part.rfind("-")
+    if last_dash < 0:
+        return module_part
+    return module_part[:last_dash] + "." + module_part[last_dash + 1:]
+
+
 def _detect_lang_from_ext(filepath):
     """Detect the language key from a file's extension."""
     base = os.path.basename(filepath)
@@ -285,6 +301,25 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
     callers_map = defaultdict(set)  # fqn -> set of caller fqns (within phase)
     all_callees_map = defaultdict(set)  # fqn -> set of callee fqns (any phase)
 
+    # Try codegraph backend for call edges; merge all supported languages.
+    # Falls back to regex scanning per-file when unavailable or language not
+    # yet in CODEGRAPH_SUPPORTED.
+    from src.extractors.codegraph import CodeGraphExtractor, CODEGRAPH_SUPPORTED
+    _cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    _cg_edges = {}  # {(caller_stem, caller_basename): {callee_stem}}
+    if _cg:
+        _cg_langs = {
+            _detect_lang_from_ext(fp)
+            for fp, _ in phase_files
+            if _detect_lang_from_ext(fp) in CODEGRAPH_SUPPORTED
+        }
+        for _lang in _cg_langs:
+            for key, callees in _cg.get_call_edges(_lang).items():
+                if key in _cg_edges:
+                    _cg_edges[key] |= callees
+                else:
+                    _cg_edges[key] = set(callees)
+
     for filepath, module_name in phase_files:
         fqn = fqn_map[filepath]
         lang_key = _detect_lang_from_ext(filepath)
@@ -292,13 +327,17 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
             continue
         keywords = _get_keywords_for_lang(lang_key)
 
-        try:
-            with open(filepath, "r", errors="replace") as f:
-                text = f.read()
-        except OSError:
-            continue
-
-        called_stems = _find_call_sites(text, lang_key, known_stems, keywords)
+        caller_stem = fqn.split("::")[-1]
+        if _cg_edges and lang_key in CODEGRAPH_SUPPORTED:
+            source_basename = _fqn_to_source_basename(fqn)
+            called_stems = _cg_edges.get((caller_stem, source_basename), set()) & known_stems
+        else:
+            try:
+                with open(filepath, "r", errors="replace") as f:
+                    text = f.read()
+            except OSError:
+                continue
+            called_stems = _find_call_sites(text, lang_key, known_stems, keywords)
 
         # Resolve stems to FQNs, excluding self
         for stem in called_stems:

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -287,7 +287,7 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
     all_callees_map = defaultdict(set)  # fqn -> set of callee fqns (any phase)
 
     phase_langs = {_detect_lang_from_ext(fp) for fp, _ in phase_files if _detect_lang_from_ext(fp)}
-    backend_edges, backend_langs = call_edges_all(proj_dir, phase_langs)
+    registry_edges, registry_langs = call_edges_all(proj_dir, phase_langs)
 
     for filepath, module_name in phase_files:
         fqn = fqn_map[filepath]
@@ -297,9 +297,9 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
         keywords = _get_keywords_for_lang(lang_key)
 
         caller_stem = fqn.split("::")[-1]
-        if lang_key in backend_langs:
+        if lang_key in registry_langs:
             caller_module = fqn.split("::")[-2]
-            called_stems = backend_edges.get((caller_stem, caller_module), set()) & known_stems
+            called_stems = registry_edges.get((caller_stem, caller_module), set()) & known_stems
         else:
             try:
                 with open(filepath, "r", errors="replace") as f:

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from collections import defaultdict
 
 from src.extract import EXT_TO_LANG, LANG_CONFIG
+from src.languages.codegraph import CodeGraphExtractor, CODEGRAPH_SUPPORTED
 
 
 # ---------------------------------------------------------------------------
@@ -304,7 +305,6 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
     # Try codegraph backend for call edges; merge all supported languages.
     # Falls back to regex scanning per-file when unavailable or language not
     # yet in CODEGRAPH_SUPPORTED.
-    from src.extractors.codegraph import CodeGraphExtractor, CODEGRAPH_SUPPORTED
     _cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     _cg_edges = {}  # {(caller_stem, caller_basename): {callee_stem}}
     if _cg:

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -140,6 +140,18 @@ class CodeGraphExtractor:
             result[key].add(callee)
         return dict(result)
 
+    def get_all_call_edges(self, lang_keys) -> dict:
+        """Return merged call edges for multiple languages.
+
+        Equivalent to calling get_call_edges for each lang_key and unioning
+        the results into a single {(caller_stem, caller_module): {callee_stems}} dict.
+        """
+        result = {}
+        for lang_key in lang_keys:
+            for key, callees in self.get_call_edges(lang_key).items():
+                result.setdefault(key, set()).update(callees)
+        return result
+
 
 def try_codegraph_init(proj_dir: str) -> None:
     """Run `codegraph init` in proj_dir if the index does not yet exist.

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -133,7 +133,10 @@ class CodeGraphExtractor:
 
         result = defaultdict(set)
         for caller, caller_file, callee in rows:
-            key = (caller, os.path.basename(caller_file))
+            base = os.path.basename(caller_file)
+            last_dot = base.rfind(".")
+            dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
+            key = (caller, dashed)
             result[key].add(callee)
         return dict(result)
 

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -4,7 +4,7 @@ CodeGraph backend for FM-Agent function extraction and call graph building.
 Requires the user to have run `codegraph init` in the project directory first,
 which produces `.codegraph/codegraph.db` (SQLite).
 
-To add support for a new language: add its FM-Agent lang_key to CODEGRAPH_SUPPORTED.
+To add support for a new language: add its lang_key to REGISTRY in src/languages/__init__.py.
 No other changes are needed in extract.py or generate_topdown_layers.py.
 """
 
@@ -13,13 +13,6 @@ import os
 import sqlite3
 import subprocess
 from collections import defaultdict
-
-# Languages currently routed through the codegraph backend.
-# One language is added per PR; all other languages continue to use the
-# existing regex fallback automatically.
-CODEGRAPH_SUPPORTED = {
-    "python",
-}
 
 # Maps FM-Agent lang_key → the language string stored in codegraph's SQLite
 # nodes.language column. Only includes languages that codegraph actually supports.

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -17,14 +17,17 @@ from collections import defaultdict
 # Maps FM-Agent lang_key → the language string stored in codegraph's SQLite
 # nodes.language column. Only includes languages that codegraph actually supports.
 # ArkTS is omitted (not supported by codegraph).
-# CUDA maps to "c" because codegraph treats .cu files as C.
+# CUDA: .cu is not in codegraph's built-in extension list and will not be indexed.
+#   To enable partial CUDA support, add {"extensions": {".cu": "cpp"}} to a
+#   codegraph.json file at the project root — codegraph will then parse .cu files
+#   using the C++ grammar. This workaround has not been verified.
 _CG_LANG = {
     "python":     "python",
     "go":         "go",
     "rust":       "rust",
     "c":          "c",
     "cpp":        "cpp",
-    "cuda":       "c",
+    "cuda":       "cpp",  # .cu is not natively indexed by codegraph; kept for future use
     "java":       "java",
     "javascript": "javascript",
     "typescript": "typescript",
@@ -140,28 +143,6 @@ class CodeGraphExtractor:
             result[key].add(callee)
         return dict(result)
 
-    def get_all_functions(self, lang_keys, proj_dir: str) -> dict:
-        """Return merged function extraction results for multiple languages.
-
-        Equivalent to calling get_functions_by_file for each lang_key and
-        merging into a single {abs_filepath: [(name, body)]} dict.
-        """
-        result = {}
-        for lang_key in lang_keys:
-            result.update(self.get_functions_by_file(lang_key, proj_dir))
-        return result
-
-    def get_all_call_edges(self, lang_keys) -> dict:
-        """Return merged call edges for multiple languages.
-
-        Equivalent to calling get_call_edges for each lang_key and unioning
-        the results into a single {(caller_stem, caller_module): {callee_stems}} dict.
-        """
-        result = {}
-        for lang_key in lang_keys:
-            for key, callees in self.get_call_edges(lang_key).items():
-                result.setdefault(key, set()).update(callees)
-        return result
 
 
 def try_codegraph_init(proj_dir: str) -> None:

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -140,6 +140,17 @@ class CodeGraphExtractor:
             result[key].add(callee)
         return dict(result)
 
+    def get_all_functions(self, lang_keys, proj_dir: str) -> dict:
+        """Return merged function extraction results for multiple languages.
+
+        Equivalent to calling get_functions_by_file for each lang_key and
+        merging into a single {abs_filepath: [(name, body)]} dict.
+        """
+        result = {}
+        for lang_key in lang_keys:
+            result.update(self.get_functions_by_file(lang_key, proj_dir))
+        return result
+
     def get_all_call_edges(self, lang_keys) -> dict:
         """Return merged call edges for multiple languages.
 

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -8,8 +8,10 @@ To add support for a new language: add its FM-Agent lang_key to CODEGRAPH_SUPPOR
 No other changes are needed in extract.py or generate_topdown_layers.py.
 """
 
+import logging
 import os
 import sqlite3
+import subprocess
 from collections import defaultdict
 
 # Languages currently routed through the codegraph backend.
@@ -141,3 +143,28 @@ class CodeGraphExtractor:
             key = (caller, os.path.basename(caller_file))
             result[key].add(callee)
         return dict(result)
+
+
+def try_codegraph_init(proj_dir: str) -> None:
+    """Run `codegraph init` in proj_dir if the index does not yet exist.
+
+    Silently skips when codegraph is not installed so the pipeline falls back
+    to the regex-based extractor without any error.
+    """
+    db_path = os.path.join(proj_dir, ".codegraph", "codegraph.db")
+    if os.path.exists(db_path):
+        return
+    print("[Pipeline] Building codegraph index (this runs once per project)...")
+    try:
+        result = subprocess.run(
+            ["codegraph", "init"], cwd=proj_dir, capture_output=True, text=True
+        )
+    except FileNotFoundError:
+        return  # codegraph not installed
+    if result.returncode == 0:
+        print("[Pipeline] codegraph index built.")
+    else:
+        logging.warning(
+            "codegraph init failed (non-fatal, falling back to regex): %s",
+            result.stderr[:300],
+        )

--- a/src/languages/python.py
+++ b/src/languages/python.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from src.languages.codegraph import CodeGraphExtractor
+from src.languages.codegraph import CodeGraphExtractor
 
 
-def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+def batch_extract(proj_dir: str) -> dict:
     """Return {abs_filepath: [(func_name, body)]} for all Python files."""
-    return cg.get_functions_by_file("python", proj_dir)
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_functions_by_file("python", proj_dir) if cg else {}
 
 
-def call_edges(cg: "CodeGraphExtractor") -> dict:
-    """Return {(caller_stem, caller_basename): {callee_stems}} for Python."""
-    return cg.get_call_edges("python")
+def call_edges(proj_dir: str) -> dict:
+    """Return {(caller_stem, caller_module): {callee_stems}} for Python."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_call_edges("python") if cg else {}

--- a/src/languages/python.py
+++ b/src/languages/python.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.languages.codegraph import CodeGraphExtractor
+
+
+def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    """Return {abs_filepath: [(func_name, body)]} for all Python files."""
+    return cg.get_functions_by_file("python", proj_dir)
+
+
+def call_edges(cg: "CodeGraphExtractor") -> dict:
+    """Return {(caller_stem, caller_basename): {callee_stems}} for Python."""
+    return cg.get_call_edges("python")

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from src.languages import python as _python
+
+
+@dataclass
+class LanguageHandler:
+    """Extraction and call-graph backend for one language.
+
+    batch_extract(cg, proj_dir) -> {abs_filepath: [(func_name, body)]}
+    call_edges(cg)              -> {(caller_stem, caller_basename): {callee_stems}}
+
+    To add a new language:
+      1. Create src/languages/<lang>.py implementing batch_extract and call_edges
+      2. Import it here and add one entry to REGISTRY
+    No other files need to change.
+    """
+    batch_extract: Callable
+    call_edges: Callable
+
+
+REGISTRY: dict = {
+    "python": LanguageHandler(
+        batch_extract=_python.batch_extract,
+        call_edges=_python.call_edges,
+    ),
+}

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -8,8 +8,11 @@ from src.languages import python as _python
 class LanguageHandler:
     """Extraction and call-graph backend for one language.
 
-    batch_extract(cg, proj_dir) -> {abs_filepath: [(func_name, body)]}
-    call_edges(cg)              -> {(caller_stem, caller_basename): {callee_stems}}
+    batch_extract(proj_dir) -> {abs_filepath: [(func_name, body)]}
+    call_edges(proj_dir)    -> {(caller_stem, caller_module): {callee_stems}}
+
+    Each function handles its own backend (e.g. codegraph) internally and
+    returns an empty dict when the backend is unavailable.
 
     To add a new language:
       1. Create src/languages/<lang>.py implementing batch_extract and call_edges
@@ -26,3 +29,38 @@ REGISTRY: dict = {
         call_edges=_python.call_edges,
     ),
 }
+
+
+def batch_extract_all(proj_dir: str) -> tuple:
+    """Call batch_extract for every registered language and merge results.
+
+    Returns (funcs, langs) where funcs is {abs_filepath: [(func_name, body)]}
+    and langs is the set of language keys that returned data.
+    """
+    funcs = {}
+    langs = set()
+    for lang, handler in REGISTRY.items():
+        result = handler.batch_extract(proj_dir)
+        if result:
+            funcs.update(result)
+            langs.add(lang)
+    return funcs, langs
+
+
+def call_edges_all(proj_dir: str, lang_keys) -> tuple:
+    """Call call_edges for each language in lang_keys and merge results.
+
+    Returns (edges, langs) where edges is {(caller_stem, caller_module): {callee_stems}}
+    and langs is the set of language keys that returned data.
+    """
+    edges = {}
+    langs = set()
+    for lang in lang_keys:
+        if lang not in REGISTRY:
+            continue
+        result = REGISTRY[lang].call_edges(proj_dir)
+        if result:
+            langs.add(lang)
+            for key, callees in result.items():
+                edges.setdefault(key, set()).update(callees)
+    return edges, langs


### PR DESCRIPTION
## Summary
Integrate `@colbymchenry/codegraph` (tree-sitter based) as the function extraction and call graph backend for Python, replacing the regex-based approach. Existing regex extractor is preserved as a fallback when codegraph is unavailable.

## Changes
- `src/extractors/codegraph.py` — new module: queries `.codegraph/codegraph.db` for function bodies and call edges
- `src/extract.py` — route Python files through codegraph when index is available; fall back to regex otherwise
- `src/generate_topdown_layers.py` — build call graph from codegraph edges when available; fall back to regex scan otherwise
- `main.py` — auto-run `codegraph init` between Stage 1 and Stage 2 so only original source files are indexed (before `fm_agent/extracted_functions/` is created)
- `install.sh` — install `@colbymchenry/codegraph` via bun as part of FM-Agent setup

## Motivation
The regex-based extractor is fragile on complex syntax. Tree-sitter based codegraph provides accurate AST-level function extraction and precise call edges. The new backend is designed to be extensible: adding support for a new language requires only adding one line to `CODEGRAPH_SUPPORTED` in `codegraph.py`.

As a side effect, the codegraph path also correctly extracts `async def` functions, which the regex-based fallback silently drops (see #54).