### PR TITLE
feat: adds an optional local CLI-backed model execution path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@
 LLM_API_KEY=YOUR_LLM_API_KEY
 LLM_API_BASE_URL=https://openrouter.ai/api/v1
 LLM_MODEL=anthropic/claude-sonnet-4.6
+LLM_EFFORT=
+
+# Model backend. Keep opencode for upstream behavior, or set to auto,
+# codex-cli, or claude-cli to bypass OpenCode and use local CLI auth.
+FM_AGENT_MODEL_BACKEND=opencode
 
 # OpenCode provider prefix — must match a provider registered in
 # ~/.config/opencode/opencode.json.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ cp .env.example .env
 LLM_API_KEY=your-api-key-here
 LLM_API_BASE_URL=https://openrouter.ai/api/v1
 LLM_MODEL=anthropic/claude-sonnet-4.6
+LLM_EFFORT=
+FM_AGENT_MODEL_BACKEND=opencode
 OPENCODE_MODEL_PROVIDER=openrouter
 ```
 
@@ -106,6 +108,8 @@ Key parameters can be adjusted in [config.py](config.py).
 | `OPENCODE_MODEL_PROVIDER`       | `openrouter`                   | OpenCode provider prefix used when invoking `opencode run --model <prefix>/<model>` |
 | `LLM_API_KEY`                   | (env)                          | LLM API key for FM-Agent's direct calls |
 | `LLM_API_BASE_URL`              | `https://openrouter.ai/api/v1` | LLM API base URL for FM-Agent's direct calls |
+| `LLM_EFFORT`                    | unset                          | Optional reasoning effort passed to `codex exec` or `claude -p`; leave empty to omit the effort flag |
+| `FM_AGENT_MODEL_BACKEND`        | `opencode`                     | Model backend. Use `auto`, `codex-cli`, or `claude-cli` to bypass OpenCode and use local CLI authentication |
 | `GRANULARITY`                   | `40`                           | Minimum number of lines per code block when splitting a function for block-by-block reasoning |
 | `MAX_WORKERS`                   | `10`                           | Maximum number of concurrent worker threads for reasoning and bug validation |
 | `MAX_SPC_ITER`                  | `5`                            | Maximum number of retries/iterations for FM-Agent's direct LLM verification calls (post-condition and spec checks) |
@@ -227,4 +231,3 @@ Eprint = {arXiv:2604.11556},
 ## Contact
 
 If you have any questions, please submit an issue or send [email](mailto:nhaorand@gmail.com).
-

--- a/README_zh.md
+++ b/README_zh.md
@@ -76,6 +76,8 @@ cp .env.example .env
 LLM_API_KEY=your-api-key-here
 LLM_API_BASE_URL=https://openrouter.ai/api/v1
 LLM_MODEL=anthropic/claude-sonnet-4.6
+LLM_EFFORT=
+FM_AGENT_MODEL_BACKEND=opencode
 OPENCODE_MODEL_PROVIDER=openrouter
 ```
 
@@ -97,7 +99,9 @@ OpenCode provider 的配置以及可选的 prompt 缓存设置见 [docs/config_l
 
 | 参数 | 默认值 | 描述 |
 |---|---|---|
-| `LLM_MODEL` | `anthropic/claude-sonnet-4.6` | 所有任务的默认模型 |
+| `LLM_MODEL` | `anthropic/claude-sonnet-4.6` | 所有任务的默认模型；本地 CLI 后端下非空时也会传给对应 CLI |
+| `LLM_EFFORT` | unset | 可选；非空时传给 `codex exec` 或 `claude -p`，留空则不传 effort 参数 |
+| `FM_AGENT_MODEL_BACKEND` | `opencode` | 模型后端；设为 `auto`、`codex-cli` 或 `claude-cli` 可绕过 OpenCode 使用本地 CLI |
 | `OPENCODE_SETUP_MODEL` | `LLM_MODEL` | 用于理解代码库、划分代码模块和生成领域知识的模型 |
 | `OPENCODE_SPEC_MODEL` | `LLM_MODEL` | 用于规约生成的模型 |
 | `OPENCODE_BUG_VALIDATION_MODEL` | `LLM_MODEL` | 用于进行 Bug 分析和生成报告的模型 |

--- a/config.py
+++ b/config.py
@@ -5,7 +5,9 @@ load_dotenv()
 
 LLM_API_KEY = os.environ.get("LLM_API_KEY", "")
 LLM_API_BASE_URL = os.environ.get("LLM_API_BASE_URL", "https://openrouter.ai/api/v1")
+FM_AGENT_MODEL_BACKEND = os.environ.get("FM_AGENT_MODEL_BACKEND", "opencode")
 LLM_MODEL = os.environ.get("LLM_MODEL", "anthropic/claude-sonnet-4.6")
+LLM_EFFORT = os.environ.get("LLM_EFFORT", "").strip()
 # OpenCode provider prefix used when invoking `opencode run --model <prefix>/<model>`.
 # Must match a provider registered in ~/.config/opencode/opencode.json.
 OPENCODE_MODEL_PROVIDER = os.environ.get("OPENCODE_MODEL_PROVIDER", "openrouter")

--- a/docs/config_llm.md
+++ b/docs/config_llm.md
@@ -5,7 +5,9 @@ FM-Agent reads these settings from `.env` (mapped to constants in `config.py`):
 ```dotenv
 LLM_API_KEY=your-api-key                  # auth token for FM-Agent's direct calls
 LLM_API_BASE_URL=https://openrouter.ai/api/v1    # endpoint for FM-Agent's direct reasoner calls
-LLM_MODEL=anthropic/claude-sonnet-4.6            # a model key registered under the provider below
+LLM_MODEL=anthropic/claude-sonnet-4.6              # default model, same as upstream FM-Agent
+LLM_EFFORT=                                        # optional local CLI reasoning effort
+FM_AGENT_MODEL_BACKEND=opencode                 # opencode, auto, codex-cli, or claude-cli
 OPENCODE_MODEL_PROVIDER=openrouter               # an OpenCode provider id
 ```
 
@@ -13,6 +15,19 @@ It calls the model two ways:
 
 - **OpenCode** (setup / spec / bug validation): `opencode run --model "$OPENCODE_MODEL_PROVIDER/$LLM_MODEL"`, so that string must resolve to a provider + model registered in OpenCode (below).
 - **Direct** (reasoner): hits `$LLM_API_BASE_URL` itself, authenticating with `$LLM_API_KEY`.
+
+When `FM_AGENT_MODEL_BACKEND` is set to `auto`, `codex-cli`, or `claude-cli`,
+FM-Agent bypasses both of those paths and uses local CLI authentication for all
+model calls:
+
+- Codex sessions use `codex exec` with full filesystem access, plus `--model "$LLM_MODEL"` when set and `model_reasoning_effort="$LLM_EFFORT"` when non-empty.
+- Claude Code sessions use `claude -p --dangerously-skip-permissions`, plus `--model "$LLM_MODEL"` when set and `--effort "$LLM_EFFORT"` when non-empty.
+
+Leave `LLM_EFFORT` empty to use the selected CLI's default effort behavior.
+Set it only to a value accepted by the selected CLI and model.
+
+In this mode `LLM_API_KEY`, `LLM_API_BASE_URL`, and
+`OPENCODE_MODEL_PROVIDER` are not required for model access.
 
 ## Register the OpenCode provider
 

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,30 @@ set -euo pipefail
 
 echo "=== fm-agent: installing required software ==="
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$SCRIPT_DIR/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/.env"
+    set +a
+fi
+
+FM_AGENT_MODEL_BACKEND="${FM_AGENT_MODEL_BACKEND:-opencode}"
+FM_AGENT_MODEL_BACKEND="$(echo "$FM_AGENT_MODEL_BACKEND" | tr '[:upper:]' '[:lower:]')"
+USE_LOCAL_CLI_BACKEND=0
+case "$FM_AGENT_MODEL_BACKEND" in
+    ""|0|false|no|off|opencode|open-code)
+        USE_LOCAL_CLI_BACKEND=0
+        ;;
+    auto|codex|codex-cli|claude|claude-cli)
+        USE_LOCAL_CLI_BACKEND=1
+        ;;
+    *)
+        echo "[!!] unsupported FM_AGENT_MODEL_BACKEND: $FM_AGENT_MODEL_BACKEND"
+        exit 1
+        ;;
+esac
+
 # ---------- Python 3.10+ ----------
 if command -v python3 &>/dev/null; then
     py_ver=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
@@ -58,29 +82,46 @@ else
     exit 1
 fi
 
-# ---------- opencode CLI ----------
-if command -v opencode &>/dev/null; then
-    echo "[ok] opencode found: $(opencode --version 2>/dev/null || echo 'unknown version')"
+if [[ "$USE_LOCAL_CLI_BACKEND" -eq 1 ]]; then
+    echo "[ok] local CLI backend enabled: $FM_AGENT_MODEL_BACKEND"
+    if [[ "$FM_AGENT_MODEL_BACKEND" == "claude" || "$FM_AGENT_MODEL_BACKEND" == "claude-cli" ]]; then
+        command -v claude &>/dev/null || { echo "[!!] claude CLI not found"; exit 1; }
+        echo "[ok] claude found: $(claude --version 2>/dev/null || echo 'unknown version')"
+    elif [[ "$FM_AGENT_MODEL_BACKEND" == "codex" || "$FM_AGENT_MODEL_BACKEND" == "codex-cli" ]]; then
+        command -v codex &>/dev/null || { echo "[!!] codex CLI not found"; exit 1; }
+        echo "[ok] codex found: $(codex --version 2>/dev/null || echo 'unknown version')"
+    else
+        command -v codex &>/dev/null || { echo "[!!] codex CLI not found for auto backend"; exit 1; }
+        command -v claude &>/dev/null || { echo "[!!] claude CLI not found for auto backend"; exit 1; }
+        echo "[ok] codex found: $(codex --version 2>/dev/null || echo 'unknown version')"
+        echo "[ok] claude found: $(claude --version 2>/dev/null || echo 'unknown version')"
+    fi
+    echo "[ok] skipping opencode and oh-my-openagent initialization"
 else
-    echo "[..] installing opencode"
-    curl -fsSL https://opencode.ai/install | bash
-fi
+    # ---------- opencode CLI ----------
+    if command -v opencode &>/dev/null; then
+        echo "[ok] opencode found: $(opencode --version 2>/dev/null || echo 'unknown version')"
+    else
+        echo "[..] installing opencode"
+        curl -fsSL https://opencode.ai/install | bash
+    fi
 
-# ---------- oh-my-openagent plugin ----------
-if command -v bunx &>/dev/null; then
-    echo "[ok] bun found"
-else
-    echo "[..] installing bun"
-    curl -fsSL https://bun.sh/install | bash
-    # source shell config to pick up bun PATH written by the installer
-    for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
-        [[ -f "$rc" ]] && source "$rc"
-    done
-    export BUN_INSTALL="$HOME/.bun"
-    export PATH="$BUN_INSTALL/bin:$PATH"
+    # ---------- oh-my-openagent plugin ----------
+    if command -v bunx &>/dev/null; then
+        echo "[ok] bun found"
+    else
+        echo "[..] installing bun"
+        curl -fsSL https://bun.sh/install | bash
+        # source shell config to pick up bun PATH written by the installer
+        for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+            [[ -f "$rc" ]] && source "$rc"
+        done
+        export BUN_INSTALL="$HOME/.bun"
+        export PATH="$BUN_INSTALL/bin:$PATH"
+    fi
+    echo "[..] installing/updating oh-my-openagent"
+    bunx oh-my-openagent install --no-tui --claude=no --gemini=no --copilot=no
 fi
-echo "[..] installing/updating oh-my-openagent"
-bunx oh-my-openagent install --no-tui --claude=no --gemini=no --copilot=no
 
 echo ""
 echo "=== all dependencies installed ==="

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from src.opencode_trace import (
     run_opencode_traced,
     start_opencode_traced,
 )
+from src.cli_backend import build_agent_command, is_cli_backend_enabled
 from src.incremental_reasoner import run_incremental_pipeline
 import os
 import sys
@@ -422,8 +423,17 @@ def _run_setup_extract(proj_dir, work_dir, script_dir, is_incremental=False, res
                       f"work that is already done. {fm_reminder}")
         if is_incremental:
             prompt = f"{prompt} {incremental_reminder}"
-        command = ["opencode", "run", "--model", f"{OPENCODE_MODEL_PROVIDER}/{OPENCODE_SETUP_MODEL}",
-                   "--file", os.path.join(proj_dir, "fm_agent", "workflow_setup_extract.md"), "--", prompt]
+        prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_setup_extract.md")
+        if is_cli_backend_enabled():
+            command = build_agent_command(
+                model=OPENCODE_SETUP_MODEL,
+                prompt=prompt,
+                cwd=proj_dir,
+                files=[prompt_file],
+            )
+        else:
+            command = ["opencode", "run", "--model", f"{OPENCODE_MODEL_PROVIDER}/{OPENCODE_SETUP_MODEL}",
+                       "--file", prompt_file, "--", prompt]
         try:
             run_opencode_traced(
                 proj_dir=proj_dir,
@@ -758,9 +768,18 @@ def run_pipeline(proj_dir, resume=False, required_source_files=None):
                             f"that don't have [SPEC] blocks yet. "
                             f"Read fm_agent/spec_prompts/system_prompt.md for the format rules. {fm_reminder}"
                         )
-                    command = ["opencode", "run", "--model", f"{OPENCODE_MODEL_PROVIDER}/{OPENCODE_SPEC_MODEL}",
-                               "--file", os.path.join(proj_dir, "fm_agent", "workflow_spec_step4_batch.md"),
-                               "--", prompt]
+                    prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_spec_step4_batch.md")
+                    if is_cli_backend_enabled():
+                        command = build_agent_command(
+                            model=OPENCODE_SPEC_MODEL,
+                            prompt=prompt,
+                            cwd=proj_dir,
+                            files=[prompt_file],
+                        )
+                    else:
+                        command = ["opencode", "run", "--model", f"{OPENCODE_MODEL_PROVIDER}/{OPENCODE_SPEC_MODEL}",
+                                   "--file", prompt_file,
+                                   "--", prompt]
                     trace_record = start_opencode_traced(
                         proj_dir=proj_dir,
                         work_dir=work_dir,

--- a/src/cli_backend.py
+++ b/src/cli_backend.py
@@ -1,0 +1,187 @@
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+_BACKEND_ALIASES = {
+    "codex": "codex-cli",
+    "codex-cli": "codex-cli",
+    "claude": "claude-cli",
+    "claude-cli": "claude-cli",
+    "opencode": "opencode",
+    "open-code": "opencode",
+}
+
+
+@dataclass(frozen=True)
+class AgentCommand:
+    argv: list[str]
+    stdin: Optional[str] = None
+    backend: str = "opencode"
+
+
+def _normalize_backend(value):
+    backend = (value or "").strip().lower()
+    if not backend or backend in {"0", "false", "no", "off"}:
+        return "opencode"
+    if backend == "auto":
+        return "auto"
+    return _BACKEND_ALIASES.get(backend, backend)
+
+
+def resolve_model_backend():
+    backend = _normalize_backend(os.environ.get("FM_AGENT_MODEL_BACKEND"))
+    if backend != "auto":
+        return backend
+
+    host_hint = (os.environ.get("FM_AGENT_HOST") or os.environ.get("FM_AGENT_CLIENT") or "").lower()
+    if "claude" in host_hint:
+        return "claude-cli"
+    if "codex" in host_hint:
+        return "codex-cli"
+
+    claude_markers = ("CLAUDE_PLUGIN_ROOT", "CLAUDE_CODE_ENTRYPOINT")
+    if any(os.environ.get(name) for name in claude_markers):
+        return "claude-cli"
+
+    codex_markers = ("CODEX_HOME", "CODEX_SANDBOX", "CODEX_EXECUTION_MODE")
+    if any(os.environ.get(name) for name in codex_markers):
+        return "codex-cli"
+
+    return "codex-cli"
+
+
+def is_cli_backend_enabled():
+    return resolve_model_backend() in {"codex-cli", "claude-cli"}
+
+
+def cli_effort():
+    return os.environ.get("LLM_EFFORT", "").strip()
+
+
+def _compose_stdin(prompt, files):
+    if not files:
+        return prompt
+    file_list = "\n".join(f"- {path}" for path in files)
+    return (
+        "Read these file(s) before acting:\n"
+        f"{file_list}\n\n"
+        f"{prompt}"
+    )
+
+
+def build_agent_command(model, prompt, cwd, files=None, backend=None, effort=None):
+    resolved = _normalize_backend(backend) if backend else resolve_model_backend()
+    if resolved == "auto":
+        resolved = resolve_model_backend()
+    if resolved not in {"codex-cli", "claude-cli"}:
+        raise ValueError(f"unsupported CLI backend: {resolved}")
+
+    cwd = os.path.abspath(cwd)
+    stdin = _compose_stdin(prompt, files or [])
+    model = (model or "").strip()
+    effort = (effort if effort is not None else cli_effort()).strip()
+
+    if resolved == "codex-cli":
+        argv = [
+            "codex",
+            "exec",
+            "--sandbox",
+            "danger-full-access",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--skip-git-repo-check",
+            "-C",
+            cwd,
+        ]
+        if model:
+            argv += ["--model", model]
+        if effort:
+            argv += ["-c", f'model_reasoning_effort="{effort}"']
+        argv.append("-")
+        return AgentCommand(argv=argv, stdin=stdin, backend=resolved)
+
+    argv = [
+        "claude",
+        "-p",
+        "--output-format",
+        "text",
+        "--no-session-persistence",
+        "--dangerously-skip-permissions",
+        "--permission-mode",
+        "bypassPermissions",
+        "--add-dir",
+        cwd,
+    ]
+    if model:
+        argv += ["--model", model]
+    if effort:
+        argv += ["--effort", effort]
+    return AgentCommand(argv=argv, stdin=stdin, backend=resolved)
+
+
+def command_argv(command):
+    if isinstance(command, AgentCommand):
+        return command.argv
+    return list(command)
+
+
+def command_stdin(command):
+    if isinstance(command, AgentCommand):
+        return command.stdin
+    return None
+
+
+def command_display(command):
+    argv = command_argv(command)
+    suffix = " <stdin>" if command_stdin(command) is not None else ""
+    return shlex.join(argv) + suffix
+
+
+def messages_to_prompt(messages):
+    parts = []
+    for message in messages:
+        role = message.get("role", "user")
+        content = message.get("content", "")
+        if not isinstance(content, str):
+            content = "\n".join(
+                block.get("text", "")
+                for block in content
+                if isinstance(block, dict)
+            )
+        parts.append(f"{role.upper()}:\n{content}")
+    return "\n\n".join(parts)
+
+
+def run_agent_for_messages(model, messages):
+    prompt = (
+        "Answer the following conversation directly. Preserve any requested output tags "
+        "exactly and do not add unrelated commentary.\n\n"
+        f"{messages_to_prompt(messages)}"
+    )
+    cwd = os.path.abspath(os.getcwd())
+    command = build_agent_command(model=model, prompt=prompt, cwd=cwd)
+    result = subprocess.run(
+        command.argv,
+        input=command.stdin,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=1800,
+        check=False,
+    )
+    if result.returncode != 0:
+        output = (result.stdout or "")[-4000:]
+        raise RuntimeError(
+            f"{command.backend} exited with code {result.returncode}: {output}"
+        )
+    return result.stdout.strip(), {}

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -41,6 +41,7 @@ from .generate_batch_prompts import (
 )
 from .opencode_trace import run_opencode_traced
 from .llm_client import _llm_provider_client, _llm_call
+from .cli_backend import build_agent_command, is_cli_backend_enabled
 from .prompts import _load_spec_check_json
 from .scope import _parse_issue_signals, rank_functions_in_file
 from .verification import _verify_single_file, _validate_single_bug, _generate_validation_summary, EXT_TO_LANG as _VERIFY_EXT_TO_LANG
@@ -759,11 +760,20 @@ def _opencode_select_json(proj_dir, work_dir, prompt_relpath, prompt_content,
         f.write(prompt_content)
     os.replace(tmp_path, prompt_path)
 
-    command = [
-        "opencode", "run", "--model", f"{OPENCODE_MODEL_PROVIDER}/{OPENCODE_SETUP_MODEL}",
-        "--file", prompt_path,
-        "--", "Follow the instructions in the attached file.",
-    ]
+    prompt = "Follow the instructions in the attached file."
+    if is_cli_backend_enabled():
+        command = build_agent_command(
+            model=OPENCODE_SETUP_MODEL,
+            prompt=prompt,
+            cwd=proj_dir,
+            files=[prompt_path],
+        )
+    else:
+        command = [
+            "opencode", "run", "--model", f"{OPENCODE_MODEL_PROVIDER}/{OPENCODE_SETUP_MODEL}",
+            "--file", prompt_path,
+            "--", prompt,
+        ]
 
     produced = False
     for attempt in range(1, OPENCODE_MAX_RETRIES + 1):

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -8,6 +8,7 @@ import urllib.error
 import urllib.parse
 import logging
 from config import *
+from .cli_backend import is_cli_backend_enabled, run_agent_for_messages
 from openai import OpenAI, RateLimitError, BadRequestError
 from .trace_writer import (
     new_event_id,
@@ -166,6 +167,9 @@ def _retry_create(client, model, messages):
     - When LLM_API_BASE_URL matches INJECT_HOST, metadata.user_id is attached so
       third-party relays that support it can keep prompt-cache routing sticky.
     """
+    if is_cli_backend_enabled():
+        return run_agent_for_messages(model, messages)
+
     rate_limit_attempts = 0
     transient_attempts = 0
     use_anthropic = _is_anthropic_model(model)

--- a/src/opencode_trace.py
+++ b/src/opencode_trace.py
@@ -5,6 +5,7 @@ import threading
 from dataclasses import dataclass
 
 from config import OPENCODE_TIMEOUT_SECONDS
+from .cli_backend import command_argv, command_display, command_stdin
 from .trace_writer import (
     new_event_id,
     record_trace_event,
@@ -45,6 +46,7 @@ class TracedOpenCodeProcess:
     opencode_log_path: str | None = None
     opencode_trace_path: str | None = None
     log_thread: threading.Thread | None = None
+    stdin_thread: threading.Thread | None = None
     error: str | None = None
 
 
@@ -103,24 +105,42 @@ def _copy_opencode_output(stream, trace_log_path=None):
     stream.close()
 
 
+def _write_command_stdin(stream, text):
+    try:
+        stream.write(text)
+        stream.flush()
+    finally:
+        stream.close()
+
+
 def _start_opencode_process(proj_dir, work_dir, event_id, command, trace_log_path):
+    stdin_text = command_stdin(command)
     proc = subprocess.Popen(
-        command,
+        command_argv(command),
         cwd=proj_dir,
         env=_opencode_env(work_dir, event_id),
+        stdin=subprocess.PIPE if stdin_text is not None else None,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
         encoding="utf-8",
         errors="replace",
     )
+    stdin_thread = None
+    if stdin_text is not None:
+        stdin_thread = threading.Thread(
+            target=_write_command_stdin,
+            args=(proc.stdin, stdin_text),
+            daemon=True,
+        )
+        stdin_thread.start()
     log_thread = threading.Thread(
         target=_copy_opencode_output,
         args=(proc.stdout, trace_log_path),
         daemon=True,
     )
     log_thread.start()
-    return proc, log_thread
+    return proc, log_thread, stdin_thread
 
 
 def _wait_opencode_process(proc, command, stage, timeout_seconds=OPENCODE_TIMEOUT_SECONDS):
@@ -132,7 +152,7 @@ def _wait_opencode_process(proc, command, stage, timeout_seconds=OPENCODE_TIMEOU
         # take over instead of the whole pipeline hanging.
         logging.warning(
             "opencode %s timed out after %ss, killing: %s",
-            stage, timeout_seconds, " ".join(command),
+            stage, timeout_seconds, command_display(command),
         )
         proc.terminate()
         try:
@@ -197,12 +217,13 @@ def record_opencode_call(
         "function_ids": function_ids or [],
         "children": children,
         "metadata": {
-            "command": command,
+            "command": command_argv(command),
             "exit_code": exit_code,
             "input_files": input_files or [],
             "output_files": output_files or [],
             "error": error,
             **(metadata or {}),
+            "command_display": command_display(command),
         },
     })
 
@@ -225,16 +246,19 @@ def run_opencode_traced(
     opencode_log_path = _opencode_log_path(work_dir, event_id)
     opencode_trace_path = _opencode_trace_path(work_dir, event_id)
     log_thread = None
+    stdin_thread = None
     try:
-        proc, log_thread = _start_opencode_process(proj_dir, work_dir, event_id, command, opencode_log_path)
+        proc, log_thread, stdin_thread = _start_opencode_process(proj_dir, work_dir, event_id, command, opencode_log_path)
         exit_code, error = _wait_opencode_process(proc, command, stage)
         if error:
-            raise subprocess.CalledProcessError(exit_code, command)
+            raise subprocess.CalledProcessError(exit_code, command_argv(command))
         if log_thread:
             log_thread.join()
+        if stdin_thread:
+            stdin_thread.join()
         if exit_code != 0:
-            raise subprocess.CalledProcessError(exit_code, command)
-        return subprocess.CompletedProcess(command, exit_code)
+            raise subprocess.CalledProcessError(exit_code, command_argv(command))
+        return subprocess.CompletedProcess(command_argv(command), exit_code)
     except subprocess.CalledProcessError as exc:
         exit_code = exc.returncode
         error = error or str(exc)
@@ -242,6 +266,8 @@ def run_opencode_traced(
     finally:
         if log_thread and log_thread.is_alive():
             log_thread.join()
+        if stdin_thread and stdin_thread.is_alive():
+            stdin_thread.join()
         record_opencode_call(
             work_dir=work_dir,
             event_id=event_id,
@@ -277,7 +303,7 @@ def start_opencode_traced(
     started = utc_now_iso()
     opencode_log_path = _opencode_log_path(work_dir, event_id)
     opencode_trace_path = _opencode_trace_path(work_dir, event_id)
-    proc, log_thread = _start_opencode_process(proj_dir, work_dir, event_id, command, opencode_log_path)
+    proc, log_thread, stdin_thread = _start_opencode_process(proj_dir, work_dir, event_id, command, opencode_log_path)
     return TracedOpenCodeProcess(
         proc=proc,
         work_dir=work_dir,
@@ -293,6 +319,7 @@ def start_opencode_traced(
         opencode_log_path=opencode_log_path,
         opencode_trace_path=opencode_trace_path,
         log_thread=log_thread,
+        stdin_thread=stdin_thread,
     )
 
 
@@ -309,6 +336,8 @@ def wait_opencode_traced(record, timeout_seconds=OPENCODE_TIMEOUT_SECONDS):
 
 
 def finish_opencode_trace(record):
+    if record.stdin_thread:
+        record.stdin_thread.join()
     if record.log_thread:
         record.log_thread.join()
     status = "error" if record.error or record.proc.returncode != 0 else "success"

--- a/src/verification.py
+++ b/src/verification.py
@@ -4,6 +4,7 @@ from .parser import parse_input_function
 from .reasoner import reasoner, _parse_spec_conditions, _sanitize_strings
 from .file_utils import is_file_ready
 from .opencode_trace import function_id_from_result_path, run_opencode_traced
+from .cli_backend import build_agent_command, is_cli_backend_enabled
 import os
 import re
 import json
@@ -335,9 +336,18 @@ def _validate_single_bug(result_json_rel, proj_dir, work_dir=None, resume=False)
         f.write(prompt_content)
     os.replace(tmp_path, prompt_path)
 
-    command = ["opencode", "run", "--model", f"{OPENCODE_MODEL_PROVIDER}/{OPENCODE_BUG_VALIDATION_MODEL}",
-               "--file", prompt_path,
-               "--", "Follow the instructions in the attached file"]
+    prompt = "Follow the instructions in the attached file"
+    if is_cli_backend_enabled():
+        command = build_agent_command(
+            model=OPENCODE_BUG_VALIDATION_MODEL,
+            prompt=prompt,
+            cwd=proj_dir,
+            files=[prompt_path],
+        )
+    else:
+        command = ["opencode", "run", "--model", f"{OPENCODE_MODEL_PROVIDER}/{OPENCODE_BUG_VALIDATION_MODEL}",
+                   "--file", prompt_path,
+                   "--", prompt]
     result_relpath = os.path.join("fm_agent", "bug_validation", f"{bug_id}.result.json")
     result_path = os.path.join(proj_dir, result_relpath)
     # Resume idempotency: if resuming and this bug was already validated, don't pay for it again.


### PR DESCRIPTION
This PR adds an optional local CLI backend for running FM-Agent with authenticated local agent CLIs. 

- By default, FM-Agent still uses OpenCode with the existing OpenRouter/API-key setup. Users who already have an authenticated local CLI session can opt in to bypass OpenCode by setting `FM_AGENT_MODEL_BACKEND=codex-cli / claude-cli / auto`, then FM-Agent will call models through `codex exec` or `claude -p` instead of opencode run.

- `LLM_MODEL` is passed to both local CLI backends. `LLM_EFFORT` is optional: when set, it is passed as `model_reasoning_effort` for codex exec and `--effort` for claude -p; when empty, no effort flag is passed. 

- The installer also checks for the selected local CLI and skips OpenCode/oh-my-openagent initialization when a local CLI backend is enabled.

There is also a PR for new FM-Agent-Plugin backend modes: https://github.com/fmagent-project/FM-Agent-Plugin/pull/6