### PR TITLE
ci: validate private sync deploy key

### DIFF
--- a/.github/workflows/sync-private.yml
+++ b/.github/workflows/sync-private.yml
@@ -28,9 +28,26 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.PRIVATE_REPO_DEPLOY_KEY }}
         run: |
+          if [ -z "$SSH_PRIVATE_KEY" ]; then
+            echo "::error::PRIVATE_REPO_DEPLOY_KEY is empty or not configured."
+            exit 1
+          fi
+
           mkdir -p ~/.ssh
-          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          key = os.environ["SSH_PRIVATE_KEY"].strip()
+          key = key.replace("\\r\\n", "\n").replace("\\n", "\n")
+          key = key.replace("\r\n", "\n").replace("\r", "\n")
+          Path.home().joinpath(".ssh", "id_ed25519").write_text(key + "\n", encoding="utf-8")
+          PY
           chmod 600 ~/.ssh/id_ed25519
+          if ! ssh-keygen -y -P "" -f ~/.ssh/id_ed25519 > ~/.ssh/id_ed25519.pub; then
+            echo "::error::PRIVATE_REPO_DEPLOY_KEY must be an unencrypted private key, not a public key or passphrase-protected key."
+            exit 1
+          fi
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
       - name: Push to private repository


### PR DESCRIPTION
## Summary

Fixes the private sync workflow SSH setup so malformed deploy key secrets fail early with a clear message instead of reaching `git push` as `Load key ... error in libcrypto`.

## Details

- Fails clearly when `PRIVATE_REPO_DEPLOY_KEY` is empty or missing.
- Normalizes CRLF and literal `\n` key secret formats before writing `~/.ssh/id_ed25519`.
- Validates the key with `ssh-keygen -y -P ""` before adding the private remote and pushing.

## Validation

- Parsed `.github/workflows/sync-private.yml` with Python YAML loader: `YAML OK`.
- Tested the SSH setup script locally with a generated ed25519 key using both multiline and literal `\n`-escaped secret formats.
- Verified the SSH setup script fails early when `PRIVATE_REPO_DEPLOY_KEY` is empty.
- Compared PR branch against `main`: 1 commit ahead, only `.github/workflows/sync-private.yml` modified.