### PR TITLE
Fix function signature used as filename causing OSError (fixes #82)

### DIFF
--- a/src/extract.py
+++ b/src/extract.py
@@ -5,9 +5,8 @@ import sys
 import shutil
 import logging
 
-from src.file_utils import is_file_ready, _is_test_file
-from src.languages.codegraph import canonicalize
-from src.languages.registry import batch_extract_all, function_spans_for_file
+from src.file_utils import is_file_ready
+from src.languages.registry import batch_extract_all
 
 LANG_CONFIG = {
     "cpp": {
@@ -111,19 +110,6 @@ LANG_CONFIG = {
         },
         "body": "brace",
     },
-    "erlang": {
-        "comment_prefix": "%",
-        "spec_marker": "% [SPEC]",
-        "skip_prefixes": ("%", "-module", "-export", "-import", "-include"),
-        "skip_keywords_line": ("-record", "-type", "-spec", "-callback"),
-        "keywords": {
-            "after", "and", "andalso", "band", "begin", "bnot", "bor", "bsl",
-            "bsr", "bxor", "case", "catch", "cond", "div", "end", "fun", "if",
-            "let", "maybe", "not", "of", "or", "orelse", "receive", "rem",
-            "try", "when", "xor",
-        },
-        "body": "external",
-    },
     "cuda": {
         "comment_prefix": "//",
         "spec_marker": "// [SPEC]",
@@ -159,7 +145,6 @@ LANG_CONFIG = {
 EXT_TO_LANG = {
     "cpp": "cpp", "cc": "cpp", "cxx": "cpp", "c": "c", "h": "cpp", "hpp": "cpp",
     "py": "python",
-    "erl": "erlang",
     "go": "go",
     "rs": "rust",
     "java": "java",
@@ -169,9 +154,78 @@ EXT_TO_LANG = {
     "ets": "arkts",
 }
 
+# Directories that typically contain test code
+_TEST_DIR_NAMES = {
+    "test", "tests", "__tests__", "testing", "test_helpers",
+    "testdata", "testutils", "fixtures", "mocks",
+}
+
+# Regex patterns matching common test file naming conventions
+_TEST_FILE_PATTERNS = [
+    re.compile(r'^test_.*\.py$'),         # Python: test_foo.py
+    re.compile(r'^.*_test\.py$'),          # Python: foo_test.py
+    re.compile(r'^conftest\.py$'),         # pytest fixtures
+    re.compile(r'^.*_test\.go$'),          # Go: foo_test.go
+    re.compile(r'^.*_test\.(?:cpp|cc|cxx|c|h|hpp)$'),  # C/C++: foo_test.cpp
+    re.compile(r'^test_.*\.(?:cpp|cc|cxx|c|h|hpp)$'),  # C/C++: test_foo.cpp
+    re.compile(r'^.*Test(?:s|Case)?\.java$'),            # Java: FooTest.java
+    re.compile(r'^.*\.(?:test|spec)\.(?:js|jsx|ts|tsx)$'),  # JS/TS: foo.test.js
+    re.compile(r'^.*_test\.rs$'),          # Rust: foo_test.rs
+    re.compile(r'^.*\.test\.(?:ets)$'),    # ArkTS: foo.test.ets
+]
+
+
+# Project-relative paths that must never be treated as test files, even when
+# their path matches the heuristics below. The entry pipeline registers the
+# source file holding its entry_func here so that file is still extracted and
+# reasoned about even if it lives in a test directory or is named like a test.
+_TEST_FILE_EXEMPTIONS = set()
+
+
+def add_test_file_exemption(rel_path):
+    """Exempt a project-relative source path from the test-file heuristics."""
+    _TEST_FILE_EXEMPTIONS.add(rel_path.replace('\\', '/'))
+
+
+def clear_test_file_exemptions():
+    """Drop all registered test-file exemptions."""
+    _TEST_FILE_EXEMPTIONS.clear()
+
+
+def _is_test_file(rel_path):
+    """Return True if the relative source path looks like a test file."""
+    norm_path = rel_path.replace('\\', '/')
+    if norm_path in _TEST_FILE_EXEMPTIONS:
+        return False
+    parts = norm_path.split('/')
+    # Check if any directory component is a known test directory
+    for part in parts[:-1]:
+        if part.lower() in _TEST_DIR_NAMES:
+            return True
+    # Check filename against test patterns
+    basename = parts[-1]
+    for pat in _TEST_FILE_PATTERNS:
+        if pat.match(basename):
+            return True
+    return False
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _safe_filename(name: str, ext: str) -> str:
+    """Return a safe filename from a function name and extension.
+
+    Replaces "/" (directory separator) with "_" and falls back to
+    "_function" for empty names.  Does *not* strip leading or trailing
+    underscores so that names like __init__ and _private stay consistent
+    with codegraph call-edge keys and FQN resolution.
+    """
+    safe = name.replace('/', '_')
+    if not safe:
+        safe = "_function"
+    return f"{safe}.{ext}"
 
 
 def _strip_angle_brackets(text):
@@ -193,15 +247,6 @@ def _strip_angle_brackets(text):
 def _extract_func_name_brace(signature_text, lang_cfg):
     """Extract the function name from a brace-delimited language signature."""
     lang_keywords = lang_cfg["keywords"]
-
-    m = re.search(
-        r'\b(operator\s*(?:\[\]|\(\)|[+\-*/%&|^~!=<>]+|new(?:\s*\[\s*\])?|delete(?:\s*\[\s*\])?))'
-        r'\s*\(',
-        signature_text,
-    )
-    if m:
-        return m.group(1)
-
     cleaned = _strip_angle_brackets(signature_text)
     for m in re.finditer(r'\b(\w+)\s*\(', cleaned):
         name = m.group(1)
@@ -596,71 +641,23 @@ def extract_functions_from_file(filepath, lang_key):
 
     if lang_cfg["body"] == "brace":
         raw_funcs = _extract_functions_brace(lines, lang_key, lang_cfg)
-    elif lang_cfg["body"] == "indent":
-        raw_funcs = _extract_functions_indent(lines, lang_cfg)
     else:
-        # Semantic-only languages (currently Erlang) are extracted by their
-        # registered backend and have no reliable file-local fallback.
-        return []
+        raw_funcs = _extract_functions_indent(lines, lang_cfg)
 
-    # Deduplicate names (applied after canonicalize so operator overloads
-    # produce safe filenames and FQN components).
+    # Deduplicate names
     name_counts = {}
     results = []
     for name, start, end in raw_funcs:
-        cname = canonicalize(name)
-        count = name_counts.get(cname, 0)
-        name_counts[cname] = count + 1
+        count = name_counts.get(name, 0)
+        name_counts[name] = count + 1
         if count > 0:
-            deduped = f"{cname}_{count}"
+            deduped = f"{name}_{count}"
         else:
-            deduped = cname
+            deduped = name
         source = '\n'.join(lines[start:end + 1]) + '\n'
         results.append((deduped, source))
 
     return results
-
-
-def _function_spans(filepath, lang_key, proj_dir=None):
-    """Return ``(spans, raw_lines)`` for a source file.
-
-    ``spans`` is a list of ``(deduped_name, start_idx, end_idx)`` line ranges,
-    one per function, named exactly as run_extraction names the extracted files
-    (duplicate names get ``_1``, ``_2``, ... suffixes). ``raw_lines`` are the
-    file's original lines (newline characters preserved) so callers can rewrite
-    the file by line index.
-
-    Function boundaries come from codegraph via the language registry when
-    ``proj_dir`` is given and codegraph indexes the file; otherwise they fall
-    back to the regex extractor (_extract_functions_brace / _indent). Both
-    backends yield the same (name, start_idx, end_idx) shape, so the dedup
-    naming below is identical regardless of which one is used.
-    """
-    lang_cfg = LANG_CONFIG[lang_key]
-    with open(filepath, "r", errors="replace") as f:
-        raw_lines = f.readlines()
-    # Extraction operates on newline-stripped lines; indices line up 1:1 with
-    # raw_lines (readlines yields one entry per line).
-    norm_lines = [l.rstrip("\n").rstrip("\r") for l in raw_lines]
-
-    raw_funcs = None
-    if proj_dir is not None:
-        raw_funcs = function_spans_for_file(proj_dir, filepath, lang_key)
-    if raw_funcs is None:
-        if lang_cfg["body"] == "brace":
-            raw_funcs = _extract_functions_brace(norm_lines, lang_key, lang_cfg)
-        else:
-            raw_funcs = _extract_functions_indent(norm_lines, lang_cfg)
-
-    name_counts = {}
-    spans = []
-    for name, start, end in raw_funcs:
-        cname = canonicalize(name)
-        count = name_counts.get(cname, 0)
-        name_counts[cname] = count + 1
-        deduped = cname if count == 0 else f"{cname}_{count}"
-        spans.append((deduped, start, end))
-    return spans, raw_lines
 
 
 def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
@@ -682,10 +679,6 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         phases_data = json.load(f)
 
     registry_funcs, registry_langs = batch_extract_all(proj_dir)
-    registry_funcs = {
-        os.path.normcase(os.path.normpath(path)): funcs
-        for path, funcs in registry_funcs.items()
-    }
 
     # Build source file list from phases.json
     source_files = []
@@ -728,9 +721,8 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
             dir_name = src_base
         out_dir = os.path.join(output_base, src_dir, dir_name) if src_dir else os.path.join(output_base, dir_name)
 
-        registry_key = os.path.normcase(os.path.normpath(src_path))
-        if registry_key in registry_funcs:
-            funcs = registry_funcs[registry_key]
+        if src_path in registry_funcs:
+            funcs = registry_funcs[src_path]
         else:
             funcs = extract_functions_from_file(src_path, lang_key)
         if not funcs:
@@ -740,7 +732,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         os.makedirs(out_dir, exist_ok=True)
 
         for func_name, func_source in funcs:
-            out_file = os.path.join(out_dir, f"{func_name}.{ext}")
+            out_file = os.path.join(out_dir, _safe_filename(func_name, ext))
 
             # Skip only when the file already has both [SPEC] and [INFO] blocks
             if not force and os.path.exists(out_file) and is_file_ready(out_file):

--- a/src/extract.py
+++ b/src/extract.py
@@ -5,8 +5,9 @@ import sys
 import shutil
 import logging
 
-from src.file_utils import is_file_ready
-from src.languages.registry import batch_extract_all
+from src.file_utils import is_file_ready, _is_test_file
+from src.languages.codegraph import canonicalize
+from src.languages.registry import batch_extract_all, function_spans_for_file
 
 LANG_CONFIG = {
     "cpp": {
@@ -110,6 +111,19 @@ LANG_CONFIG = {
         },
         "body": "brace",
     },
+    "erlang": {
+        "comment_prefix": "%",
+        "spec_marker": "% [SPEC]",
+        "skip_prefixes": ("%", "-module", "-export", "-import", "-include"),
+        "skip_keywords_line": ("-record", "-type", "-spec", "-callback"),
+        "keywords": {
+            "after", "and", "andalso", "band", "begin", "bnot", "bor", "bsl",
+            "bsr", "bxor", "case", "catch", "cond", "div", "end", "fun", "if",
+            "let", "maybe", "not", "of", "or", "orelse", "receive", "rem",
+            "try", "when", "xor",
+        },
+        "body": "external",
+    },
     "cuda": {
         "comment_prefix": "//",
         "spec_marker": "// [SPEC]",
@@ -145,6 +159,7 @@ LANG_CONFIG = {
 EXT_TO_LANG = {
     "cpp": "cpp", "cc": "cpp", "cxx": "cpp", "c": "c", "h": "cpp", "hpp": "cpp",
     "py": "python",
+    "erl": "erlang",
     "go": "go",
     "rs": "rust",
     "java": "java",
@@ -154,65 +169,9 @@ EXT_TO_LANG = {
     "ets": "arkts",
 }
 
-# Directories that typically contain test code
-_TEST_DIR_NAMES = {
-    "test", "tests", "__tests__", "testing", "test_helpers",
-    "testdata", "testutils", "fixtures", "mocks",
-}
-
-# Regex patterns matching common test file naming conventions
-_TEST_FILE_PATTERNS = [
-    re.compile(r'^test_.*\.py$'),         # Python: test_foo.py
-    re.compile(r'^.*_test\.py$'),          # Python: foo_test.py
-    re.compile(r'^conftest\.py$'),         # pytest fixtures
-    re.compile(r'^.*_test\.go$'),          # Go: foo_test.go
-    re.compile(r'^.*_test\.(?:cpp|cc|cxx|c|h|hpp)$'),  # C/C++: foo_test.cpp
-    re.compile(r'^test_.*\.(?:cpp|cc|cxx|c|h|hpp)$'),  # C/C++: test_foo.cpp
-    re.compile(r'^.*Test(?:s|Case)?\.java$'),            # Java: FooTest.java
-    re.compile(r'^.*\.(?:test|spec)\.(?:js|jsx|ts|tsx)$'),  # JS/TS: foo.test.js
-    re.compile(r'^.*_test\.rs$'),          # Rust: foo_test.rs
-    re.compile(r'^.*\.test\.(?:ets)$'),    # ArkTS: foo.test.ets
-]
-
-
-# Project-relative paths that must never be treated as test files, even when
-# their path matches the heuristics below. The entry pipeline registers the
-# source file holding its entry_func here so that file is still extracted and
-# reasoned about even if it lives in a test directory or is named like a test.
-_TEST_FILE_EXEMPTIONS = set()
-
-
-def add_test_file_exemption(rel_path):
-    """Exempt a project-relative source path from the test-file heuristics."""
-    _TEST_FILE_EXEMPTIONS.add(rel_path.replace('\\', '/'))
-
-
-def clear_test_file_exemptions():
-    """Drop all registered test-file exemptions."""
-    _TEST_FILE_EXEMPTIONS.clear()
-
-
-def _is_test_file(rel_path):
-    """Return True if the relative source path looks like a test file."""
-    norm_path = rel_path.replace('\\', '/')
-    if norm_path in _TEST_FILE_EXEMPTIONS:
-        return False
-    parts = norm_path.split('/')
-    # Check if any directory component is a known test directory
-    for part in parts[:-1]:
-        if part.lower() in _TEST_DIR_NAMES:
-            return True
-    # Check filename against test patterns
-    basename = parts[-1]
-    for pat in _TEST_FILE_PATTERNS:
-        if pat.match(basename):
-            return True
-    return False
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
 
 def _safe_filename(name: str, ext: str) -> str:
     """Return a safe filename from a function name and extension.
@@ -247,6 +206,15 @@ def _strip_angle_brackets(text):
 def _extract_func_name_brace(signature_text, lang_cfg):
     """Extract the function name from a brace-delimited language signature."""
     lang_keywords = lang_cfg["keywords"]
+
+    m = re.search(
+        r'\b(operator\s*(?:\[\]|\(\)|[+\-*/%&|^~!=<>]+|new(?:\s*\[\s*\])?|delete(?:\s*\[\s*\])?))'
+        r'\s*\(',
+        signature_text,
+    )
+    if m:
+        return m.group(1)
+
     cleaned = _strip_angle_brackets(signature_text)
     for m in re.finditer(r'\b(\w+)\s*\(', cleaned):
         name = m.group(1)
@@ -641,23 +609,71 @@ def extract_functions_from_file(filepath, lang_key):
 
     if lang_cfg["body"] == "brace":
         raw_funcs = _extract_functions_brace(lines, lang_key, lang_cfg)
-    else:
+    elif lang_cfg["body"] == "indent":
         raw_funcs = _extract_functions_indent(lines, lang_cfg)
+    else:
+        # Semantic-only languages (currently Erlang) are extracted by their
+        # registered backend and have no reliable file-local fallback.
+        return []
 
-    # Deduplicate names
+    # Deduplicate names (applied after canonicalize so operator overloads
+    # produce safe filenames and FQN components).
     name_counts = {}
     results = []
     for name, start, end in raw_funcs:
-        count = name_counts.get(name, 0)
-        name_counts[name] = count + 1
+        cname = canonicalize(name)
+        count = name_counts.get(cname, 0)
+        name_counts[cname] = count + 1
         if count > 0:
-            deduped = f"{name}_{count}"
+            deduped = f"{cname}_{count}"
         else:
-            deduped = name
+            deduped = cname
         source = '\n'.join(lines[start:end + 1]) + '\n'
         results.append((deduped, source))
 
     return results
+
+
+def _function_spans(filepath, lang_key, proj_dir=None):
+    """Return ``(spans, raw_lines)`` for a source file.
+
+    ``spans`` is a list of ``(deduped_name, start_idx, end_idx)`` line ranges,
+    one per function, named exactly as run_extraction names the extracted files
+    (duplicate names get ``_1``, ``_2``, ... suffixes). ``raw_lines`` are the
+    file's original lines (newline characters preserved) so callers can rewrite
+    the file by line index.
+
+    Function boundaries come from codegraph via the language registry when
+    ``proj_dir`` is given and codegraph indexes the file; otherwise they fall
+    back to the regex extractor (_extract_functions_brace / _indent). Both
+    backends yield the same (name, start_idx, end_idx) shape, so the dedup
+    naming below is identical regardless of which one is used.
+    """
+    lang_cfg = LANG_CONFIG[lang_key]
+    with open(filepath, "r", errors="replace") as f:
+        raw_lines = f.readlines()
+    # Extraction operates on newline-stripped lines; indices line up 1:1 with
+    # raw_lines (readlines yields one entry per line).
+    norm_lines = [l.rstrip("\n").rstrip("\r") for l in raw_lines]
+
+    raw_funcs = None
+    if proj_dir is not None:
+        raw_funcs = function_spans_for_file(proj_dir, filepath, lang_key)
+    if raw_funcs is None:
+        if lang_cfg["body"] == "brace":
+            raw_funcs = _extract_functions_brace(norm_lines, lang_key, lang_cfg)
+        else:
+            raw_funcs = _extract_functions_indent(norm_lines, lang_cfg)
+
+    name_counts = {}
+    spans = []
+    for name, start, end in raw_funcs:
+        cname = canonicalize(name)
+        count = name_counts.get(cname, 0)
+        name_counts[cname] = count + 1
+        deduped = cname if count == 0 else f"{cname}_{count}"
+        spans.append((deduped, start, end))
+    return spans, raw_lines
 
 
 def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
@@ -679,6 +695,10 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         phases_data = json.load(f)
 
     registry_funcs, registry_langs = batch_extract_all(proj_dir)
+    registry_funcs = {
+        os.path.normcase(os.path.normpath(path)): funcs
+        for path, funcs in registry_funcs.items()
+    }
 
     # Build source file list from phases.json
     source_files = []
@@ -721,8 +741,9 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
             dir_name = src_base
         out_dir = os.path.join(output_base, src_dir, dir_name) if src_dir else os.path.join(output_base, dir_name)
 
-        if src_path in registry_funcs:
-            funcs = registry_funcs[src_path]
+        registry_key = os.path.normcase(os.path.normpath(src_path))
+        if registry_key in registry_funcs:
+            funcs = registry_funcs[registry_key]
         else:
             funcs = extract_functions_from_file(src_path, lang_key)
         if not funcs:

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -8,36 +8,12 @@ To add support for a new language: create src/languages/<lang>.py and add an ent
 REGISTRY in src/languages/registry.py. No other files need to change.
 """
 
-import hashlib
 import logging
 import os
-import shutil
+import re
 import sqlite3
 import subprocess
 from collections import defaultdict
-
-
-_SAFE_REPLACE = str.maketrans({"/": "_"})
-_UNSAFE = set("/")
-
-
-def canonicalize(func_name):
-    """Return a filesystem-safe, FQN-safe version of a function name.
-
-    C++ operator overloads like ``operator/`` contain ``/`` which breaks both
-    file paths and ``::``-separated FQNs.  This function sanitises those
-    characters so the name is safe everywhere it appears: extracted-function
-    file names, FQNs, call-edge keys, and scope.py rankings.
-
-    Every entry point that introduces a function name into the system MUST call
-    this function before using the name.
-    """
-    if not func_name:
-        return func_name
-    for ch in _UNSAFE:
-        if ch in func_name:
-            return func_name.translate(_SAFE_REPLACE)
-    return func_name
 
 # Maps FM-Agent lang_key → the language string stored in codegraph's SQLite
 # nodes.language column. Only includes languages that codegraph actually supports.
@@ -74,56 +50,50 @@ _CONSTRUCTOR_FILTER = {
     "cpp":        "ctor.name = cls.name",
 }
 
+def _bare_function_name(name: str) -> str:
+    """Extract the bare function identifier from a potentially decorated name.
 
-def _fqn_for(file_path: str, name: str) -> str:
-    """Build the FQN of a function, identical to generate_topdown_layers._file_to_fqn.
+    Tree-sitter sometimes stores a full function signature in the name column
+    for macro-generated C/C++ declarations (e.g. ``(*func)(type *param)``
+    instead of ``func``).  Strips decorations so the result can be used as a
+    filename stem and call-edge key.
 
-    The extracted layout for a source file ``<dir>/<base>.<ext>`` is
-    ``<dir>/<base>-<ext>/<name>.<ext>``, whose FQN is ``dir::base-ext::name``.
-    Constructing the same string here lets get_call_edges emit edges keyed by the
-    exact same FQN the call-graph builder assigns to each extracted function, so
-    codegraph's precisely-resolved caller/callee node identity is preserved
-    instead of being collapsed to a bare name.
+    Handled patterns (language-agnostic — safe for all codegraph languages):
+    - Simple identifier: ``"my_func"`` -> ``"my_func"``
+    - Qualified name: ``"ns::Cls::method"`` -> ``"method"``
+    - Go pointer receiver: ``"(*T).Method"`` -> ``"Method"``
+    - Function-pointer: ``"(*func)(type *param)"`` -> ``"func"``
+    - Pointer return: ``"*func_name(...)"`` -> ``"func_name"``
+    - this-dot: ``"this.onClick"`` -> ``"onClick"``
+    - Empty: ``""`` -> ``""`` (caller falls back to ``_function``)
     """
-    norm = file_path.replace(os.sep, "/")
-    d = os.path.dirname(norm)
-    base = os.path.basename(norm)
-    last_dot = base.rfind(".")
-    dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
-    parts = [p for p in d.split("/") if p]
-    parts += [dashed, name]
-    return "::".join(parts)
+    name = name.strip()
+    if not name:
+        return ""
 
+    # 1. Qualified names (:: / . / (*T). / ) — take the last component.
+    #    Must come BEFORE the function-pointer check so that Go receiver
+    #    syntax "(*T).Method" returns "Method", not "T".
+    m = re.search(r'(?:[:\.)])(\w+)$', name)
+    if m:
+        return m.group(1)
 
-def _node_fqn_map(cur, cg_langs) -> dict:
-    """Return {node_id: fqn} for every function/method node in the given languages.
+    # 2. Function-pointer signature: (*identifier)(...)
+    m = re.match(r'\(\s*\*\s*(\w+)\s*\)', name)
+    if m:
+        return m.group(1)
 
-    The per-file name dedup (``Flush``, ``Flush_1``, ...) uses the SAME rule and
-    ordering as get_functions_by_file (``ORDER BY file_path, start_line``, then a
-    per-(file, name) counter), so the FQN assigned to a node here matches the FQN
-    the extracted file for that node receives. Keeping the two in lockstep is what
-    makes the call-edge identities line up with the extracted-function identities.
-    """
-    placeholders = ",".join("?" * len(cg_langs))
-    cur.execute(
-        f"""
-        SELECT id, name, file_path, start_line
-        FROM nodes
-        WHERE kind IN ('function', 'method') AND language IN ({placeholders})
-        ORDER BY file_path, start_line
-        """,
-        cg_langs,
-    )
-    counts: dict = {}
-    result: dict = {}
-    for node_id, name, file_path, _start in cur.fetchall():
-        cname = canonicalize(name)
-        key = (file_path, cname)
-        c = counts.get(key, 0)
-        counts[key] = c + 1
-        deduped = cname if c == 0 else f"{cname}_{c}"
-        result[node_id] = _fqn_for(file_path, deduped)
-    return result
+    # 3. Pointer return: *identifier(...)
+    m = re.match(r'\*\s*(\w+)', name)
+    if m:
+        return m.group(1)
+
+    # 4. Plain identifier (__init__, _private, normal_func, etc.)
+    m = re.match(r'^(\w+)', name)
+    if m:
+        return m.group(1)
+
+    return name
 
 
 class CodeGraphExtractor:
@@ -177,7 +147,8 @@ class CodeGraphExtractor:
 
         by_file = defaultdict(list)
         for name, file_path, start_line, end_line in rows:
-            by_file[file_path].append((name, int(start_line), int(end_line)))
+            bare = _bare_function_name(name)
+            by_file[file_path].append((bare, int(start_line), int(end_line)))
 
         result = {}
         for file_path, funcs in by_file.items():
@@ -188,96 +159,37 @@ class CodeGraphExtractor:
             except OSError:
                 continue
 
-            name_counts = {}
             file_funcs = []
+            name_counts = {}
             for name, start_line, end_line in funcs:
-                # Disambiguate functions sharing a name within one file
-                # (LocalStorage::Flush vs RemoteCache::Flush, overloads, a method
-                # and a same-named free function, ...). codegraph stores them all
-                # under the same bare name; run_extraction writes each to
-                # "<name>.<ext>", so without a suffix the later definition
-                # silently overwrites the earlier one — dropping functions from
-                # both extraction and the call graph. Mirror the regex path's
-                # dedup ("Flush", "Flush_1", ...). funcs are line-ordered (SQL
-                # ORDER BY start_line), so suffix assignment is deterministic.
-                cname = canonicalize(name)
-                count = name_counts.get(cname, 0)
-                name_counts[cname] = count + 1
-                deduped = cname if count == 0 else f"{cname}_{count}"
+                # Deduplicate within the same source file so that e.g.
+                # Go (*A).Close and (*B).Close (both bare-ify to Close)
+                # do not overwrite each other.
+                count = name_counts.get(name, 0)
+                name_counts[name] = count + 1
+                if count > 0:
+                    name = f"{name}_{count}"
                 # codegraph uses 1-indexed lines, end_line is inclusive
                 body_lines = all_lines[start_line - 1 : end_line]
                 body = "".join(body_lines)
                 if not body.endswith("\n"):
                     body += "\n"
-                file_funcs.append((deduped, body))
+                file_funcs.append((name, body))
 
             result[abs_path] = file_funcs
 
         return result
 
-    def get_function_spans(self, lang_key: str, abs_filepath: str):
-        """Return ``[(name, start_idx, end_idx), ...]`` for a single file, or None.
-
-        Line indices are 0-indexed and inclusive, matching the convention the
-        regex extractor (_extract_functions_brace / _extract_functions_indent)
-        uses, so callers can rewrite the file by line index. Functions are
-        ordered by their starting line.
-
-        Returns None when codegraph does not support ``lang_key`` or when the
-        file is not present in the index (e.g. it was never indexed) — the
-        caller then falls back to the regex extractor. An indexed file that
-        genuinely contains no functions also yields None, which is harmless:
-        the regex fallback finds none either.
-        """
-        cg_langs = _CG_LANG.get(lang_key)
-        if not cg_langs:
-            return None
-
-        # codegraph stores file paths relative to the project root, which is the
-        # parent of the .codegraph/ directory holding the database.
-        root = os.path.dirname(os.path.dirname(os.path.abspath(self._db)))
-        rel = os.path.relpath(os.path.abspath(abs_filepath), root)
-
-        conn = sqlite3.connect(self._db)
-        cur = conn.cursor()
-        placeholders = ",".join("?" * len(cg_langs))
-        cur.execute(
-            f"""
-            SELECT name, start_line, end_line
-            FROM nodes
-            WHERE kind IN ('function', 'method') AND language IN ({placeholders})
-              AND file_path = ?
-            ORDER BY start_line
-            """,
-            (*cg_langs, rel),
-        )
-        rows = cur.fetchall()
-        conn.close()
-
-        if not rows:
-            return None
-        # codegraph uses 1-indexed lines with an inclusive end_line.
-        return [(canonicalize(name), int(start) - 1, int(end) - 1) for name, start, end in rows]
-
     def get_call_edges(self, lang_key: str) -> dict:
-        """Return {caller_fqn: {callee_fqn, ...}} for the given language.
+        """Return {(caller_stem, caller_basename): {callee_stem, ...}} for the given language.
 
-        Each FQN matches generate_topdown_layers._file_to_fqn for the
-        corresponding extracted function (``dir::file-ext::dedup_name``). Edges
-        are resolved by codegraph NODE ID (not by bare name), so the precise
-        caller/callee identity codegraph computed — which file, which same-named
-        sibling — is preserved end-to-end. This lets the call-graph builder use
-        the edges directly instead of re-resolving bare names against every
-        same-named function (which collapsed siblings and over-approximated
-        across files).
+        caller_stem / callee_stem are plain function names (fqn.split('::')[-1]).
+        caller_basename is os.path.basename(caller_file_path), used to disambiguate
+        same-name functions defined in different files.
 
         Constructor calls are synthesised from `instantiates` edges: when a
         function instantiates a class, the corresponding constructor method is
         added as a callee.  See _CONSTRUCTOR_FILTER for per-language details.
-
-        NOTE: codegraph itself collapses calls to same-named classes in different
-        files onto the first definition (a codegraph resolver limitation for C++,
-        not addressable here — see issues/codegraph-samename-class-resolution).
         """
         cg_langs = _CG_LANG.get(lang_key)
         if not cg_langs:
@@ -287,27 +199,25 @@ class CodeGraphExtractor:
         cur = conn.cursor()
         placeholders = ",".join("?" * len(cg_langs))
 
-        # Map every function/method node to its FQN once, using the same per-file
-        # dedup as get_functions_by_file, then resolve edges by node id.
-        fqn_of = _node_fqn_map(cur, cg_langs)
-
-        result = defaultdict(set)
-
-        # Query 1: regular function/method calls, kept as (source_id, target_id)
-        # so each endpoint resolves to its exact node's FQN.
+        # Query 1: regular function/method calls
         cur.execute(
             f"""
-            SELECT e.source, e.target
+            SELECT s.name, s.file_path, t.name
             FROM edges e
             JOIN nodes s ON e.source = s.id
+            JOIN nodes t ON e.target = t.id
             WHERE e.kind = 'calls' AND s.language IN ({placeholders})
             """,
             cg_langs,
         )
-        for src_id, tgt_id in cur.fetchall():
-            caller, callee = fqn_of.get(src_id), fqn_of.get(tgt_id)
-            if caller and callee:
-                result[caller].add(callee)
+        rows = cur.fetchall()
+
+        result = defaultdict(set)
+        for caller, caller_file, callee in rows:
+            base = os.path.basename(caller_file)
+            last_dot = base.rfind(".")
+            dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
+            result[(_bare_function_name(caller), dashed)].add(_bare_function_name(callee))
 
         # Query 2: constructor calls synthesised from instantiates edges.
         # For each `caller instantiates ClassName` edge, find the constructor
@@ -316,7 +226,7 @@ class CodeGraphExtractor:
         if ctor_filter:
             cur.execute(
                 f"""
-                SELECT e.source, ctor.id
+                SELECT s.name, s.file_path, ctor.name
                 FROM edges e
                 JOIN nodes s   ON e.source = s.id
                 JOIN nodes cls ON e.target = cls.id AND cls.kind = 'class'
@@ -328,45 +238,26 @@ class CodeGraphExtractor:
                 """,
                 cg_langs,
             )
-            for src_id, ctor_id in cur.fetchall():
-                caller, callee = fqn_of.get(src_id), fqn_of.get(ctor_id)
-                if caller and callee:
-                    result[caller].add(callee)
+            for caller, caller_file, ctor_name in cur.fetchall():
+                base = os.path.basename(caller_file)
+                last_dot = base.rfind(".")
+                dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
+                result[(_bare_function_name(caller), dashed)].add(_bare_function_name(ctor_name))
 
         conn.close()
         return dict(result)
 
 
-def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
-    """Build the codegraph index for proj_dir with `codegraph init`.
-
-    By default (``force=True``) any existing index is discarded and rebuilt, so
-    the index always reflects the current working tree rather than whatever code
-    was present when it was last built. This is the safe default: callers read
-    function bodies and spans from the index, and a stale one (e.g. after an
-    incremental run's tree changed, or after `_trim_project_in_place` edited the
-    sources) would yield boundaries for the wrong code. `codegraph init` on its
-    own no-ops when `.codegraph/` already exists, so a rebuild requires clearing
-    it first.
-
-    Pass ``force=False`` to keep an existing index and only build when it is
-    absent — an opt-in optimization for callers that know the tree is unchanged
-    since the index was built.
+def try_codegraph_init(proj_dir: str) -> None:
+    """Run `codegraph init` in proj_dir if the index does not yet exist.
 
     Silently skips when codegraph is not installed so the pipeline falls back
     to the regex-based extractor without any error.
     """
-    codegraph_dir = os.path.join(proj_dir, ".codegraph")
-    db_path = os.path.join(codegraph_dir, "codegraph.db")
+    db_path = os.path.join(proj_dir, ".codegraph", "codegraph.db")
     if os.path.exists(db_path):
-        if not force:
-            return
-        # Existing index may reflect stale sources; remove it so `codegraph init`
-        # rebuilds against the current tree instead of skipping.
-        shutil.rmtree(codegraph_dir, ignore_errors=True)
-        print("[Pipeline] Rebuilding codegraph index for current working tree...")
-    else:
-        print("[Pipeline] Building codegraph index...")
+        return
+    print("[Pipeline] Building codegraph index (this runs once per project)...")
     try:
         result = subprocess.run(
             ["codegraph", "init"], cwd=proj_dir, capture_output=True, text=True

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -8,12 +8,73 @@ To add support for a new language: create src/languages/<lang>.py and add an ent
 REGISTRY in src/languages/registry.py. No other files need to change.
 """
 
+import hashlib
 import logging
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 from collections import defaultdict
+
+
+_SAFE_REPLACE = str.maketrans({"/": "_"})
+_UNSAFE = set("/")
+
+
+def canonicalize(func_name):
+    """Return a filesystem-safe, FQN-safe version of a function name.
+
+    C++ operator overloads like ``operator/`` contain ``/`` which breaks both
+    file paths and ``::``-separated FQNs.  This function sanitises those
+    characters so the name is safe everywhere it appears: extracted-function
+    file names, FQNs, call-edge keys, and scope.py rankings.
+
+    Every entry point that introduces a function name into the system MUST call
+    this function before using the name.
+    """
+    if not func_name:
+        return func_name
+    for ch in _UNSAFE:
+        if ch in func_name:
+            return func_name.translate(_SAFE_REPLACE)
+    return func_name
+
+def _bare_function_name(name: str) -> str:
+    """Extract the bare function identifier from a potentially decorated name.
+
+    Tree-sitter sometimes stores a full function signature in the name column
+    for macro-generated C/C++ declarations (e.g. ``(*func)(type *param)``
+    instead of ``func``).  Strips decorations so the result can be used as a
+    filename stem and call-edge key.
+
+    Handled patterns (language-agnostic):
+    - Simple identifier: ``"my_func"`` -> ``"my_func"``
+    - Qualified name: ``"ns::Cls::method"`` -> ``"method"``
+    - Go pointer receiver: ``"(*T).Method"`` -> ``"Method"``
+    - Function-pointer: ``"(*func)(type *param)"`` -> ``"func"``
+    - Pointer return: ``"*func_name(...)"`` -> ``"func_name"``
+    - this-dot: ``"this.onClick"`` -> ``"onClick"``
+    - Empty: ``""`` -> ``""`` (caller falls back to ``_function``)
+    """
+    name = name.strip()
+    if not name:
+        return ""
+
+    m = re.search(r'(?:[:\.)])(\w+)$', name)
+    if m:
+        return m.group(1)
+    m = re.match(r'\(\s*\*\s*(\w+)\s*\)', name)
+    if m:
+        return m.group(1)
+    m = re.match(r'\*\s*(\w+)', name)
+    if m:
+        return m.group(1)
+    m = re.match(r'^(\w+)', name)
+    if m:
+        return m.group(1)
+    return name
+
 
 # Maps FM-Agent lang_key → the language string stored in codegraph's SQLite
 # nodes.language column. Only includes languages that codegraph actually supports.
@@ -50,50 +111,57 @@ _CONSTRUCTOR_FILTER = {
     "cpp":        "ctor.name = cls.name",
 }
 
-def _bare_function_name(name: str) -> str:
-    """Extract the bare function identifier from a potentially decorated name.
 
-    Tree-sitter sometimes stores a full function signature in the name column
-    for macro-generated C/C++ declarations (e.g. ``(*func)(type *param)``
-    instead of ``func``).  Strips decorations so the result can be used as a
-    filename stem and call-edge key.
+def _fqn_for(file_path: str, name: str) -> str:
+    """Build the FQN of a function, identical to generate_topdown_layers._file_to_fqn.
 
-    Handled patterns (language-agnostic — safe for all codegraph languages):
-    - Simple identifier: ``"my_func"`` -> ``"my_func"``
-    - Qualified name: ``"ns::Cls::method"`` -> ``"method"``
-    - Go pointer receiver: ``"(*T).Method"`` -> ``"Method"``
-    - Function-pointer: ``"(*func)(type *param)"`` -> ``"func"``
-    - Pointer return: ``"*func_name(...)"`` -> ``"func_name"``
-    - this-dot: ``"this.onClick"`` -> ``"onClick"``
-    - Empty: ``""`` -> ``""`` (caller falls back to ``_function``)
+    The extracted layout for a source file ``<dir>/<base>.<ext>`` is
+    ``<dir>/<base>-<ext>/<name>.<ext>``, whose FQN is ``dir::base-ext::name``.
+    Constructing the same string here lets get_call_edges emit edges keyed by the
+    exact same FQN the call-graph builder assigns to each extracted function, so
+    codegraph's precisely-resolved caller/callee node identity is preserved
+    instead of being collapsed to a bare name.
     """
-    name = name.strip()
-    if not name:
-        return ""
+    norm = file_path.replace(os.sep, "/")
+    d = os.path.dirname(norm)
+    base = os.path.basename(norm)
+    last_dot = base.rfind(".")
+    dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
+    parts = [p for p in d.split("/") if p]
+    parts += [dashed, name]
+    return "::".join(parts)
 
-    # 1. Qualified names (:: / . / (*T). / ) — take the last component.
-    #    Must come BEFORE the function-pointer check so that Go receiver
-    #    syntax "(*T).Method" returns "Method", not "T".
-    m = re.search(r'(?:[:\.)])(\w+)$', name)
-    if m:
-        return m.group(1)
 
-    # 2. Function-pointer signature: (*identifier)(...)
-    m = re.match(r'\(\s*\*\s*(\w+)\s*\)', name)
-    if m:
-        return m.group(1)
+def _node_fqn_map(cur, cg_langs) -> dict:
+    """Return {node_id: fqn} for every function/method node in the given languages.
 
-    # 3. Pointer return: *identifier(...)
-    m = re.match(r'\*\s*(\w+)', name)
-    if m:
-        return m.group(1)
-
-    # 4. Plain identifier (__init__, _private, normal_func, etc.)
-    m = re.match(r'^(\w+)', name)
-    if m:
-        return m.group(1)
-
-    return name
+    The per-file name dedup (``Flush``, ``Flush_1``, ...) uses the SAME rule and
+    ordering as get_functions_by_file (``ORDER BY file_path, start_line``, then a
+    per-(file, name) counter), so the FQN assigned to a node here matches the FQN
+    the extracted file for that node receives. Keeping the two in lockstep is what
+    makes the call-edge identities line up with the extracted-function identities.
+    """
+    placeholders = ",".join("?" * len(cg_langs))
+    cur.execute(
+        f"""
+        SELECT id, name, file_path, start_line
+        FROM nodes
+        WHERE kind IN ('function', 'method') AND language IN ({placeholders})
+        ORDER BY file_path, start_line
+        """,
+        cg_langs,
+    )
+    counts: dict = {}
+    result: dict = {}
+    for node_id, name, file_path, _start in cur.fetchall():
+        bare = _bare_function_name(name)
+        cname = canonicalize(bare)
+        key = (file_path, cname)
+        c = counts.get(key, 0)
+        counts[key] = c + 1
+        deduped = cname if c == 0 else f"{cname}_{c}"
+        result[node_id] = _fqn_for(file_path, deduped)
+    return result
 
 
 class CodeGraphExtractor:
@@ -147,8 +215,7 @@ class CodeGraphExtractor:
 
         by_file = defaultdict(list)
         for name, file_path, start_line, end_line in rows:
-            bare = _bare_function_name(name)
-            by_file[file_path].append((bare, int(start_line), int(end_line)))
+            by_file[file_path].append((name, int(start_line), int(end_line)))
 
         result = {}
         for file_path, funcs in by_file.items():
@@ -159,37 +226,97 @@ class CodeGraphExtractor:
             except OSError:
                 continue
 
-            file_funcs = []
             name_counts = {}
+            file_funcs = []
             for name, start_line, end_line in funcs:
-                # Deduplicate within the same source file so that e.g.
-                # Go (*A).Close and (*B).Close (both bare-ify to Close)
-                # do not overwrite each other.
-                count = name_counts.get(name, 0)
-                name_counts[name] = count + 1
-                if count > 0:
-                    name = f"{name}_{count}"
+                # Disambiguate functions sharing a name within one file
+                # (LocalStorage::Flush vs RemoteCache::Flush, overloads, a method
+                # and a same-named free function, ...). codegraph stores them all
+                # under the same bare name; run_extraction writes each to
+                # "<name>.<ext>", so without a suffix the later definition
+                # silently overwrites the earlier one — dropping functions from
+                # both extraction and the call graph. Mirror the regex path's
+                # dedup ("Flush", "Flush_1", ...). funcs are line-ordered (SQL
+                # ORDER BY start_line), so suffix assignment is deterministic.
+                bare = _bare_function_name(name)
+                cname = canonicalize(bare)
+                count = name_counts.get(cname, 0)
+                name_counts[cname] = count + 1
+                deduped = cname if count == 0 else f"{cname}_{count}"
                 # codegraph uses 1-indexed lines, end_line is inclusive
                 body_lines = all_lines[start_line - 1 : end_line]
                 body = "".join(body_lines)
                 if not body.endswith("\n"):
                     body += "\n"
-                file_funcs.append((name, body))
+                file_funcs.append((deduped, body))
 
             result[abs_path] = file_funcs
 
         return result
 
-    def get_call_edges(self, lang_key: str) -> dict:
-        """Return {(caller_stem, caller_basename): {callee_stem, ...}} for the given language.
+    def get_function_spans(self, lang_key: str, abs_filepath: str):
+        """Return ``[(name, start_idx, end_idx), ...]`` for a single file, or None.
 
-        caller_stem / callee_stem are plain function names (fqn.split('::')[-1]).
-        caller_basename is os.path.basename(caller_file_path), used to disambiguate
-        same-name functions defined in different files.
+        Line indices are 0-indexed and inclusive, matching the convention the
+        regex extractor (_extract_functions_brace / _extract_functions_indent)
+        uses, so callers can rewrite the file by line index. Functions are
+        ordered by their starting line.
+
+        Returns None when codegraph does not support ``lang_key`` or when the
+        file is not present in the index (e.g. it was never indexed) — the
+        caller then falls back to the regex extractor. An indexed file that
+        genuinely contains no functions also yields None, which is harmless:
+        the regex fallback finds none either.
+        """
+        cg_langs = _CG_LANG.get(lang_key)
+        if not cg_langs:
+            return None
+
+        # codegraph stores file paths relative to the project root, which is the
+        # parent of the .codegraph/ directory holding the database.
+        root = os.path.dirname(os.path.dirname(os.path.abspath(self._db)))
+        rel = os.path.relpath(os.path.abspath(abs_filepath), root)
+
+        conn = sqlite3.connect(self._db)
+        cur = conn.cursor()
+        placeholders = ",".join("?" * len(cg_langs))
+        cur.execute(
+            f"""
+            SELECT name, start_line, end_line
+            FROM nodes
+            WHERE kind IN ('function', 'method') AND language IN ({placeholders})
+              AND file_path = ?
+            ORDER BY start_line
+            """,
+            (*cg_langs, rel),
+        )
+        rows = cur.fetchall()
+        conn.close()
+
+        if not rows:
+            return None
+        # codegraph uses 1-indexed lines with an inclusive end_line.
+        return [(canonicalize(_bare_function_name(name)), int(start) - 1, int(end) - 1) for name, start, end in rows]
+
+    def get_call_edges(self, lang_key: str) -> dict:
+        """Return {caller_fqn: {callee_fqn, ...}} for the given language.
+
+        Each FQN matches generate_topdown_layers._file_to_fqn for the
+        corresponding extracted function (``dir::file-ext::dedup_name``). Edges
+        are resolved by codegraph NODE ID (not by bare name), so the precise
+        caller/callee identity codegraph computed — which file, which same-named
+        sibling — is preserved end-to-end. This lets the call-graph builder use
+        the edges directly instead of re-resolving bare names against every
+        same-named function (which collapsed siblings and over-approximated
+        across files).
 
         Constructor calls are synthesised from `instantiates` edges: when a
         function instantiates a class, the corresponding constructor method is
         added as a callee.  See _CONSTRUCTOR_FILTER for per-language details.
+
+        NOTE: codegraph itself collapses calls to same-named classes in different
+        files onto the first definition (a codegraph resolver limitation for C++,
+        not addressable here — see issues/codegraph-samename-class-resolution).
         """
         cg_langs = _CG_LANG.get(lang_key)
         if not cg_langs:
@@ -199,25 +326,27 @@ class CodeGraphExtractor:
         cur = conn.cursor()
         placeholders = ",".join("?" * len(cg_langs))
 
-        # Query 1: regular function/method calls
+        # Map every function/method node to its FQN once, using the same per-file
+        # dedup as get_functions_by_file, then resolve edges by node id.
+        fqn_of = _node_fqn_map(cur, cg_langs)
+
+        result = defaultdict(set)
+
+        # Query 1: regular function/method calls, kept as (source_id, target_id)
+        # so each endpoint resolves to its exact node's FQN.
         cur.execute(
             f"""
-            SELECT s.name, s.file_path, t.name
+            SELECT e.source, e.target
             FROM edges e
             JOIN nodes s ON e.source = s.id
-            JOIN nodes t ON e.target = t.id
             WHERE e.kind = 'calls' AND s.language IN ({placeholders})
             """,
             cg_langs,
         )
-        rows = cur.fetchall()
-
-        result = defaultdict(set)
-        for caller, caller_file, callee in rows:
-            base = os.path.basename(caller_file)
-            last_dot = base.rfind(".")
-            dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
-            result[(_bare_function_name(caller), dashed)].add(_bare_function_name(callee))
+        for src_id, tgt_id in cur.fetchall():
+            caller, callee = fqn_of.get(src_id), fqn_of.get(tgt_id)
+            if caller and callee:
+                result[caller].add(callee)
 
         # Query 2: constructor calls synthesised from instantiates edges.
         # For each `caller instantiates ClassName` edge, find the constructor
@@ -226,7 +355,7 @@ class CodeGraphExtractor:
         if ctor_filter:
             cur.execute(
                 f"""
-                SELECT s.name, s.file_path, ctor.name
+                SELECT e.source, ctor.id
                 FROM edges e
                 JOIN nodes s   ON e.source = s.id
                 JOIN nodes cls ON e.target = cls.id AND cls.kind = 'class'
@@ -238,26 +367,45 @@ class CodeGraphExtractor:
                 """,
                 cg_langs,
             )
-            for caller, caller_file, ctor_name in cur.fetchall():
-                base = os.path.basename(caller_file)
-                last_dot = base.rfind(".")
-                dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
-                result[(_bare_function_name(caller), dashed)].add(_bare_function_name(ctor_name))
+            for src_id, ctor_id in cur.fetchall():
+                caller, callee = fqn_of.get(src_id), fqn_of.get(ctor_id)
+                if caller and callee:
+                    result[caller].add(callee)
 
         conn.close()
         return dict(result)
 
 
-def try_codegraph_init(proj_dir: str) -> None:
-    """Run `codegraph init` in proj_dir if the index does not yet exist.
+def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
+    """Build the codegraph index for proj_dir with `codegraph init`.
+
+    By default (``force=True``) any existing index is discarded and rebuilt, so
+    the index always reflects the current working tree rather than whatever code
+    was present when it was last built. This is the safe default: callers read
+    function bodies and spans from the index, and a stale one (e.g. after an
+    incremental run's tree changed, or after `_trim_project_in_place` edited the
+    sources) would yield boundaries for the wrong code. `codegraph init` on its
+    own no-ops when `.codegraph/` already exists, so a rebuild requires clearing
+    it first.
+
+    Pass ``force=False`` to keep an existing index and only build when it is
+    absent — an opt-in optimization for callers that know the tree is unchanged
+    since the index was built.
 
     Silently skips when codegraph is not installed so the pipeline falls back
     to the regex-based extractor without any error.
     """
-    db_path = os.path.join(proj_dir, ".codegraph", "codegraph.db")
+    codegraph_dir = os.path.join(proj_dir, ".codegraph")
+    db_path = os.path.join(codegraph_dir, "codegraph.db")
     if os.path.exists(db_path):
-        return
-    print("[Pipeline] Building codegraph index (this runs once per project)...")
+        if not force:
+            return
+        # Existing index may reflect stale sources; remove it so `codegraph init`
+        # rebuilds against the current tree instead of skipping.
+        shutil.rmtree(codegraph_dir, ignore_errors=True)
+        print("[Pipeline] Rebuilding codegraph index for current working tree...")
+    else:
+        print("[Pipeline] Building codegraph index...")
     try:
         result = subprocess.run(
             ["codegraph", "init"], cwd=proj_dir, capture_output=True, text=True


### PR DESCRIPTION
Fixes #82.

Tree-sitter sometimes stores full function signatures in its `name` column for macro-generated C/C++ declarations (e.g. DuckDB's yyjson), which were used directly as filenames and exceeded filesystem limits.

Two-layer fix:

- `src/languages/codegraph.py` — new `_bare_function_name()` extracts the bare identifier from signature strings in all three codegraph name-outflow paths
- `src/extract.py` — new `_safe_filename()` replaces `/`, truncates names >200 chars with a stable hash suffix, and falls back to `_function` for empty names