### PR TITLE
Support macOS install compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,23 @@ The [website](http://fm-agent.ai/) of FM-Agent provides an online service for re
 
 ## Table of Contents
 
-- [File Structure](#file-structure)
-- [Environment Setup](#environment-setup)
-  - [Requirements](#requirements)
-  - [Install Dependencies](#install-dependencies)
-- [Configuration](#configuration)
-- [Quick Start](#quick-start)
-- [Important Notes](#important-notes)
-- [Citation](#citation)
-- [Contact](#contact)
+- [FM-Agent: Scaling Formal Methods to Large Systems via LLM-Based Hoare-Style Reasoning](#fm-agent-scaling-formal-methods-to-large-systems-via-llm-based-hoare-style-reasoning)
+  - [Table of Contents](#table-of-contents)
+  - [File Structure](#file-structure)
+  - [Environment Setup](#environment-setup)
+    - [Requirements](#requirements)
+      - [Tested macOS Environment](#tested-macos-environment)
+    - [Install Dependencies](#install-dependencies)
+  - [Configuration](#configuration)
+    - [Structured Trace](#structured-trace)
+  - [Quick Start](#quick-start)
+    - [Incremental Mode](#incremental-mode)
+    - [Live Dashboard](#live-dashboard)
+    - [Output](#output)
+      - [Bug Reports (`fm_agent/bug_validation/<bug_id>.md`)](#bug-reports-fm_agentbug_validationbug_idmd)
+  - [Important Notes](#important-notes)
+  - [Citation](#citation)
+  - [Contact](#contact)
 
 
 ## File Structure
@@ -59,6 +67,20 @@ The [website](http://fm-agent.ai/) of FM-Agent provides an online service for re
 - [oh-my-openagent](https://www.npmjs.com/package/oh-my-openagent) plugin (installed via `bunx`)
 - [@lucentia/opencode-trace](https://www.npmjs.com/package/@lucentia/opencode-trace) plugin — captures raw OpenCode LLM request/response traces (see [Structured Trace](#structured-trace))
 - An LLM API key for your provider (the examples use [OpenRouter](https://openrouter.ai/))
+
+#### Tested macOS Environment
+
+The following macOS environment has been tested with the install script:
+
+- macOS 14.5 (Build 23F79), arm64
+- Darwin 23.5.0
+- Python 3.11.7
+- pip 23.3.1
+- uv 0.7.9
+- OpenCode 1.17.9
+- Bun/bunx 1.3.14
+- Homebrew 6.0.3
+- UnZip 6.00
 
 ### Install Dependencies
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -60,6 +60,20 @@ FM-Agent 的[官方网站](http://fm-agent.ai/)提供了在线代码库推理服
 - [@lucentia/opencode-trace](https://www.npmjs.com/package/@lucentia/opencode-trace) 插件 —— 采集 OpenCode 原始 LLM 请求/响应 trace
 - 你所用 provider 的 LLM API 密钥（示例使用 [OpenRouter](https://openrouter.ai/)）
 
+#### 已测试 macOS 环境
+
+以下 macOS 环境已使用安装脚本测试：
+
+- macOS 14.5（Build 23F79），arm64
+- Darwin 23.5.0
+- Python 3.11.7
+- pip 23.3.1
+- uv 0.7.9
+- OpenCode 1.17.9
+- Bun/bunx 1.3.14
+- Homebrew 6.0.3
+- UnZip 6.00
+
 ### 安装依赖
 
 设置 FM-Agent 和 OpenCode 共用的 LLM API 密钥。推荐使用 [OpenRouter](https://openrouter.ai/)：FM-Agent 会并发调用 LLM，而 OpenRouter 的 RPM（每分钟请求数）和 TPM（每分钟 Token 数）限制更宽松——不过任何兼容的 provider 都可以。

--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,10 @@ fi
 
 # ---------- Python packages ----------
 echo "[..] installing Python dependencies"
-python3 -m pip install openai
+if ! python3 -m pip install openai; then
+    echo "[..] pip install failed; syncing Python dependencies with uv"
+    uv sync --locked
+fi
 
 # ---------- unzip ----------
 if command -v unzip &>/dev/null; then


### PR DESCRIPTION
## Summary

- Keep the existing `pip install openai` path as the first install attempt, and fall back to `uv sync --locked` when pip installation fails.
- Improve install compatibility for macOS setups where Homebrew-managed Python environments reject direct package installation through pip.
- Document the tested macOS environment and tool versions in both English and Chinese READMEs.

## Test

- `bash -n install.sh`