### PR TITLE
Feat: use codegraph in incremental reasoning

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,10 +97,12 @@ def run_pipeline(proj_dir, resume=False, required_source_files=None):
         required_source_files=required_source_files,
     )
 
-    # Build codegraph index if codegraph is installed and index not yet present.
-    # Both run_extraction (Stage 2) and generate_topdown_layers (Stage 3) will
-    # automatically use the index when it exists.
-    try_codegraph_init(proj_dir)
+    # Build (or rebuild) the codegraph index if codegraph is installed. Both
+    # run_extraction (Stage 2) and generate_topdown_layers (Stage 3) read from it.
+    # force=not resume mirrors run_extraction below: a fresh run rebuilds so the
+    # index matches the current tree, while a resume reuses the existing index
+    # (same tree as the interrupted run — rebuilding would just be wasted work).
+    try_codegraph_init(proj_dir, force=not resume)
 
     # Run function extraction using extract.py
     # force=False on resume preserves already-specced extracted files; on a fresh

--- a/src/entry_reasoning_pipeline.py
+++ b/src/entry_reasoning_pipeline.py
@@ -409,10 +409,10 @@ def _run_entry_pipeline_inner(proj_dir, work_dir, entry_func, end_funcs, resume)
         # codegraph backend that _select_functions_by_source used to produce
         # keep_by_source. Without it the trim would fall back to the regex
         # extractor and could disagree with the selection (mismatched names or
-        # spans -> wrong functions kept/removed). Idempotent and non-fatal:
-        # no-ops if an index already exists, skips silently if codegraph is not
-        # installed (selection then also used regex, so the two stay consistent).
-        # The index also gets reused by run_pipeline's own try_codegraph_init.
+        # spans -> wrong functions kept/removed). Non-fatal: skips silently if
+        # codegraph is not installed (selection then also used regex, so the two
+        # stay consistent). run_pipeline rebuilds the index again after the trim
+        # edits these sources, so extraction sees the trimmed tree, not this one.
         try_codegraph_init(run_dir)
         _trim_project_in_place(run_dir, all_by_source, keep_by_source)
 

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -43,6 +43,7 @@ from .llm_client import _llm_provider_client, _llm_call
 from .cli_backend import build_agent_command, is_cli_backend_enabled
 from .prompts import _load_spec_check_json
 from .scope import _parse_issue_signals, rank_functions_in_file
+from .languages.codegraph import try_codegraph_init
 from .verification import _verify_single_file, _validate_single_bug, _generate_validation_summary, EXT_TO_LANG as _VERIFY_EXT_TO_LANG
 
 
@@ -649,6 +650,12 @@ def run_incremental_pipeline(proj_dir, intent_file_path, old_commit_id):
     logging.info("[Stage 4/10] Re-extracting functions and restoring previous specs...")
     old_spec = extract_existing_specs(proj_dir)
     logging.info("  -> captured %d existing spec block(s) before re-extraction.", len(old_spec))
+    # Rebuild the codegraph index before re-extraction. The index still reflects the code as
+    # of the previous full run, but the working tree has changed since then; run_extraction
+    # (and the downstream scope ranking) read function bodies and spans from codegraph, so a
+    # stale index would yield boundaries for the old code. try_codegraph_init rebuilds by
+    # default; no-op when codegraph is uninstalled (extraction then falls back to regex).
+    try_codegraph_init(proj_dir)
     run_extraction(proj_dir, work_dir=work_dir, force=True, verbose=True)
     _reapply_existing_specs(proj_dir, old_spec)
     logging.info("  -> functions re-extracted and prior [SPEC]/[INFO] headers reapplied.")
@@ -1060,6 +1067,7 @@ def collect_relevent_function_scope(proj_dir, developer_intent, changed_function
                     src_path=src_path,
                     issue=developer_intent,
                     signals=signals,
+                    proj_dir=proj_dir,
                 )
 
             if ranked:

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -10,6 +10,7 @@ REGISTRY in src/languages/registry.py. No other files need to change.
 
 import logging
 import os
+import shutil
 import sqlite3
 import subprocess
 from collections import defaultdict
@@ -237,16 +238,36 @@ class CodeGraphExtractor:
         return dict(result)
 
 
-def try_codegraph_init(proj_dir: str) -> None:
-    """Run `codegraph init` in proj_dir if the index does not yet exist.
+def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
+    """Build the codegraph index for proj_dir with `codegraph init`.
+
+    By default (``force=True``) any existing index is discarded and rebuilt, so
+    the index always reflects the current working tree rather than whatever code
+    was present when it was last built. This is the safe default: callers read
+    function bodies and spans from the index, and a stale one (e.g. after an
+    incremental run's tree changed, or after `_trim_project_in_place` edited the
+    sources) would yield boundaries for the wrong code. `codegraph init` on its
+    own no-ops when `.codegraph/` already exists, so a rebuild requires clearing
+    it first.
+
+    Pass ``force=False`` to keep an existing index and only build when it is
+    absent — an opt-in optimization for callers that know the tree is unchanged
+    since the index was built.
 
     Silently skips when codegraph is not installed so the pipeline falls back
     to the regex-based extractor without any error.
     """
-    db_path = os.path.join(proj_dir, ".codegraph", "codegraph.db")
+    codegraph_dir = os.path.join(proj_dir, ".codegraph")
+    db_path = os.path.join(codegraph_dir, "codegraph.db")
     if os.path.exists(db_path):
-        return
-    print("[Pipeline] Building codegraph index (this runs once per project)...")
+        if not force:
+            return
+        # Existing index may reflect stale sources; remove it so `codegraph init`
+        # rebuilds against the current tree instead of skipping.
+        shutil.rmtree(codegraph_dir, ignore_errors=True)
+        print("[Pipeline] Rebuilding codegraph index for current working tree...")
+    else:
+        print("[Pipeline] Building codegraph index...")
     try:
         result = subprocess.run(
             ["codegraph", "init"], cwd=proj_dir, capture_output=True, text=True

--- a/src/scope.py
+++ b/src/scope.py
@@ -64,8 +64,7 @@ from config import (
 from .extract import (
     EXT_TO_LANG,
     LANG_CONFIG,
-    _extract_functions_brace,
-    _extract_functions_indent,
+    _function_spans,
 )
 
 logger = logging.getLogger(__name__)
@@ -625,44 +624,49 @@ def _generic_func_info(name: str, start0: int, end0: int,
     }
 
 
-def _parse_generic_file(src_path: Path, lang_key: str) -> tuple[list[dict], list[str], list[dict]] | tuple[None, None, None]:
+def _parse_generic_file(src_path: Path, lang_key: str,
+                        proj_dir: str | None = None) -> tuple[list[dict], list[str], list[dict]] | tuple[None, None, None]:
     """
-    Parse a non-Python source with the same brace/indent function extractor used by
-    extract.py, recovering per-function signals by regex. Returns no classes (class-scope
-    narrowing is Python-only).
+    Parse a non-Python source into per-function signals, recovering per-function signals
+    by regex. Returns no classes (class-scope narrowing is Python-only).
+
+    Function boundaries are located by extract._function_spans, which draws them from
+    codegraph when proj_dir indexes the file (the same source of truth run_extraction uses
+    to name the extracted-function files) and falls back to extract.py's regex brace/indent
+    extractor otherwise. The names it returns are already deduped (foo, foo_1, ...) exactly
+    as run_extraction names those files, so a ranked function's 'name' maps straight onto its
+    extracted-function file.
     """
     try:
-        content = src_path.read_text(errors='replace')
+        spans, raw_lines = _function_spans(str(src_path), lang_key, proj_dir=proj_dir)
     except Exception as exc:
         logger.warning("Could not read %s: %s", src_path, exc)
         return None, None, None
 
-    # splitlines() normalizes line endings the same way extract.run_extraction does before
-    # feeding the extractors, so the returned 0-based line indices line up with source_lines.
-    source_lines = content.splitlines()
+    # _function_spans keeps newline characters on raw_lines; strip them the same way
+    # extract.py normalizes before extraction so the 0-based span indices line up with
+    # source_lines (source_lines[start0] is the signature line).
+    source_lines = [l.rstrip('\n').rstrip('\r') for l in raw_lines]
     lang_cfg = LANG_CONFIG[lang_key]
-
-    if lang_cfg['body'] == 'brace':
-        raw_funcs = _extract_functions_brace(source_lines, lang_key, lang_cfg)
-    else:
-        raw_funcs = _extract_functions_indent(source_lines, lang_cfg)
 
     funcs = [
         _generic_func_info(name, start0, end0, source_lines, lang_cfg)
-        for name, start0, end0 in raw_funcs
+        for name, start0, end0 in spans
     ]
     return funcs, source_lines, []
 
 
-def _parse_file(src_path: Path) -> tuple[list[dict], list[str], list[dict]] | tuple[None, None, None]:
+def _parse_file(src_path: Path,
+                proj_dir: str | None = None) -> tuple[list[dict], list[str], list[dict]] | tuple[None, None, None]:
     """
     Parse a source file into (funcs_info, source_lines, classes).
 
     Dispatches on the file extension via extract.EXT_TO_LANG: Python files go through the
     ast-based path (with a fall back to the generic extractor if the AST parse fails, e.g.
-    on Python 2 syntax), and every other language registered in EXT_TO_LANG goes through the
-    brace/indent extractor shared with extract.py. Returns (None, None, None) for unsupported
-    extensions or unreadable files.
+    on Python 2 syntax), and every other language registered in EXT_TO_LANG goes through
+    extract._function_spans (codegraph-backed when proj_dir indexes the file, regex otherwise).
+    proj_dir is forwarded so the generic path can use codegraph; Returns (None, None, None)
+    for unsupported extensions or unreadable files.
     """
     ext = src_path.suffix.lstrip('.').lower()
     lang_key = EXT_TO_LANG.get(ext)
@@ -676,7 +680,7 @@ def _parse_file(src_path: Path) -> tuple[list[dict], list[str], list[dict]] | tu
             return funcs, source_lines, classes
         # AST parse failed — fall back to the generic line-based extractor.
 
-    return _parse_generic_file(src_path, lang_key)
+    return _parse_generic_file(src_path, lang_key, proj_dir=proj_dir)
 
 
 # ── main entry point ─────────────────────────────────────────────────────────
@@ -692,14 +696,18 @@ def rank_functions_in_file(
     llm_trigger: int = LLM_TRIGGER_FUNCS,
     llm_top_k: int = LLM_TOP_K,
     llm_confidence_threshold: float = LLM_CONFIDENCE_THRESHOLD,
+    proj_dir: str | None = None,
 ) -> list[dict]:
     """
     Rank functions in a single file by relevance to the issue.
 
+    proj_dir, when given, lets the non-Python parse path resolve function boundaries from
+    codegraph (via extract._function_spans) instead of the regex fallback.
+
     Returns a list of dicts (file, name, lineno, end_lineno, score, reason),
     sorted descending by score, length ≤ top_k.
     """
-    funcs_info, source_lines, classes = _parse_file(src_path)
+    funcs_info, source_lines, classes = _parse_file(src_path, proj_dir=proj_dir)
     if funcs_info is None or not funcs_info:
         print(f"  [scope] {filepath}: no functions found, skipping")
         return []


### PR DESCRIPTION
## Summary

Makes the incremental reasoning pipeline use the codegraph index as its source of
truth for function boundaries, and ensures that index is always rebuilt against the
current working tree before it is read. Previously the index was built once and reused
even after the tree changed, so incremental runs (and the non-Python scope ranking)
could resolve function spans against stale code.

## Motivation

`try_codegraph_init` used to no-op whenever a `.codegraph/` index already existed. That
is fine for a one-shot full run, but it breaks two flows:

- **Incremental runs** — the index reflects the code as of the previous full run, but the
  working tree has since changed. Re-extraction and scope ranking read function bodies and
  spans from codegraph, so a stale index yields boundaries for the old code.
- **Entry trimming** — `_trim_project_in_place` edits sources after the index is built, so
  extraction would see boundaries that no longer match the trimmed tree.

The non-Python scope path also went straight to the regex brace/indent extractor, which
could disagree with the codegraph-based names/spans that `run_extraction` uses to name the
extracted-function files.

## Changes

- **`src/languages/codegraph.py`** — `try_codegraph_init(proj_dir, force=True)` now rebuilds
  the index by default: it removes any existing `.codegraph/` (since `codegraph init` no-ops
  when one is present) so the index always matches the current tree. `force=False` is an
  opt-in optimization for callers that know the tree is unchanged. Still silently skips when
  codegraph is not installed (falls back to the regex extractor).
- **`src/incremental_reasoner.py`** — rebuilds the index before re-extraction in Stage 4, and
  threads `proj_dir` into `rank_functions_in_file` so the scope path can use codegraph.
- **`src/scope.py`** — `_parse_generic_file` / `_parse_file` / `rank_functions_in_file` now
  locate non-Python function boundaries via `extract._function_spans` (codegraph-backed when
  `proj_dir` indexes the file, regex fallback otherwise), keeping ranked names aligned with the
  extracted-function file names.
- **`main.py`** — passes `force=not resume` to `try_codegraph_init`: a fresh run rebuilds so the
  index matches the current tree, a resume reuses the existing index.
- **`src/entry_reasoning_pipeline.py`** — updated the comment around the pre-trim
  `try_codegraph_init` to reflect that `run_pipeline` rebuilds the index after the trim edits
  the sources.
