### PR TITLE
fix(codegraph): disambiguate same-named functions (data loss + call-edge attribution)

### DIFF
--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -281,6 +281,9 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
     # For call-site detection, use global stems if available
     effective_stem_to_fqns = global_stem_to_fqns if global_stem_to_fqns else stem_to_fqns
     known_stems = set(effective_stem_to_fqns.keys())
+    # All extracted FQNs (across phases when a global map is supplied), used to
+    # keep only codegraph callees that correspond to an extracted function.
+    known_fqns = set().union(*effective_stem_to_fqns.values()) if effective_stem_to_fqns else set()
 
     callees_map = defaultdict(set)  # fqn -> set of callee fqns (within phase)
     callers_map = defaultdict(set)  # fqn -> set of caller fqns (within phase)
@@ -294,28 +297,31 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None):
         lang_key = _detect_lang_from_ext(filepath)
         if not lang_key:
             continue
-        keywords = _get_keywords_for_lang(lang_key)
 
-        caller_stem = fqn.split("::")[-1]
         if lang_key in registry_langs:
-            caller_module = fqn.split("::")[-2]
-            called_stems = registry_edges.get((caller_stem, caller_module), set()) & known_stems
+            # codegraph: edges are already precise caller_fqn -> callee_fqn (the
+            # exact node codegraph resolved). Keep only callees that are extracted
+            # functions; drop external/library targets.
+            callee_fqns = {c for c in registry_edges.get(fqn, set())
+                           if c != fqn and c in known_fqns}
         else:
+            # regex fallback: detect bare-name call sites, then resolve each stem
+            # to every same-named FQN (an over-approximation — unchanged).
+            keywords = _get_keywords_for_lang(lang_key)
             try:
                 with open(filepath, "r", errors="replace") as f:
                     text = f.read()
             except OSError:
                 continue
             called_stems = _find_call_sites(text, lang_key, known_stems, keywords)
+            callee_fqns = {cf for stem in called_stems
+                           for cf in effective_stem_to_fqns[stem] if cf != fqn}
 
-        # Resolve stems to FQNs, excluding self
-        for stem in called_stems:
-            for callee_fqn in effective_stem_to_fqns[stem]:
-                if callee_fqn != fqn:
-                    all_callees_map[fqn].add(callee_fqn)
-                    if callee_fqn in phase_fqns:
-                        callees_map[fqn].add(callee_fqn)
-                        callers_map[callee_fqn].add(fqn)
+        for callee_fqn in callee_fqns:
+            all_callees_map[fqn].add(callee_fqn)
+            if callee_fqn in phase_fqns:
+                callees_map[fqn].add(callee_fqn)
+                callers_map[callee_fqn].add(fqn)
 
     return callees_map, callers_map, all_callees_map, file_map, module_map
 

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -50,6 +50,56 @@ _CONSTRUCTOR_FILTER = {
 }
 
 
+def _fqn_for(file_path: str, name: str) -> str:
+    """Build the FQN of a function, identical to generate_topdown_layers._file_to_fqn.
+
+    The extracted layout for a source file ``<dir>/<base>.<ext>`` is
+    ``<dir>/<base>-<ext>/<name>.<ext>``, whose FQN is ``dir::base-ext::name``.
+    Constructing the same string here lets get_call_edges emit edges keyed by the
+    exact same FQN the call-graph builder assigns to each extracted function, so
+    codegraph's precisely-resolved caller/callee node identity is preserved
+    instead of being collapsed to a bare name.
+    """
+    norm = file_path.replace(os.sep, "/")
+    d = os.path.dirname(norm)
+    base = os.path.basename(norm)
+    last_dot = base.rfind(".")
+    dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
+    parts = [p for p in d.split("/") if p]
+    parts += [dashed, name]
+    return "::".join(parts)
+
+
+def _node_fqn_map(cur, cg_langs) -> dict:
+    """Return {node_id: fqn} for every function/method node in the given languages.
+
+    The per-file name dedup (``Flush``, ``Flush_1``, ...) uses the SAME rule and
+    ordering as get_functions_by_file (``ORDER BY file_path, start_line``, then a
+    per-(file, name) counter), so the FQN assigned to a node here matches the FQN
+    the extracted file for that node receives. Keeping the two in lockstep is what
+    makes the call-edge identities line up with the extracted-function identities.
+    """
+    placeholders = ",".join("?" * len(cg_langs))
+    cur.execute(
+        f"""
+        SELECT id, name, file_path, start_line
+        FROM nodes
+        WHERE kind IN ('function', 'method') AND language IN ({placeholders})
+        ORDER BY file_path, start_line
+        """,
+        cg_langs,
+    )
+    counts: dict = {}
+    result: dict = {}
+    for node_id, name, file_path, _start in cur.fetchall():
+        key = (file_path, name)
+        c = counts.get(key, 0)
+        counts[key] = c + 1
+        deduped = name if c == 0 else f"{name}_{c}"
+        result[node_id] = _fqn_for(file_path, deduped)
+    return result
+
+
 class CodeGraphExtractor:
     """Query a codegraph SQLite database to extract functions and call edges."""
 
@@ -113,28 +163,50 @@ class CodeGraphExtractor:
                 continue
 
             file_funcs = []
+            name_counts = {}
             for name, start_line, end_line in funcs:
+                # Disambiguate functions sharing a name within one file
+                # (LocalStorage::Flush vs RemoteCache::Flush, overloads, a method
+                # and a same-named free function, ...). codegraph stores them all
+                # under the same bare name; run_extraction writes each to
+                # "<name>.<ext>", so without a suffix the later definition
+                # silently overwrites the earlier one — dropping functions from
+                # both extraction and the call graph. Mirror the regex path's
+                # dedup ("Flush", "Flush_1", ...). funcs are line-ordered (SQL
+                # ORDER BY start_line), so suffix assignment is deterministic.
+                count = name_counts.get(name, 0)
+                name_counts[name] = count + 1
+                deduped = name if count == 0 else f"{name}_{count}"
                 # codegraph uses 1-indexed lines, end_line is inclusive
                 body_lines = all_lines[start_line - 1 : end_line]
                 body = "".join(body_lines)
                 if not body.endswith("\n"):
                     body += "\n"
-                file_funcs.append((name, body))
+                file_funcs.append((deduped, body))
 
             result[abs_path] = file_funcs
 
         return result
 
     def get_call_edges(self, lang_key: str) -> dict:
-        """Return {(caller_stem, caller_basename): {callee_stem, ...}} for the given language.
+        """Return {caller_fqn: {callee_fqn, ...}} for the given language.
 
-        caller_stem / callee_stem are plain function names (fqn.split('::')[-1]).
-        caller_basename is os.path.basename(caller_file_path), used to disambiguate
-        same-name functions defined in different files.
+        Each FQN matches generate_topdown_layers._file_to_fqn for the
+        corresponding extracted function (``dir::file-ext::dedup_name``). Edges
+        are resolved by codegraph NODE ID (not by bare name), so the precise
+        caller/callee identity codegraph computed — which file, which same-named
+        sibling — is preserved end-to-end. This lets the call-graph builder use
+        the edges directly instead of re-resolving bare names against every
+        same-named function (which collapsed siblings and over-approximated
+        across files).
 
         Constructor calls are synthesised from `instantiates` edges: when a
         function instantiates a class, the corresponding constructor method is
         added as a callee.  See _CONSTRUCTOR_FILTER for per-language details.
+
+        NOTE: codegraph itself collapses calls to same-named classes in different
+        files onto the first definition (a codegraph resolver limitation for C++,
+        not addressable here — see issues/codegraph-samename-class-resolution).
         """
         cg_langs = _CG_LANG.get(lang_key)
         if not cg_langs:
@@ -144,25 +216,27 @@ class CodeGraphExtractor:
         cur = conn.cursor()
         placeholders = ",".join("?" * len(cg_langs))
 
-        # Query 1: regular function/method calls
+        # Map every function/method node to its FQN once, using the same per-file
+        # dedup as get_functions_by_file, then resolve edges by node id.
+        fqn_of = _node_fqn_map(cur, cg_langs)
+
+        result = defaultdict(set)
+
+        # Query 1: regular function/method calls, kept as (source_id, target_id)
+        # so each endpoint resolves to its exact node's FQN.
         cur.execute(
             f"""
-            SELECT s.name, s.file_path, t.name
+            SELECT e.source, e.target
             FROM edges e
             JOIN nodes s ON e.source = s.id
-            JOIN nodes t ON e.target = t.id
             WHERE e.kind = 'calls' AND s.language IN ({placeholders})
             """,
             cg_langs,
         )
-        rows = cur.fetchall()
-
-        result = defaultdict(set)
-        for caller, caller_file, callee in rows:
-            base = os.path.basename(caller_file)
-            last_dot = base.rfind(".")
-            dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
-            result[(caller, dashed)].add(callee)
+        for src_id, tgt_id in cur.fetchall():
+            caller, callee = fqn_of.get(src_id), fqn_of.get(tgt_id)
+            if caller and callee:
+                result[caller].add(callee)
 
         # Query 2: constructor calls synthesised from instantiates edges.
         # For each `caller instantiates ClassName` edge, find the constructor
@@ -171,7 +245,7 @@ class CodeGraphExtractor:
         if ctor_filter:
             cur.execute(
                 f"""
-                SELECT s.name, s.file_path, ctor.name
+                SELECT e.source, ctor.id
                 FROM edges e
                 JOIN nodes s   ON e.source = s.id
                 JOIN nodes cls ON e.target = cls.id AND cls.kind = 'class'
@@ -183,11 +257,10 @@ class CodeGraphExtractor:
                 """,
                 cg_langs,
             )
-            for caller, caller_file, ctor_name in cur.fetchall():
-                base = os.path.basename(caller_file)
-                last_dot = base.rfind(".")
-                dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
-                result[(caller, dashed)].add(ctor_name)
+            for src_id, ctor_id in cur.fetchall():
+                caller, callee = fqn_of.get(src_id), fqn_of.get(ctor_id)
+                if caller and callee:
+                    result[caller].add(callee)
 
         conn.close()
         return dict(result)

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -16,7 +16,7 @@ class LanguageHandler:
     """Extraction and call-graph backend for one language.
 
     batch_extract(proj_dir) -> {abs_filepath: [(func_name, body)]}
-    call_edges(proj_dir)    -> {(caller_stem, caller_module): {callee_stems}}
+    call_edges(proj_dir)    -> {caller_fqn: {callee_fqns}}
 
     Each function handles its own backend (e.g. codegraph) internally and
     returns an empty dict when the backend is unavailable.
@@ -61,8 +61,8 @@ def batch_extract_all(proj_dir: str) -> tuple:
 def call_edges_all(proj_dir: str, lang_keys) -> tuple:
     """Call call_edges for each language in lang_keys and merge results.
 
-    Returns (edges, langs) where edges is {(caller_stem, caller_module): {callee_stems}}
-    and langs is the set of language keys that returned data.
+    Returns (edges, langs) where edges is {caller_fqn: {callee_fqns}} and langs is
+    the set of language keys that returned data.
     """
     edges = {}
     langs = set()


### PR DESCRIPTION
## Summary

FM-Agent keyed extracted functions and call edges by bare name, so functions
sharing a name were (1) silently overwritten during extraction and (2)
misattributed in the call graph. This fixes both.

## Changes

- `src/languages/codegraph.py`
  - `get_functions_by_file`: dedup same-file same-name functions
    (`Flush`, `Flush_1`, ...) so none is overwritten.
  - new `_fqn_for` / `_node_fqn_map`; `get_call_edges` now resolves edges by
    codegraph **node id** into FQNs (identical to `_file_to_fqn`), returning
    `{caller_fqn: {callee_fqn}}`.
- `src/generate_topdown_layers.py`
  - `_build_call_graph` consumes the precise FQN edges for codegraph-handled
    languages; the regex fallback path is unchanged.
- `src/languages/registry.py`: docstring update for the new contract.

## Scope

Cross-file calls to same-named C++ *classes* were previously collapsed onto the
first definition — a codegraph resolver limitation we reported upstream at
colbymchenry/codegraph#1079. That is now **fixed in codegraph 1.2.0**, so with
codegraph >= 1.2.0 this case resolves correctly too. FM-Agent faithfully
reflects codegraph's resolution, so nothing was needed here for it.

Fixes #62
