### PR TITLE
fix: crash on C++ operator/ function name

### DIFF
--- a/src/extract.py
+++ b/src/extract.py
@@ -193,6 +193,15 @@ def _strip_angle_brackets(text):
 def _extract_func_name_brace(signature_text, lang_cfg):
     """Extract the function name from a brace-delimited language signature."""
     lang_keywords = lang_cfg["keywords"]
+
+    m = re.search(
+        r'\b(operator\s*(?:\[\]|\(\)|[+\-*/%&|^~!=<>]+|new(?:\s*\[\s*\])?|delete(?:\s*\[\s*\])?))'
+        r'\s*\(',
+        signature_text,
+    )
+    if m:
+        return m.group(1)
+
     cleaned = _strip_angle_brackets(signature_text)
     for m in re.finditer(r'\b(\w+)\s*\(', cleaned):
         name = m.group(1)

--- a/src/extract.py
+++ b/src/extract.py
@@ -6,6 +6,7 @@ import shutil
 import logging
 
 from src.file_utils import is_file_ready, _is_test_file
+from src.languages.codegraph import canonicalize
 from src.languages.registry import batch_extract_all, function_spans_for_file
 
 LANG_CONFIG = {
@@ -593,16 +594,18 @@ def extract_functions_from_file(filepath, lang_key):
         # registered backend and have no reliable file-local fallback.
         return []
 
-    # Deduplicate names
+    # Deduplicate names (applied after canonicalize so operator overloads
+    # produce safe filenames and FQN components).
     name_counts = {}
     results = []
     for name, start, end in raw_funcs:
-        count = name_counts.get(name, 0)
-        name_counts[name] = count + 1
+        cname = canonicalize(name)
+        count = name_counts.get(cname, 0)
+        name_counts[cname] = count + 1
         if count > 0:
-            deduped = f"{name}_{count}"
+            deduped = f"{cname}_{count}"
         else:
-            deduped = name
+            deduped = cname
         source = '\n'.join(lines[start:end + 1]) + '\n'
         results.append((deduped, source))
 
@@ -643,9 +646,10 @@ def _function_spans(filepath, lang_key, proj_dir=None):
     name_counts = {}
     spans = []
     for name, start, end in raw_funcs:
-        count = name_counts.get(name, 0)
-        name_counts[name] = count + 1
-        deduped = name if count == 0 else f"{name}_{count}"
+        cname = canonicalize(name)
+        count = name_counts.get(cname, 0)
+        name_counts[cname] = count + 1
+        deduped = cname if count == 0 else f"{cname}_{count}"
         spans.append((deduped, start, end))
     return spans, raw_lines
 

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -8,12 +8,36 @@ To add support for a new language: create src/languages/<lang>.py and add an ent
 REGISTRY in src/languages/registry.py. No other files need to change.
 """
 
+import hashlib
 import logging
 import os
 import shutil
 import sqlite3
 import subprocess
 from collections import defaultdict
+
+
+_SAFE_REPLACE = str.maketrans({"/": "_"})
+_UNSAFE = set("/")
+
+
+def canonicalize(func_name):
+    """Return a filesystem-safe, FQN-safe version of a function name.
+
+    C++ operator overloads like ``operator/`` contain ``/`` which breaks both
+    file paths and ``::``-separated FQNs.  This function sanitises those
+    characters so the name is safe everywhere it appears: extracted-function
+    file names, FQNs, call-edge keys, and scope.py rankings.
+
+    Every entry point that introduces a function name into the system MUST call
+    this function before using the name.
+    """
+    if not func_name:
+        return func_name
+    for ch in _UNSAFE:
+        if ch in func_name:
+            return func_name.translate(_SAFE_REPLACE)
+    return func_name
 
 # Maps FM-Agent lang_key → the language string stored in codegraph's SQLite
 # nodes.language column. Only includes languages that codegraph actually supports.
@@ -93,10 +117,11 @@ def _node_fqn_map(cur, cg_langs) -> dict:
     counts: dict = {}
     result: dict = {}
     for node_id, name, file_path, _start in cur.fetchall():
-        key = (file_path, name)
+        cname = canonicalize(name)
+        key = (file_path, cname)
         c = counts.get(key, 0)
         counts[key] = c + 1
-        deduped = name if c == 0 else f"{name}_{c}"
+        deduped = cname if c == 0 else f"{cname}_{c}"
         result[node_id] = _fqn_for(file_path, deduped)
     return result
 
@@ -163,8 +188,8 @@ class CodeGraphExtractor:
             except OSError:
                 continue
 
-            file_funcs = []
             name_counts = {}
+            file_funcs = []
             for name, start_line, end_line in funcs:
                 # Disambiguate functions sharing a name within one file
                 # (LocalStorage::Flush vs RemoteCache::Flush, overloads, a method
@@ -175,9 +200,10 @@ class CodeGraphExtractor:
                 # both extraction and the call graph. Mirror the regex path's
                 # dedup ("Flush", "Flush_1", ...). funcs are line-ordered (SQL
                 # ORDER BY start_line), so suffix assignment is deterministic.
-                count = name_counts.get(name, 0)
-                name_counts[name] = count + 1
-                deduped = name if count == 0 else f"{name}_{count}"
+                cname = canonicalize(name)
+                count = name_counts.get(cname, 0)
+                name_counts[cname] = count + 1
+                deduped = cname if count == 0 else f"{cname}_{count}"
                 # codegraph uses 1-indexed lines, end_line is inclusive
                 body_lines = all_lines[start_line - 1 : end_line]
                 body = "".join(body_lines)
@@ -231,7 +257,7 @@ class CodeGraphExtractor:
         if not rows:
             return None
         # codegraph uses 1-indexed lines with an inclusive end_line.
-        return [(name, int(start) - 1, int(end) - 1) for name, start, end in rows]
+        return [(canonicalize(name), int(start) - 1, int(end) - 1) for name, start, end in rows]
 
     def get_call_edges(self, lang_key: str) -> dict:
         """Return {caller_fqn: {callee_fqn, ...}} for the given language.


### PR DESCRIPTION
Introduce canonicalize() to sanitize filesystem-unsafe characters in function names (e.g. operator/ -> operator_). Applied at all five data entry points in codegraph and extract layers. Downstream modules need zero changes - FQNs and scope lookups automatically pick up the canonicalized names.

Closes #66