### PR TITLE
feat(languages): extend codegraph backend to Go, C, C++, Java, Rust, TypeScript and JavaScript

### DIFF
--- a/src/languages/c.py
+++ b/src/languages/c.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from src.languages.codegraph import CodeGraphExtractor
+from src.languages.codegraph import CodeGraphExtractor
 
 
-def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+def batch_extract(proj_dir: str) -> dict:
     """Return {abs_filepath: [(func_name, body)]} for all C files."""
-    return cg.get_functions_by_file("c", proj_dir)
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_functions_by_file("c", proj_dir) if cg else {}
 
 
-def call_edges(cg: "CodeGraphExtractor") -> dict:
-    """Return {(caller_stem, caller_basename): {callee_stems}} for C."""
-    return cg.get_call_edges("c")
+def call_edges(proj_dir: str) -> dict:
+    """Return {(caller_stem, caller_module): {callee_stems}} for C."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_call_edges("c") if cg else {}

--- a/src/languages/c.py
+++ b/src/languages/c.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.languages.codegraph import CodeGraphExtractor
+
+
+def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    return cg.get_functions_by_file("c", proj_dir)
+
+
+def call_edges(cg: "CodeGraphExtractor") -> dict:
+    return cg.get_call_edges("c")

--- a/src/languages/c.py
+++ b/src/languages/c.py
@@ -6,8 +6,10 @@ if TYPE_CHECKING:
 
 
 def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    """Return {abs_filepath: [(func_name, body)]} for all C files."""
     return cg.get_functions_by_file("c", proj_dir)
 
 
 def call_edges(cg: "CodeGraphExtractor") -> dict:
+    """Return {(caller_stem, caller_basename): {callee_stems}} for C."""
     return cg.get_call_edges("c")

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -4,8 +4,8 @@ CodeGraph backend for FM-Agent function extraction and call graph building.
 Requires the user to have run `codegraph init` in the project directory first,
 which produces `.codegraph/codegraph.db` (SQLite).
 
-To add support for a new language: add its lang_key to REGISTRY in src/languages/__init__.py.
-No other changes are needed in extract.py or generate_topdown_layers.py.
+To add support for a new language: create src/languages/<lang>.py and add an entry to
+REGISTRY in src/languages/registry.py. No other files need to change.
 """
 
 import logging
@@ -144,7 +144,6 @@ class CodeGraphExtractor:
             key = (caller, dashed)
             result[key].add(callee)
         return dict(result)
-
 
 
 def try_codegraph_init(proj_dir: str) -> None:

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -22,15 +22,15 @@ from collections import defaultdict
 #   codegraph.json file at the project root — codegraph will then parse .cu files
 #   using the C++ grammar. This workaround has not been verified.
 _CG_LANG = {
-    "python":     "python",
-    "go":         "go",
-    "rust":       "rust",
-    "c":          "c",
-    "cpp":        "cpp",
-    "cuda":       "cpp",  # .cu is not natively indexed by codegraph; kept for future use
-    "java":       "java",
-    "javascript": "javascript",
-    "typescript": "typescript",
+    "python":     ["python"],
+    "go":         ["go"],
+    "rust":       ["rust"],
+    "c":          ["c"],
+    "cpp":        ["cpp"],
+    "cuda":       ["cpp"],  # .cu is not natively indexed by codegraph; kept for future use
+    "java":       ["java"],
+    "javascript": ["javascript", "jsx"],  # codegraph stores .jsx files as language='jsx'
+    "typescript": ["typescript", "tsx"],  # codegraph stores .tsx files as language='tsx'
 }
 
 
@@ -64,20 +64,21 @@ class CodeGraphExtractor:
         codegraph can be resolved to absolute paths for opening and for dict
         key lookup in run_extraction.
         """
-        cg_lang = _CG_LANG.get(lang_key)
-        if not cg_lang:
+        cg_langs = _CG_LANG.get(lang_key)
+        if not cg_langs:
             return {}
 
         conn = sqlite3.connect(self._db)
         cur = conn.cursor()
+        placeholders = ",".join("?" * len(cg_langs))
         cur.execute(
-            """
+            f"""
             SELECT name, file_path, start_line, end_line
             FROM nodes
-            WHERE kind IN ('function', 'method') AND language = ?
+            WHERE kind IN ('function', 'method') AND language IN ({placeholders})
             ORDER BY file_path, start_line
             """,
-            (cg_lang,),
+            cg_langs,
         )
         rows = cur.fetchall()
         conn.close()
@@ -115,21 +116,22 @@ class CodeGraphExtractor:
         caller_basename is os.path.basename(caller_file_path), used to disambiguate
         same-name functions defined in different files.
         """
-        cg_lang = _CG_LANG.get(lang_key)
-        if not cg_lang:
+        cg_langs = _CG_LANG.get(lang_key)
+        if not cg_langs:
             return {}
 
         conn = sqlite3.connect(self._db)
         cur = conn.cursor()
+        placeholders = ",".join("?" * len(cg_langs))
         cur.execute(
-            """
+            f"""
             SELECT s.name, s.file_path, t.name
             FROM edges e
             JOIN nodes s ON e.source = s.id
             JOIN nodes t ON e.target = t.id
-            WHERE e.kind = 'calls' AND s.language = ?
+            WHERE e.kind = 'calls' AND s.language IN ({placeholders})
             """,
-            (cg_lang,),
+            cg_langs,
         )
         rows = cur.fetchall()
         conn.close()

--- a/src/languages/cpp.py
+++ b/src/languages/cpp.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from src.languages.codegraph import CodeGraphExtractor
+from src.languages.codegraph import CodeGraphExtractor
 
 
-def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+def batch_extract(proj_dir: str) -> dict:
     """Return {abs_filepath: [(func_name, body)]} for all C++ files."""
-    return cg.get_functions_by_file("cpp", proj_dir)
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_functions_by_file("cpp", proj_dir) if cg else {}
 
 
-def call_edges(cg: "CodeGraphExtractor") -> dict:
-    """Return {(caller_stem, caller_basename): {callee_stems}} for C++."""
-    return cg.get_call_edges("cpp")
+def call_edges(proj_dir: str) -> dict:
+    """Return {(caller_stem, caller_module): {callee_stems}} for C++."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_call_edges("cpp") if cg else {}

--- a/src/languages/cpp.py
+++ b/src/languages/cpp.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.languages.codegraph import CodeGraphExtractor
+
+
+def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    return cg.get_functions_by_file("cpp", proj_dir)
+
+
+def call_edges(cg: "CodeGraphExtractor") -> dict:
+    return cg.get_call_edges("cpp")

--- a/src/languages/cpp.py
+++ b/src/languages/cpp.py
@@ -6,8 +6,10 @@ if TYPE_CHECKING:
 
 
 def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    """Return {abs_filepath: [(func_name, body)]} for all C++ files."""
     return cg.get_functions_by_file("cpp", proj_dir)
 
 
 def call_edges(cg: "CodeGraphExtractor") -> dict:
+    """Return {(caller_stem, caller_basename): {callee_stems}} for C++."""
     return cg.get_call_edges("cpp")

--- a/src/languages/go.py
+++ b/src/languages/go.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from src.languages.codegraph import CodeGraphExtractor
+from src.languages.codegraph import CodeGraphExtractor
 
 
-def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+def batch_extract(proj_dir: str) -> dict:
     """Return {abs_filepath: [(func_name, body)]} for all Go files."""
-    return cg.get_functions_by_file("go", proj_dir)
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_functions_by_file("go", proj_dir) if cg else {}
 
 
-def call_edges(cg: "CodeGraphExtractor") -> dict:
-    """Return {(caller_stem, caller_basename): {callee_stems}} for Go."""
-    return cg.get_call_edges("go")
+def call_edges(proj_dir: str) -> dict:
+    """Return {(caller_stem, caller_module): {callee_stems}} for Go."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_call_edges("go") if cg else {}

--- a/src/languages/go.py
+++ b/src/languages/go.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.languages.codegraph import CodeGraphExtractor
+
+
+def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    return cg.get_functions_by_file("go", proj_dir)
+
+
+def call_edges(cg: "CodeGraphExtractor") -> dict:
+    return cg.get_call_edges("go")

--- a/src/languages/go.py
+++ b/src/languages/go.py
@@ -6,8 +6,10 @@ if TYPE_CHECKING:
 
 
 def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    """Return {abs_filepath: [(func_name, body)]} for all Go files."""
     return cg.get_functions_by_file("go", proj_dir)
 
 
 def call_edges(cg: "CodeGraphExtractor") -> dict:
+    """Return {(caller_stem, caller_basename): {callee_stems}} for Go."""
     return cg.get_call_edges("go")

--- a/src/languages/java.py
+++ b/src/languages/java.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from src.languages.codegraph import CodeGraphExtractor
+from src.languages.codegraph import CodeGraphExtractor
 
 
-def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+def batch_extract(proj_dir: str) -> dict:
     """Return {abs_filepath: [(func_name, body)]} for all Java files."""
-    return cg.get_functions_by_file("java", proj_dir)
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_functions_by_file("java", proj_dir) if cg else {}
 
 
-def call_edges(cg: "CodeGraphExtractor") -> dict:
-    """Return {(caller_stem, caller_basename): {callee_stems}} for Java."""
-    return cg.get_call_edges("java")
+def call_edges(proj_dir: str) -> dict:
+    """Return {(caller_stem, caller_module): {callee_stems}} for Java."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_call_edges("java") if cg else {}

--- a/src/languages/java.py
+++ b/src/languages/java.py
@@ -6,8 +6,10 @@ if TYPE_CHECKING:
 
 
 def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    """Return {abs_filepath: [(func_name, body)]} for all Java files."""
     return cg.get_functions_by_file("java", proj_dir)
 
 
 def call_edges(cg: "CodeGraphExtractor") -> dict:
+    """Return {(caller_stem, caller_basename): {callee_stems}} for Java."""
     return cg.get_call_edges("java")

--- a/src/languages/java.py
+++ b/src/languages/java.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.languages.codegraph import CodeGraphExtractor
+
+
+def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    return cg.get_functions_by_file("java", proj_dir)
+
+
+def call_edges(cg: "CodeGraphExtractor") -> dict:
+    return cg.get_call_edges("java")

--- a/src/languages/javascript.py
+++ b/src/languages/javascript.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from src.languages.codegraph import CodeGraphExtractor
+from src.languages.codegraph import CodeGraphExtractor
 
 
-def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+def batch_extract(proj_dir: str) -> dict:
     """Return {abs_filepath: [(func_name, body)]} for all JavaScript files."""
-    return cg.get_functions_by_file("javascript", proj_dir)
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_functions_by_file("javascript", proj_dir) if cg else {}
 
 
-def call_edges(cg: "CodeGraphExtractor") -> dict:
-    """Return {(caller_stem, caller_basename): {callee_stems}} for JavaScript."""
-    return cg.get_call_edges("javascript")
+def call_edges(proj_dir: str) -> dict:
+    """Return {(caller_stem, caller_module): {callee_stems}} for JavaScript."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_call_edges("javascript") if cg else {}

--- a/src/languages/javascript.py
+++ b/src/languages/javascript.py
@@ -6,8 +6,10 @@ if TYPE_CHECKING:
 
 
 def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    """Return {abs_filepath: [(func_name, body)]} for all JavaScript files."""
     return cg.get_functions_by_file("javascript", proj_dir)
 
 
 def call_edges(cg: "CodeGraphExtractor") -> dict:
+    """Return {(caller_stem, caller_basename): {callee_stems}} for JavaScript."""
     return cg.get_call_edges("javascript")

--- a/src/languages/javascript.py
+++ b/src/languages/javascript.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.languages.codegraph import CodeGraphExtractor
+
+
+def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    return cg.get_functions_by_file("javascript", proj_dir)
+
+
+def call_edges(cg: "CodeGraphExtractor") -> dict:
+    return cg.get_call_edges("javascript")

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -2,6 +2,13 @@ from dataclasses import dataclass
 from typing import Callable
 
 from src.languages import python as _python
+from src.languages import go as _go
+from src.languages import c as _c
+from src.languages import cpp as _cpp
+from src.languages import java as _java
+from src.languages import rust as _rust
+from src.languages import javascript as _javascript
+from src.languages import typescript as _typescript
 
 
 @dataclass
@@ -24,10 +31,14 @@ class LanguageHandler:
 
 
 REGISTRY: dict = {
-    "python": LanguageHandler(
-        batch_extract=_python.batch_extract,
-        call_edges=_python.call_edges,
-    ),
+    "python":     LanguageHandler(batch_extract=_python.batch_extract,     call_edges=_python.call_edges),
+    "go":         LanguageHandler(batch_extract=_go.batch_extract,         call_edges=_go.call_edges),
+    "c":          LanguageHandler(batch_extract=_c.batch_extract,          call_edges=_c.call_edges),
+    "cpp":        LanguageHandler(batch_extract=_cpp.batch_extract,        call_edges=_cpp.call_edges),
+    "java":       LanguageHandler(batch_extract=_java.batch_extract,       call_edges=_java.call_edges),
+    "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges),
+    "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges),
+    "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges),
 }
 
 

--- a/src/languages/rust.py
+++ b/src/languages/rust.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from src.languages.codegraph import CodeGraphExtractor
+from src.languages.codegraph import CodeGraphExtractor
 
 
-def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+def batch_extract(proj_dir: str) -> dict:
     """Return {abs_filepath: [(func_name, body)]} for all Rust files."""
-    return cg.get_functions_by_file("rust", proj_dir)
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_functions_by_file("rust", proj_dir) if cg else {}
 
 
-def call_edges(cg: "CodeGraphExtractor") -> dict:
-    """Return {(caller_stem, caller_basename): {callee_stems}} for Rust."""
-    return cg.get_call_edges("rust")
+def call_edges(proj_dir: str) -> dict:
+    """Return {(caller_stem, caller_module): {callee_stems}} for Rust."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_call_edges("rust") if cg else {}

--- a/src/languages/rust.py
+++ b/src/languages/rust.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.languages.codegraph import CodeGraphExtractor
+
+
+def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    return cg.get_functions_by_file("rust", proj_dir)
+
+
+def call_edges(cg: "CodeGraphExtractor") -> dict:
+    return cg.get_call_edges("rust")

--- a/src/languages/rust.py
+++ b/src/languages/rust.py
@@ -6,8 +6,10 @@ if TYPE_CHECKING:
 
 
 def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    """Return {abs_filepath: [(func_name, body)]} for all Rust files."""
     return cg.get_functions_by_file("rust", proj_dir)
 
 
 def call_edges(cg: "CodeGraphExtractor") -> dict:
+    """Return {(caller_stem, caller_basename): {callee_stems}} for Rust."""
     return cg.get_call_edges("rust")

--- a/src/languages/typescript.py
+++ b/src/languages/typescript.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from src.languages.codegraph import CodeGraphExtractor
+from src.languages.codegraph import CodeGraphExtractor
 
 
-def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+def batch_extract(proj_dir: str) -> dict:
     """Return {abs_filepath: [(func_name, body)]} for all TypeScript files."""
-    return cg.get_functions_by_file("typescript", proj_dir)
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_functions_by_file("typescript", proj_dir) if cg else {}
 
 
-def call_edges(cg: "CodeGraphExtractor") -> dict:
-    """Return {(caller_stem, caller_basename): {callee_stems}} for TypeScript."""
-    return cg.get_call_edges("typescript")
+def call_edges(proj_dir: str) -> dict:
+    """Return {(caller_stem, caller_module): {callee_stems}} for TypeScript."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_call_edges("typescript") if cg else {}

--- a/src/languages/typescript.py
+++ b/src/languages/typescript.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.languages.codegraph import CodeGraphExtractor
+
+
+def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    return cg.get_functions_by_file("typescript", proj_dir)
+
+
+def call_edges(cg: "CodeGraphExtractor") -> dict:
+    return cg.get_call_edges("typescript")

--- a/src/languages/typescript.py
+++ b/src/languages/typescript.py
@@ -6,8 +6,10 @@ if TYPE_CHECKING:
 
 
 def batch_extract(cg: "CodeGraphExtractor", proj_dir: str) -> dict:
+    """Return {abs_filepath: [(func_name, body)]} for all TypeScript files."""
     return cg.get_functions_by_file("typescript", proj_dir)
 
 
 def call_edges(cg: "CodeGraphExtractor") -> dict:
+    """Return {(caller_stem, caller_basename): {callee_stems}} for TypeScript."""
     return cg.get_call_edges("typescript")


### PR DESCRIPTION
## Summary

Extend the codegraph extraction backend (introduced in #53) to all FM-Agent languages that codegraph natively supports: Go, C, C++, Java, Rust, TypeScript, and JavaScript.

## Changes

- `src/languages/go.py`, `c.py`, `cpp.py`, `java.py`, `rust.py`, `javascript.py`, `typescript.py` — new per-language handler files, each implementing `batch_extract(proj_dir)` and `call_edges(proj_dir)` with internal `CodeGraphExtractor` management
- `src/languages/registry.py` — register all seven new language handlers in `REGISTRY`
- `src/languages/codegraph.py` — convert `_CG_LANG` values from single strings to lists; add `'jsx'` to the javascript entry and `'tsx'` to typescript, fixing missed call edges for `.jsx`/`.tsx` files (codegraph stores them under a separate language key)

## Motivation

`extract.py` and `generate_topdown_layers.py` call `batch_extract_all()` / `call_edges_all()` from `registry.py` and are unaware of any backend. Adding a language requires only:
1. Create `src/languages/<lang>.py` implementing `batch_extract` and `call_edges`
2. Register it in `registry.py`