### PR TITLE
fix(codegraph): don't fall back to regex when codegraph found zero call edges

### DIFF
--- a/src/languages/c.py
+++ b/src/languages/c.py
@@ -10,4 +10,4 @@ def batch_extract(proj_dir: str) -> dict:
 def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for C."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    return cg.get_call_edges("c") if cg else {}
+    return cg.get_call_edges("c") if cg else None

--- a/src/languages/cpp.py
+++ b/src/languages/cpp.py
@@ -10,4 +10,4 @@ def batch_extract(proj_dir: str) -> dict:
 def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for C++."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    return cg.get_call_edges("cpp") if cg else {}
+    return cg.get_call_edges("cpp") if cg else None

--- a/src/languages/go.py
+++ b/src/languages/go.py
@@ -10,4 +10,4 @@ def batch_extract(proj_dir: str) -> dict:
 def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for Go."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    return cg.get_call_edges("go") if cg else {}
+    return cg.get_call_edges("go") if cg else None

--- a/src/languages/java.py
+++ b/src/languages/java.py
@@ -10,4 +10,4 @@ def batch_extract(proj_dir: str) -> dict:
 def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for Java."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    return cg.get_call_edges("java") if cg else {}
+    return cg.get_call_edges("java") if cg else None

--- a/src/languages/javascript.py
+++ b/src/languages/javascript.py
@@ -10,4 +10,4 @@ def batch_extract(proj_dir: str) -> dict:
 def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for JavaScript."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    return cg.get_call_edges("javascript") if cg else {}
+    return cg.get_call_edges("javascript") if cg else None

--- a/src/languages/python.py
+++ b/src/languages/python.py
@@ -10,4 +10,4 @@ def batch_extract(proj_dir: str) -> dict:
 def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for Python."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    return cg.get_call_edges("python") if cg else {}
+    return cg.get_call_edges("python") if cg else None

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -62,7 +62,8 @@ def call_edges_all(proj_dir: str, lang_keys) -> tuple:
     """Call call_edges for each language in lang_keys and merge results.
 
     Returns (edges, langs) where edges is {caller_fqn: {callee_fqns}} and langs is
-    the set of language keys that returned data.
+    the set of language keys codegraph handled (it returned a dict, even if empty
+    — None means the backend was unavailable and the caller should use regex).
     """
     edges = {}
     langs = set()
@@ -70,7 +71,13 @@ def call_edges_all(proj_dir: str, lang_keys) -> tuple:
         if lang not in REGISTRY:
             continue
         result = REGISTRY[lang].call_edges(proj_dir)
-        if result:
+        # A handler returns None when its backend (codegraph) is unavailable, and
+        # a dict (possibly empty) when it handled the language. Treat "handled but
+        # no edges" as codegraph-authoritative — add the language to `langs` so the
+        # caller uses the codegraph path — instead of falling back to regex, which
+        # would otherwise invent edges (e.g. match a function's own signature) for
+        # a genuinely call-free project.
+        if result is not None:
             langs.add(lang)
             for key, callees in result.items():
                 edges.setdefault(key, set()).update(callees)

--- a/src/languages/rust.py
+++ b/src/languages/rust.py
@@ -10,4 +10,4 @@ def batch_extract(proj_dir: str) -> dict:
 def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for Rust."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    return cg.get_call_edges("rust") if cg else {}
+    return cg.get_call_edges("rust") if cg else None

--- a/src/languages/typescript.py
+++ b/src/languages/typescript.py
@@ -10,4 +10,4 @@ def batch_extract(proj_dir: str) -> dict:
 def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for TypeScript."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
-    return cg.get_call_edges("typescript") if cg else {}
+    return cg.get_call_edges("typescript") if cg else None


### PR DESCRIPTION
## Summary

When codegraph found no call edges, FM-Agent fell back to the regex call-site
detector, which invents edges by matching a function's own signature — producing
spurious call edges for call-free projects with duplicate-named functions. This
makes an empty codegraph result authoritative instead.

## Changes

- `src/languages/*.py` (8 handlers): `call_edges` returns `None` when codegraph
  is unavailable, instead of `{}` (which was indistinguishable from "handled but
  no calls").
- `src/languages/registry.py`: `call_edges_all` keys "codegraph handled this
  language" on `result is not None`, so a zero-edge result keeps the codegraph
  path instead of falling back to regex.

`_build_call_graph`'s codegraph branch already handles an empty edge set, so it
needs no change.

## Note

Stacked on #63 (shares `registry.py`); base will retarget to `main` once #63
merges.

Fixes #64
