### PR TITLE
Fix entry-function span detection using codegraph for selection

### DIFF
--- a/src/entry_reasoning_pipeline.py
+++ b/src/entry_reasoning_pipeline.py
@@ -2,136 +2,21 @@ import os
 import json
 import shutil
 import logging
-import tempfile
 from collections import deque, defaultdict
 
-from src.generate_topdown_layers import _build_call_graph, _file_to_fqn
-from src.extract import (
-    EXT_TO_LANG,
-    LANG_CONFIG,
-    _extract_functions_brace,
-    _extract_functions_indent,
-    extract_functions_from_file,
+from src.generate_topdown_layers import (
+    _build_call_graph,
+    _collect_phase_files,
+    _file_to_fqn,
 )
+from src.extract import EXT_TO_LANG, _function_spans, run_extraction
+from src.languages.codegraph import try_codegraph_init
 from src.file_utils import (
     _is_test_file,
     add_test_file_exemption,
     clear_test_file_exemptions,
 )
 import config
-
-
-def _collect_all_function_files(proj_dir):
-    """Collect every extracted function file under proj_dir.
-
-    Returns a list of (filepath, module_name) tuples, where module_name is the
-    extracted directory the function file lives in (only used for bookkeeping;
-    it does not affect the call-graph edges).
-    """
-    extracted_base = os.path.join(proj_dir, "extracted_functions")
-    results = []
-    for root, _, files in os.walk(extracted_base):
-        module_name = os.path.relpath(root, extracted_base)
-        for fname in files:
-            fpath = os.path.join(root, fname)
-            if os.path.isfile(fpath):
-                results.append((fpath, module_name))
-    return results
-
-
-def _extract_for_selection(proj_dir, tmp_root):
-    """Mechanically extract every function in proj_dir into a temp workspace.
-
-    Writes the standard ``extracted_functions/`` layout (same per-file naming
-    and dedup rules as run_extraction) under ``tmp_root`` so the call-graph
-    machinery can run on it. Unlike the pipeline's extraction stage this needs
-    no phases.json — and therefore no previous run_pipeline(): it simply scans
-    every supported source file, skipping the fm_agent/ workspace, .git, and
-    test files.
-
-    Returns the number of extracted functions.
-    """
-    output_base = os.path.join(tmp_root, "extracted_functions")
-    count = 0
-    for root, dirs, files in os.walk(proj_dir):
-        dirs[:] = [d for d in dirs if d not in ("fm_agent", ".git")]
-        for fname in files:
-            src_path = os.path.join(root, fname)
-            src_rel = os.path.relpath(src_path, proj_dir)
-            if not os.path.isfile(src_path):
-                logging.debug("Skipping non-file source path during entry selection: %s", src_rel)
-                continue
-            ext = fname.rsplit(".", 1)[-1] if "." in fname else ""
-            lang_key = EXT_TO_LANG.get(ext)
-            if not lang_key or _is_test_file(src_rel):
-                continue
-            funcs = extract_functions_from_file(src_path, lang_key)
-            if not funcs:
-                continue
-            # Same layout as run_extraction: replace the source filename's
-            # last dot with a hyphen to form the function directory.
-            src_dir = os.path.dirname(src_rel)
-            base = os.path.basename(src_rel)
-            last_dot = base.rfind(".")
-            dir_name = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
-            out_dir = os.path.join(output_base, src_dir, dir_name)
-            os.makedirs(out_dir, exist_ok=True)
-            for func_name, func_source in funcs:
-                with open(os.path.join(out_dir, f"{func_name}.{ext}"), "w") as f:
-                    f.write(func_source)
-                count += 1
-    return count
-
-
-def build_entry_call_graph(proj_dir, entry_func):
-    """Construct the call graph of functions reachable from entry_func.
-
-    Statically approximates which functions under ``proj_dir`` are called
-    during an execution that starts at ``entry_func``: it builds the global
-    call graph over all extracted functions, then keeps only ``entry_func``
-    and the functions transitively reachable from it via callee edges.
-
-    Args:
-        proj_dir: path to a workspace directory that contains an
-            ``extracted_functions/`` tree.
-        entry_func: FQN of the entry point, e.g. ``src::engine::loader-cpp::loadData``.
-            Assumed to be a function under ``proj_dir``.
-
-    Returns:
-        A dict mapping each reachable FQN (including ``entry_func``) to a sorted
-        list of the FQNs it directly calls within the reachable set. Functions
-        with no outgoing calls map to an empty list.
-
-    Raises:
-        ValueError: if ``entry_func`` is not found among the extracted functions.
-    """
-    all_files = _collect_all_function_files(proj_dir)
-
-    # Build the global call graph over every function. Passing all files as a
-    # single "phase" makes callees_map contain every resolved within-project edge.
-    callees_map, _callers_map, _all_callees_map, file_map, _module_map = _build_call_graph(
-        all_files, proj_dir
-    )
-
-    if entry_func not in file_map:
-        raise ValueError(
-            f"entry_func {entry_func!r} not found among extracted functions under {proj_dir!r}"
-        )
-
-    # BFS over callee edges to find the functions reachable from the entry point.
-    call_graph = {}
-    queue = deque([entry_func])
-    while queue:
-        fqn = queue.popleft()
-        if fqn in call_graph:
-            continue
-        callees = callees_map.get(fqn, set())
-        call_graph[fqn] = sorted(callees)
-        for callee in callees:
-            if callee not in call_graph:
-                queue.append(callee)
-
-    return call_graph
 
 
 def _restrict_to_chains(call_graph, entry_func, end_funcs):
@@ -144,7 +29,7 @@ def _restrict_to_chains(call_graph, entry_func, end_funcs):
 
     Args:
         call_graph: dict mapping FQN -> sorted list of callee FQNs, rooted at
-            entry_func (as returned by build_entry_call_graph).
+            entry_func (as built in _select_functions_by_source).
         entry_func: FQN of the entry point.
         end_funcs: list of FQNs at which to stop. If falsy, call_graph is
             returned unchanged.
@@ -182,14 +67,6 @@ def _restrict_to_chains(call_graph, entry_func, end_funcs):
         else:
             pruned[fqn] = [c for c in call_graph[fqn] if c in on_chain]
     return pruned
-
-
-def _fqn_to_filepath_map(proj_dir):
-    """Build a map from FQN to its extracted function filepath (inverse of _file_to_fqn)."""
-    mapping = {}
-    for filepath, _module_name in _collect_all_function_files(proj_dir):
-        mapping[_file_to_fqn(filepath, proj_dir)] = filepath
-    return mapping
 
 
 # ---------------------------------------------------------------------------
@@ -236,66 +113,24 @@ def _entry_func_source_rel(entry_func):
     return _extracted_file_to_source_rel(extracted_rel).replace(os.sep, "/")
 
 
-def _group_funcs_by_source(extracted_filepaths, extracted_base):
-    """Group extracted function files by their source file.
-
-    Returns a dict mapping source-relative path -> set of (deduped) function
-    names, where the function name is the extracted file's stem (matching the
-    dedup naming run_extraction uses).
-    """
-    by_source = defaultdict(set)
-    for fpath in extracted_filepaths:
-        rel = os.path.relpath(fpath, extracted_base)
-        func_name = os.path.splitext(os.path.basename(rel))[0]
-        by_source[_extracted_file_to_source_rel(rel)].add(func_name)
-    return by_source
-
-
-def _function_spans(filepath, lang_key):
-    """Return ``(spans, raw_lines)`` for a source file.
-
-    ``spans`` is a list of ``(deduped_name, start_idx, end_idx)`` line ranges,
-    one per function, named exactly as run_extraction names the extracted files
-    (duplicate names get ``_1``, ``_2``, ... suffixes). ``raw_lines`` are the
-    file's original lines (newline characters preserved) so callers can rewrite
-    the file by line index.
-    """
-    lang_cfg = LANG_CONFIG[lang_key]
-    with open(filepath, "r", errors="replace") as f:
-        raw_lines = f.readlines()
-    # Extraction operates on newline-stripped lines; indices line up 1:1 with
-    # raw_lines (readlines yields one entry per line).
-    norm_lines = [l.rstrip("\n").rstrip("\r") for l in raw_lines]
-
-    if lang_cfg["body"] == "brace":
-        raw_funcs = _extract_functions_brace(norm_lines, lang_key, lang_cfg)
-    else:
-        raw_funcs = _extract_functions_indent(norm_lines, lang_cfg)
-
-    name_counts = {}
-    spans = []
-    for name, start, end in raw_funcs:
-        count = name_counts.get(name, 0)
-        name_counts[name] = count + 1
-        deduped = name if count == 0 else f"{name}_{count}"
-        spans.append((deduped, start, end))
-    return spans, raw_lines
-
-
-def _trim_source_file(filepath, keep_names):
+def _trim_source_file(filepath, keep_names, proj_dir=None):
     """Delete every function NOT in ``keep_names`` from a source file in place.
 
     Non-function lines (includes, declarations, globals, etc.) are preserved as
     context; only the line ranges of unselected functions are removed. Returns
     ``(kept, removed)`` counts. Files whose language is unsupported, or that
     contain no detected functions, are left untouched.
+
+    ``proj_dir`` is forwarded to _function_spans so codegraph can locate the
+    project's index; when None, function detection falls back to the regex
+    extractor.
     """
     ext = os.path.basename(filepath).rsplit(".", 1)[-1] if "." in os.path.basename(filepath) else ""
     lang_key = EXT_TO_LANG.get(ext)
     if not lang_key:
         return 0, 0
 
-    spans, raw_lines = _function_spans(filepath, lang_key)
+    spans, raw_lines = _function_spans(filepath, lang_key, proj_dir)
     if not spans:
         return 0, 0
 
@@ -334,7 +169,7 @@ def _trim_project_in_place(proj_dir, all_by_source, keep_by_source):
             os.remove(src_path)
             deleted_files += 1
             continue
-        kept, removed = _trim_source_file(src_path, keep_names)
+        kept, removed = _trim_source_file(src_path, keep_names, proj_dir)
         total_kept += kept
         total_removed += removed
 
@@ -430,45 +265,136 @@ def run_entry_pipeline(proj_dir, entry_func=None, end_funcs=None, resume=False):
         clear_test_file_exemptions()
 
 
+def _enumerate_source_files(proj_dir):
+    """List every supported, non-test source file under proj_dir (relative paths).
+
+    Skips the fm_agent/ and .git/ directories and applies the same language and
+    test-file filters run_extraction uses, so the returned files are exactly the
+    ones that will yield extracted functions. The entry_func's source file is
+    still included when it looks like a test, because run_entry_pipeline
+    registers it as a test-file exemption before selection runs.
+    """
+    source_files = []
+    for root, dirs, files in os.walk(proj_dir):
+        dirs[:] = [d for d in dirs if d not in ("fm_agent", ".git")]
+        for fname in files:
+            src_rel = os.path.relpath(os.path.join(root, fname), proj_dir).replace(os.sep, "/")
+            ext = fname.rsplit(".", 1)[-1] if "." in fname else ""
+            if EXT_TO_LANG.get(ext) and not _is_test_file(src_rel):
+                source_files.append(src_rel)
+    return sorted(source_files)
+
+
+def _select_functions_by_source(proj_dir, entry_func, end_funcs):
+    """Select the functions reachable from entry_func, grouped by source file.
+
+    Extracts a throwaway copy of proj_dir with the very machinery the main
+    pipeline uses — ``run_extraction`` plus ``_build_call_graph`` from
+    generate_topdown_layers, both codegraph-backed whenever a codegraph index
+    can be built — then builds the call graph rooted at ``entry_func``
+    (optionally restricted to chains reaching ``end_funcs``) and returns two
+    source-file-keyed groupings:
+
+        (all_by_source, keep_by_source)
+
+    ``all_by_source`` covers every extractable function; ``keep_by_source``
+    covers only the selected ones. proj_dir is read but never modified:
+    extraction, the codegraph index and all scratch state live under a sibling
+    selection copy that is discarded before returning.
+    """
+    # A full source copy lets codegraph index the project (writing .codegraph/)
+    # and lets run_extraction/_build_call_graph run exactly as they do in
+    # run_pipeline — without ever touching proj_dir. _build_call_graph resolves
+    # the codegraph index via the copy's parent (see CodeGraphExtractor
+    # .from_proj_dir), matching how run_pipeline drives it against work_dir.
+    sel_dir = proj_dir + ".fm-entry-select"
+    work_dir = os.path.join(sel_dir, "fm_agent")
+    _make_run_copy(proj_dir, sel_dir)
+    try:
+        source_files = _enumerate_source_files(sel_dir)
+        if not source_files:
+            raise ValueError(f"no extractable source files found under {proj_dir!r}")
+
+        # One all-encompassing phase, so _build_call_graph's within-phase edges
+        # span the entire project (every reachable callee is retained).
+        phase = {"phase": 0, "name": "all",
+                 "modules": [{"name": "all", "source_files": source_files}]}
+        # _make_run_copy brings along any existing fm_agent/; start the selection
+        # extraction from a clean slate so no stale extracted_functions leak in.
+        shutil.rmtree(work_dir, ignore_errors=True)
+        os.makedirs(work_dir, exist_ok=True)
+        with open(os.path.join(work_dir, "phases.json"), "w") as f:
+            json.dump({"phases": [phase]}, f)
+
+        try_codegraph_init(sel_dir)
+        run_extraction(sel_dir, work_dir=work_dir, force=True)
+
+        phase_files = _collect_phase_files(work_dir, phase)
+        if not phase_files:
+            raise ValueError(f"no extractable functions found under {proj_dir!r}")
+        callees_map, _callers, _all_callees, _file_map, _module_map = _build_call_graph(
+            phase_files, work_dir
+        )
+        all_fqns = {_file_to_fqn(fp, work_dir) for fp, _mod in phase_files}
+
+        if entry_func not in all_fqns:
+            raise ValueError(
+                f"entry_func {entry_func!r} not found among extracted functions under proj_dir"
+            )
+
+        # BFS the call graph reachable from the entry point.
+        call_graph = {}
+        queue = deque([entry_func])
+        while queue:
+            fqn = queue.popleft()
+            if fqn in call_graph:
+                continue
+            callees = callees_map.get(fqn, set())
+            call_graph[fqn] = sorted(callees)
+            for callee in callees:
+                if callee not in call_graph:
+                    queue.append(callee)
+
+        # Every extractable function, grouped by source file.
+        all_by_source = defaultdict(set)
+        for fqn in all_fqns:
+            all_by_source[_entry_func_source_rel(fqn)].add(fqn.split("::")[-1])
+    finally:
+        shutil.rmtree(sel_dir, ignore_errors=True)
+
+    # Keep only functions on a call chain from entry_func to one of end_funcs.
+    if end_funcs:
+        unreachable = sorted(set(end_funcs) - set(call_graph))
+        call_graph = _restrict_to_chains(call_graph, entry_func, end_funcs)
+        if unreachable:
+            logging.warning(
+                "[EntryPipeline] %d end function(s) are not reachable from %s: %s",
+                len(unreachable), entry_func, ", ".join(unreachable[:5]),
+            )
+        if not call_graph:
+            raise ValueError(
+                f"none of the requested end_funcs are reachable from entry_func {entry_func!r}"
+            )
+
+    print(
+        f"[EntryPipeline] Selected {len(call_graph)} of {len(all_fqns)} function(s) "
+        f"from entry {entry_func}."
+    )
+
+    # Map the selected FQNs back to their (source file, function name).
+    keep_by_source = defaultdict(set)
+    for fqn in call_graph:
+        keep_by_source[_entry_func_source_rel(fqn)].add(fqn.split("::")[-1])
+
+    return all_by_source, keep_by_source
+
+
 def _run_entry_pipeline_inner(proj_dir, work_dir, entry_func, end_funcs, resume):
     """Body of run_entry_pipeline; runs with the entry source file exempted."""
     # 1. Selection: extract fresh into a temp workspace and build the call graph.
-    tmp_root = tempfile.mkdtemp(prefix="fm_entry_selection_")
-    try:
-        n_funcs = _extract_for_selection(proj_dir, tmp_root)
-        if not n_funcs:
-            raise ValueError(f"no extractable functions found under {proj_dir!r}")
-
-        call_graph = build_entry_call_graph(tmp_root, entry_func)
-
-        # Keep only functions on a call chain from entry_func to one of end_funcs.
-        if end_funcs:
-            unreachable = sorted(set(end_funcs) - set(call_graph))
-            call_graph = _restrict_to_chains(call_graph, entry_func, end_funcs)
-            if unreachable:
-                logging.warning(
-                    "[EntryPipeline] %d end function(s) are not reachable from %s: %s",
-                    len(unreachable), entry_func, ", ".join(unreachable[:5]),
-                )
-            if not call_graph:
-                raise ValueError(
-                    f"none of the requested end_funcs are reachable from entry_func {entry_func!r}"
-                )
-
-        print(
-            f"[EntryPipeline] Selected {len(call_graph)} of {n_funcs} function(s) "
-            f"from entry {entry_func}."
-        )
-
-        extracted_base = os.path.join(tmp_root, "extracted_functions")
-        fqn_to_file = _fqn_to_filepath_map(tmp_root)
-        all_by_source = _group_funcs_by_source(
-            (fp for fp, _ in _collect_all_function_files(tmp_root)), extracted_base
-        )
-        wanted_files = [fqn_to_file[fqn] for fqn in call_graph if fqn in fqn_to_file]
-        keep_by_source = _group_funcs_by_source(wanted_files, extracted_base)
-    finally:
-        shutil.rmtree(tmp_root, ignore_errors=True)
+    all_by_source, keep_by_source = _select_functions_by_source(
+        proj_dir, entry_func, end_funcs
+    )
 
     # 2. Copy the sources into a separate run directory, then trim that copy.
     # proj_dir is left untouched throughout.

--- a/src/extract.py
+++ b/src/extract.py
@@ -6,7 +6,7 @@ import shutil
 import logging
 
 from src.file_utils import is_file_ready, _is_test_file
-from src.languages.registry import batch_extract_all
+from src.languages.registry import batch_extract_all, function_spans_for_file
 
 LANG_CONFIG = {
     "cpp": {
@@ -589,6 +589,47 @@ def extract_functions_from_file(filepath, lang_key):
         results.append((deduped, source))
 
     return results
+
+
+def _function_spans(filepath, lang_key, proj_dir=None):
+    """Return ``(spans, raw_lines)`` for a source file.
+
+    ``spans`` is a list of ``(deduped_name, start_idx, end_idx)`` line ranges,
+    one per function, named exactly as run_extraction names the extracted files
+    (duplicate names get ``_1``, ``_2``, ... suffixes). ``raw_lines`` are the
+    file's original lines (newline characters preserved) so callers can rewrite
+    the file by line index.
+
+    Function boundaries come from codegraph via the language registry when
+    ``proj_dir`` is given and codegraph indexes the file; otherwise they fall
+    back to the regex extractor (_extract_functions_brace / _indent). Both
+    backends yield the same (name, start_idx, end_idx) shape, so the dedup
+    naming below is identical regardless of which one is used.
+    """
+    lang_cfg = LANG_CONFIG[lang_key]
+    with open(filepath, "r", errors="replace") as f:
+        raw_lines = f.readlines()
+    # Extraction operates on newline-stripped lines; indices line up 1:1 with
+    # raw_lines (readlines yields one entry per line).
+    norm_lines = [l.rstrip("\n").rstrip("\r") for l in raw_lines]
+
+    raw_funcs = None
+    if proj_dir is not None:
+        raw_funcs = function_spans_for_file(proj_dir, filepath, lang_key)
+    if raw_funcs is None:
+        if lang_cfg["body"] == "brace":
+            raw_funcs = _extract_functions_brace(norm_lines, lang_key, lang_cfg)
+        else:
+            raw_funcs = _extract_functions_indent(norm_lines, lang_cfg)
+
+    name_counts = {}
+    spans = []
+    for name, start, end in raw_funcs:
+        count = name_counts.get(name, 0)
+        name_counts[name] = count + 1
+        deduped = name if count == 0 else f"{name}_{count}"
+        spans.append((deduped, start, end))
+    return spans, raw_lines
 
 
 def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):

--- a/src/languages/c.py
+++ b/src/languages/c.py
@@ -11,3 +11,14 @@ def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for C."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     return cg.get_call_edges("c") if cg else {}
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return [(name, start_idx, end_idx)] for one C file, or None.
+
+    Line indices are 0-indexed and inclusive. None means codegraph is
+    unavailable or does not index the file, so the caller falls back to the
+    regex extractor.
+    """
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_function_spans("c", filepath) if cg else None

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -125,6 +125,50 @@ class CodeGraphExtractor:
 
         return result
 
+    def get_function_spans(self, lang_key: str, abs_filepath: str):
+        """Return ``[(name, start_idx, end_idx), ...]`` for a single file, or None.
+
+        Line indices are 0-indexed and inclusive, matching the convention the
+        regex extractor (_extract_functions_brace / _extract_functions_indent)
+        uses, so callers can rewrite the file by line index. Functions are
+        ordered by their starting line.
+
+        Returns None when codegraph does not support ``lang_key`` or when the
+        file is not present in the index (e.g. it was never indexed) — the
+        caller then falls back to the regex extractor. An indexed file that
+        genuinely contains no functions also yields None, which is harmless:
+        the regex fallback finds none either.
+        """
+        cg_langs = _CG_LANG.get(lang_key)
+        if not cg_langs:
+            return None
+
+        # codegraph stores file paths relative to the project root, which is the
+        # parent of the .codegraph/ directory holding the database.
+        root = os.path.dirname(os.path.dirname(os.path.abspath(self._db)))
+        rel = os.path.relpath(os.path.abspath(abs_filepath), root)
+
+        conn = sqlite3.connect(self._db)
+        cur = conn.cursor()
+        placeholders = ",".join("?" * len(cg_langs))
+        cur.execute(
+            f"""
+            SELECT name, start_line, end_line
+            FROM nodes
+            WHERE kind IN ('function', 'method') AND language IN ({placeholders})
+              AND file_path = ?
+            ORDER BY start_line
+            """,
+            (*cg_langs, rel),
+        )
+        rows = cur.fetchall()
+        conn.close()
+
+        if not rows:
+            return None
+        # codegraph uses 1-indexed lines with an inclusive end_line.
+        return [(name, int(start) - 1, int(end) - 1) for name, start, end in rows]
+
     def get_call_edges(self, lang_key: str) -> dict:
         """Return {(caller_stem, caller_basename): {callee_stem, ...}} for the given language.
 

--- a/src/languages/cpp.py
+++ b/src/languages/cpp.py
@@ -11,3 +11,14 @@ def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for C++."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     return cg.get_call_edges("cpp") if cg else {}
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return [(name, start_idx, end_idx)] for one C++ file, or None.
+
+    Line indices are 0-indexed and inclusive. None means codegraph is
+    unavailable or does not index the file, so the caller falls back to the
+    regex extractor.
+    """
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_function_spans("cpp", filepath) if cg else None

--- a/src/languages/go.py
+++ b/src/languages/go.py
@@ -11,3 +11,14 @@ def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for Go."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     return cg.get_call_edges("go") if cg else {}
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return [(name, start_idx, end_idx)] for one Go file, or None.
+
+    Line indices are 0-indexed and inclusive. None means codegraph is
+    unavailable or does not index the file, so the caller falls back to the
+    regex extractor.
+    """
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_function_spans("go", filepath) if cg else None

--- a/src/languages/java.py
+++ b/src/languages/java.py
@@ -11,3 +11,14 @@ def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for Java."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     return cg.get_call_edges("java") if cg else {}
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return [(name, start_idx, end_idx)] for one Java file, or None.
+
+    Line indices are 0-indexed and inclusive. None means codegraph is
+    unavailable or does not index the file, so the caller falls back to the
+    regex extractor.
+    """
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_function_spans("java", filepath) if cg else None

--- a/src/languages/javascript.py
+++ b/src/languages/javascript.py
@@ -11,3 +11,14 @@ def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for JavaScript."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     return cg.get_call_edges("javascript") if cg else {}
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return [(name, start_idx, end_idx)] for one JavaScript file, or None.
+
+    Line indices are 0-indexed and inclusive. None means codegraph is
+    unavailable or does not index the file, so the caller falls back to the
+    regex extractor.
+    """
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_function_spans("javascript", filepath) if cg else None

--- a/src/languages/python.py
+++ b/src/languages/python.py
@@ -11,3 +11,14 @@ def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for Python."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     return cg.get_call_edges("python") if cg else {}
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return [(name, start_idx, end_idx)] for one Python file, or None.
+
+    Line indices are 0-indexed and inclusive. None means codegraph is
+    unavailable or does not index the file, so the caller falls back to the
+    regex extractor.
+    """
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_function_spans("python", filepath) if cg else None

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -15,30 +15,35 @@ from src.languages import typescript as _typescript
 class LanguageHandler:
     """Extraction and call-graph backend for one language.
 
-    batch_extract(proj_dir) -> {abs_filepath: [(func_name, body)]}
-    call_edges(proj_dir)    -> {(caller_stem, caller_module): {callee_stems}}
+    batch_extract(proj_dir)             -> {abs_filepath: [(func_name, body)]}
+    call_edges(proj_dir)                -> {(caller_stem, caller_module): {callee_stems}}
+    function_spans(proj_dir, filepath)  -> [(func_name, start_idx, end_idx)] | None
 
-    Each function handles its own backend (e.g. codegraph) internally and
-    returns an empty dict when the backend is unavailable.
+    Each function handles its own backend (e.g. codegraph) internally.
+    batch_extract / call_edges return an empty dict when the backend is
+    unavailable; function_spans returns None so the caller can fall back to the
+    regex extractor for that file.
 
     To add a new language:
-      1. Create src/languages/<lang>.py implementing batch_extract and call_edges
+      1. Create src/languages/<lang>.py implementing batch_extract, call_edges,
+         and function_spans
       2. Import it here and add one entry to REGISTRY
     No other files need to change.
     """
     batch_extract: Callable
     call_edges: Callable
+    function_spans: Callable
 
 
 REGISTRY: dict = {
-    "python":     LanguageHandler(batch_extract=_python.batch_extract,     call_edges=_python.call_edges),
-    "go":         LanguageHandler(batch_extract=_go.batch_extract,         call_edges=_go.call_edges),
-    "c":          LanguageHandler(batch_extract=_c.batch_extract,          call_edges=_c.call_edges),
-    "cpp":        LanguageHandler(batch_extract=_cpp.batch_extract,        call_edges=_cpp.call_edges),
-    "java":       LanguageHandler(batch_extract=_java.batch_extract,       call_edges=_java.call_edges),
-    "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges),
-    "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges),
-    "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges),
+    "python":     LanguageHandler(batch_extract=_python.batch_extract,     call_edges=_python.call_edges,     function_spans=_python.function_spans),
+    "go":         LanguageHandler(batch_extract=_go.batch_extract,         call_edges=_go.call_edges,         function_spans=_go.function_spans),
+    "c":          LanguageHandler(batch_extract=_c.batch_extract,          call_edges=_c.call_edges,          function_spans=_c.function_spans),
+    "cpp":        LanguageHandler(batch_extract=_cpp.batch_extract,        call_edges=_cpp.call_edges,        function_spans=_cpp.function_spans),
+    "java":       LanguageHandler(batch_extract=_java.batch_extract,       call_edges=_java.call_edges,       function_spans=_java.function_spans),
+    "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges,       function_spans=_rust.function_spans),
+    "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges, function_spans=_javascript.function_spans),
+    "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges, function_spans=_typescript.function_spans),
 }
 
 
@@ -56,6 +61,21 @@ def batch_extract_all(proj_dir: str) -> tuple:
             funcs.update(result)
             langs.add(lang)
     return funcs, langs
+
+
+def function_spans_for_file(proj_dir: str, filepath: str, lang_key: str):
+    """Return codegraph function spans for one file, or None to fall back.
+
+    Delegates to the registered language handler's function_spans backend.
+    Returns [(func_name, start_idx, end_idx)] (0-indexed, inclusive) when
+    codegraph indexes the file, or None when the language is unregistered,
+    codegraph does not support it, or the file is not in the index — in every
+    such case the caller should fall back to the regex extractor.
+    """
+    handler = REGISTRY.get(lang_key)
+    if handler is None:
+        return None
+    return handler.function_spans(proj_dir, filepath)
 
 
 def call_edges_all(proj_dir: str, lang_keys) -> tuple:

--- a/src/languages/rust.py
+++ b/src/languages/rust.py
@@ -11,3 +11,14 @@ def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for Rust."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     return cg.get_call_edges("rust") if cg else {}
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return [(name, start_idx, end_idx)] for one Rust file, or None.
+
+    Line indices are 0-indexed and inclusive. None means codegraph is
+    unavailable or does not index the file, so the caller falls back to the
+    regex extractor.
+    """
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_function_spans("rust", filepath) if cg else None

--- a/src/languages/typescript.py
+++ b/src/languages/typescript.py
@@ -11,3 +11,14 @@ def call_edges(proj_dir: str) -> dict:
     """Return {(caller_stem, caller_module): {callee_stems}} for TypeScript."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)
     return cg.get_call_edges("typescript") if cg else {}
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return [(name, start_idx, end_idx)] for one TypeScript file, or None.
+
+    Line indices are 0-indexed and inclusive. None means codegraph is
+    unavailable or does not index the file, so the caller falls back to the
+    regex extractor.
+    """
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_function_spans("typescript", filepath) if cg else None


### PR DESCRIPTION
## Summary

The entry-function pipeline (`run_entry_pipeline`) selected reachable functions and
trimmed source files using a **separate, hand-rolled extraction path** that only ever
used the regex extractor. This diverged from the main pipeline (`run_pipeline`), which
extracts and builds its call graph through `run_extraction` + `_build_call_graph` —
both codegraph-backed whenever a codegraph index is available. The result was
inconsistent function boundaries: the entry pipeline could split, miss, or mis-span
functions that the rest of the system resolved correctly.

This PR unifies the two paths. Entry selection now drives the **exact same machinery**
as the main pipeline, and source-file trimming now derives function line spans from
codegraph (with a regex fallback) instead of the regex extractor alone.

## What changed

### 1. Codegraph-backed function spans (`get_function_spans`)

- Added `CodeGraphExtractor.get_function_spans(lang_key, abs_filepath)` in
  [src/languages/codegraph.py](src/languages/codegraph.py), which queries the
  codegraph `nodes` table for `function`/`method` rows in a single file and returns
  `[(name, start_idx, end_idx)]` as **0-indexed, inclusive** line ranges (matching the
  regex extractor's convention). Returns `None` when the language is unsupported or the
  file isn't indexed, so callers fall back cleanly.

### 2. New `function_spans` handler across every language

- Each language module (`c`, `cpp`, `go`, `java`, `javascript`, `python`, `rust`,
  `typescript`) gains a `function_spans(proj_dir, filepath)` function delegating to the
  codegraph extractor.
- The `LanguageHandler` dataclass in [src/languages/registry.py](src/languages/registry.py)
  gains a `function_spans` field, and a new `function_spans_for_file(proj_dir, filepath,
  lang_key)` dispatcher returns spans or `None` for fallback.

### 3. `_function_spans` moved into `extract.py` with codegraph support

- Moved `_function_spans` out of the entry pipeline and into
  [src/extract.py](src/extract.py), adding a `proj_dir` argument. When `proj_dir` is
  given and codegraph indexes the file, boundaries come from codegraph; otherwise it
  falls back to `_extract_functions_brace` / `_extract_functions_indent`. Dedup naming
  (`_1`, `_2`, …) is identical regardless of backend.

### 4. Entry pipeline rewritten to reuse the main pipeline's extraction

- [src/entry_reasoning_pipeline.py](src/entry_reasoning_pipeline.py) drops the bespoke
  selection helpers — `_collect_all_function_files`, `_extract_for_selection`,
  `build_entry_call_graph`, `_fqn_to_filepath_map`, `_group_funcs_by_source`, and its
  local copy of `_function_spans`.
- A new `_select_functions_by_source(proj_dir, entry_func, end_funcs)` makes a throwaway
  copy of the project, runs `try_codegraph_init` + `run_extraction` + `_build_call_graph`
  (the same code path as `run_pipeline`), builds the reachable call graph from
  `entry_func`, optionally restricts to chains reaching `end_funcs`, and returns
  `(all_by_source, keep_by_source)`. `proj_dir` is never modified — all scratch state
  lives under a sibling `.fm-entry-select` copy that is discarded.
- `_trim_source_file` / `_trim_project_in_place` now thread `proj_dir` through to
  `_function_spans`, so trimming uses codegraph spans too.

## Why

- **Consistency:** entry selection and trimming now agree with the main pipeline on
  where each function begins and ends.
- **Accuracy:** codegraph resolves function boundaries far more reliably than regex,
  fixing mis-spanned entry functions.
- **Less code to maintain:** removes a parallel extraction/call-graph implementation in
  favor of the shared one.

## Compatibility / fallback

Every new codegraph path returns `None` (or an empty result) when a codegraph index is
unavailable, so projects without codegraph transparently fall back to the existing regex
extractor. No public API changes; `proj_dir` on `_function_spans` / `_trim_source_file`
is optional and defaults to the old regex behavior.