### PR TITLE
Harden Verilog/Chisel HDL spec generation: resume trust chain, per-callee gate, LLM-JSON shape safety

### DIFF
--- a/main.py
+++ b/main.py
@@ -125,7 +125,7 @@ def _has_source_code(proj_dir):
     return False
 
 
-_HARDWARE_LANGUAGES = {"chisel", "verilog", "systemverilog"}
+_HARDWARE_LANGUAGES = {"chisel", "verilog", "systemverilog", "system_verilog"}
 
 
 def _reject_hardware_languages(phases_path):
@@ -504,7 +504,7 @@ if __name__ == "__main__":
     hdl.add_argument(
         "--verilog",
         action="store_true",
-        help="With --hardware: treat the design as Verilog/SystemVerilog (.v/.sv) "
+        help="With --hardware: treat the design as Verilog/SystemVerilog (.v/.sv/.svh) "
         "and generate specs via verilog_spec_generator.",
     )
     parser.add_argument(

--- a/main.py
+++ b/main.py
@@ -518,6 +518,11 @@ if __name__ == "__main__":
     if (args.chisel or args.verilog) and not args.hardware:
         parser.error("--chisel/--verilog select the HDL for --hardware runs; "
                      "add the --hardware flag")
+    if args.resume and not args.hardware:
+        # run_pipeline ignores --resume and starts by WIPING fm_agent/ — the
+        # exact workspace --resume promises to preserve.
+        parser.error("--resume only applies to --hardware runs; "
+                     "add --hardware (and --verilog for Verilog designs)")
 
     start_time = time.time()
     if args.hardware and args.verilog:

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from config import (
 )
 from src.file_utils import collect_file_names, is_file_ready
 from src.verification import streaming_reasoner
-from src.extract import run_extraction, EXT_TO_LANG
+from src.extract import run_extraction, EXT_TO_LANG, load_units_manifest
 from src.generate_topdown_layers import generate_topdown_layers
 from src.opencode_trace import (
     finish_opencode_trace,
@@ -24,17 +24,32 @@ import subprocess
 import logging
 import argparse
 
+def _as_phase_id(value):
+    """Phase and dependency ids may arrive as digit strings from LLM-written
+    phases.json; both sides of the renumbering map must normalize through
+    THIS function or a dep on a string-id phase is silently emptied."""
+    return int(value) if isinstance(value, str) and value.isdigit() else value
+
+
 def _deduplicate_phases(phases_dir):
     """Ensure each source file appears in at most one phase; keep the earliest."""
     phases_path = os.path.join(phases_dir, "phases.json")
     with open(phases_path, "r") as f:
         data = json.load(f)
 
+    for phase in data["phases"]:
+        phase["phase"] = _as_phase_id(phase["phase"])
+
     seen = set()
     phases_to_remove = []
     for phase in sorted(data["phases"], key=lambda p: p["phase"]):
         for module in phase["modules"]:
             original = module["source_files"]
+            if isinstance(original, str):
+                # LLM manifests sometimes write a single path as a bare
+                # string; iterating it would dedup CHARACTERS and persist
+                # the corruption for every downstream reader.
+                original = [original]
             deduped = []
             for sf in original:
                 if sf not in seen:
@@ -59,8 +74,13 @@ def _deduplicate_phases(phases_dir):
         old_to_new[phase["phase"]] = idx
         phase["phase"] = idx
     for phase in data["phases"]:
+        deps = phase.get("depends_on_phases", [])
+        if isinstance(deps, (str, int)):
+            # Same LLM-shape normalization as the groups bridge: a single
+            # dependency may arrive as a bare string or integer.
+            deps = [deps]
         phase["depends_on_phases"] = [
-            old_to_new[dep] for dep in phase.get("depends_on_phases", [])
+            old_to_new[dep] for dep in (_as_phase_id(d) for d in deps)
             if dep in old_to_new
         ]
 
@@ -68,11 +88,27 @@ def _deduplicate_phases(phases_dir):
         json.dump(data, f, indent=2)
 
 def _get_phase_files(phases_data, phase_num, input_dir):
-    """Return relative paths of extracted function files for a given phase."""
+    """Return relative paths of extracted function files for a given phase.
+
+    Prefers the extraction round's own manifest (extracted_units.json) — the
+    single source of truth for what the current sources actually produce —
+    so units left behind by previous rounds (deleted/renamed modules,
+    vanished sources) are never consumed. Directory enumeration remains as
+    the fallback for pre-manifest workspaces.
+    """
     phase = next(p for p in phases_data["phases"] if p["phase"] == phase_num)
+    manifest = load_units_manifest(os.path.dirname(input_dir))
     phase_files = []
     for module in phase["modules"]:
-        for src_file in module["source_files"]:
+        src_files = module["source_files"]
+        if isinstance(src_files, str):
+            src_files = [src_files]
+        for src_file in src_files:
+            if manifest is not None:
+                for rel in sorted(manifest.get(src_file, [])):
+                    if os.path.isfile(os.path.join(input_dir, rel)):
+                        phase_files.append(rel)
+                continue
             dir_part = os.path.dirname(src_file)
             base = os.path.basename(src_file)
             dot_idx = base.rfind(".")
@@ -126,6 +162,34 @@ def _has_source_code(proj_dir):
 
 
 _HARDWARE_LANGUAGES = {"chisel", "verilog", "systemverilog", "system_verilog"}
+# Unambiguously-hardware source extensions. scala is deliberately absent:
+# plain Scala software projects exist, so only the chisel language token is
+# hardware evidence on the Chisel side.
+_HARDWARE_EXTS = {"v", "sv", "svh"}
+
+
+def _harvest_strings(value):
+    """Best-effort string tokens from an LLM-shaped JSON field.
+
+    LLM manifests declare fields as strings, lists, or dicts
+    ({"primary": "verilog"}); an unintelligible shape may still CONTAIN
+    hardware evidence, and throwing the shape away would fail the guard
+    open. Harvests strings recursively from dict keys/values and sequences.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        out = []
+        for k, v in value.items():
+            out.extend(_harvest_strings(k))
+            out.extend(_harvest_strings(v))
+        return out
+    if isinstance(value, (list, tuple)):
+        out = []
+        for item in value:
+            out.extend(_harvest_strings(item))
+        return out
+    return []
 
 
 def _reject_hardware_languages(phases_path):
@@ -136,16 +200,45 @@ def _reject_hardware_languages(phases_path):
     (is_file_ready) waits for embedded [SPEC]/[INFO] markers in the extracted
     source, so Stage 5 would retry forever. Hardware designs go through
     --hardware (Chisel) or --hardware --verilog instead.
+
+    Best-effort with a fail-closed bias for hardware EVIDENCE: language
+    tokens are harvested from whatever shape the LLM wrote (string, list,
+    dict), and unambiguous hardware extensions in file_extensions or source
+    file suffixes backstop a silent/absent declaration. A malformed file
+    without any hardware evidence still passes through — shape alone must
+    not kill a legitimate software run (downstream stages report their own
+    errors).
     """
     try:
         with open(phases_path) as f:
-            languages = json.load(f).get("languages", [])
-    except (OSError, json.JSONDecodeError, AttributeError):
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
         return
-    found = sorted({str(lang).lower() for lang in languages} & _HARDWARE_LANGUAGES)
+    if not isinstance(data, dict):
+        return
+    found = sorted(
+        {t.lower() for t in _harvest_strings(data.get("languages", []))}
+        & _HARDWARE_LANGUAGES
+    )
+    if not found:
+        exts = {t.lower().lstrip(".")
+                for t in _harvest_strings(data.get("file_extensions", []))}
+        src_exts = set()
+        for phase in data.get("phases", []) if isinstance(data.get("phases"), list) else []:
+            if not isinstance(phase, dict):
+                continue
+            for module in phase.get("modules", []) if isinstance(phase.get("modules"), list) else []:
+                if not isinstance(module, dict):
+                    continue
+                for src in _harvest_strings(module.get("source_files", [])):
+                    base = src.rsplit(".", 1)
+                    if len(base) == 2:
+                        src_exts.add(base[1].lower())
+        found = sorted((exts | src_exts) & _HARDWARE_EXTS)
     if found:
         print(
-            f"[Pipeline] ERROR: phases.json declares hardware language(s): {', '.join(found)}. "
+            f"[Pipeline] ERROR: phases.json declares hardware language(s) or "
+            f"extension(s): {', '.join(found)}. "
             f"The default pipeline does not support hardware designs; rerun with "
             f"--hardware for Chisel or --hardware --verilog for Verilog/SystemVerilog."
         )

--- a/md/workflow_setup_extract_chisel.md
+++ b/md/workflow_setup_extract_chisel.md
@@ -4,7 +4,7 @@
 
 > **CRITICAL — YOU MUST CREATE FILES IN THIS SESSION**: Do NOT only research, plan, or delegate to background/sub-agents. You MUST directly write `fm_agent/groups.json` and the domain context files yourself before this session ends.
 
-This codebase is a **Chisel hardware design** (Scala sources describing hardware). This workflow organizes the codebase by **subsystem** (a functional cluster of related hardware) and lists **source groups** (the `.scala` files in each subsystem).
+This codebase is a **Chisel hardware design** (Scala sources describing hardware). This workflow organizes the codebase by **subsystem** (a functional cluster of related hardware) and lists **source groups** (the `.scala`/`.sc` files in each subsystem).
 
 **Required output files:**
 1. `fm_agent/groups.json`
@@ -33,7 +33,7 @@ Quickly scan the Scala/Chisel source tree and **immediately** write `fm_agent/gr
 {
   "project": "<repo_name>",
   "languages": ["chisel"],
-  "file_extensions": ["scala"],
+  "file_extensions": ["scala", "sc"],
   "subsystems": [
     {
       "subsystem": 1,
@@ -66,11 +66,12 @@ Quickly scan the Scala/Chisel source tree and **immediately** write `fm_agent/gr
 **Field rules:**
 
 - `project` — name of the repo root
+- `file_extensions` — the Scala extensions actually present, a subset of `["scala", "sc"]`
 - `subsystems[*].subsystem` — 1-indexed integer, unique, ascending. A subsystem is a grouping bucket
 - `subsystems[*].name` — brief label, typically the architectural block name (e.g. `Decode`, `LoadStoreQueue`, `Arbiter`)
 - `subsystems[*].description` — one sentence on the hardware function this subsystem implements
-- `subsystems[*].source_groups[*].name` — matches the subdirectory or logical name of the source group. A **source group** is a `.scala` file or a tightly-coupled set of files — it is NOT a Chisel hardware `Module`. One `.scala` file may declare several hardware modules; that is fine
-- `subsystems[*].source_groups[*].source_files` — relative paths from repo root of all Scala source files in this group. **Exclude all test/spec files** (files under `src/test/`, or named `*Spec.scala`, `*Test.scala`, `*Tester.scala`)
+- `subsystems[*].source_groups[*].name` — matches the subdirectory or logical name of the source group. A **source group** is a `.scala`/`.sc` file or a tightly-coupled set of files — it is NOT a Chisel hardware `Module`. One `.scala`/`.sc` file may declare several hardware modules; that is fine
+- `subsystems[*].source_groups[*].source_files` — relative paths from repo root of all Scala source files (`.scala` or `.sc`) in this group. **Exclude all test/spec files** (files under `src/test/`, or named `*Spec.scala`/`*Spec.sc`, `*Test.scala`/`*Test.sc`, `*Tester.scala`/`*Tester.sc`)
 - `subsystems[*].depends_on_subsystems` — list of subsystem numbers whose hardware this subsystem instantiates or inherits from (empty list when there is no cross-subsystem dependency)
 
 Each source file must belong to **at most one subsystem**. If the same file appears in more than one subsystem's `source_groups[*].source_files`, the `groups.json` is invalid and must be corrected before proceeding.
@@ -79,7 +80,7 @@ Each subsystem must be **self-contained**: all source files for a group in that 
 
 If the design is small or has no clear subsystem boundaries, a single subsystem containing all sources is valid.
 
-**Implementation tip:** Use a glob or `find` command to list `.scala` files per directory. Do not enumerate files by hand. Filter out test files (`src/test/`, `*Spec.scala`, `*Test.scala`, `*Tester.scala`). Write `fm_agent/groups.json` immediately after listing files — do not delay.
+**Implementation tip:** Use a glob or `find` command to list `.scala`/`.sc` files per directory. Do not enumerate files by hand. Filter out test files (`src/test/`, `*Spec.scala`/`*Spec.sc`, `*Test.scala`/`*Test.sc`, `*Tester.scala`/`*Tester.sc`). Write `fm_agent/groups.json` immediately after listing files — do not delay.
 
 **IMPORTANT: After writing `fm_agent/groups.json`, proceed to Step 2 immediately. Do not revisit or refactor Step 1.**
 

--- a/md/workflow_setup_extract_verilog.md
+++ b/md/workflow_setup_extract_verilog.md
@@ -4,7 +4,7 @@
 
 > **CRITICAL — YOU MUST CREATE FILES IN THIS SESSION**: Do NOT only research, plan, or delegate to background/sub-agents. You MUST directly write `fm_agent/groups.json` and the domain context files yourself before this session ends.
 
-This codebase is a **Verilog / SystemVerilog hardware design** (`.v` / `.sv` sources describing hardware). This workflow organizes the codebase by **subsystem** (a functional cluster of related hardware) and lists **source groups** (the `.v`/`.sv` files in each subsystem).
+This codebase is a **Verilog / SystemVerilog hardware design** (`.v` / `.sv` / `.svh` sources describing hardware). This workflow organizes the codebase by **subsystem** (a functional cluster of related hardware) and lists **source groups** (the `.v`/`.sv`/`.svh` files in each subsystem).
 
 **Required output files:**
 1. `fm_agent/groups.json`
@@ -71,8 +71,8 @@ Quickly scan the Verilog/SystemVerilog source tree and **immediately** write `fm
 - `subsystems[*].subsystem` — 1-indexed integer, unique, ascending. A subsystem is a grouping bucket
 - `subsystems[*].name` — brief label, typically the architectural block name (e.g. `Adder`, `LoadStoreUnit`, `Arbiter`)
 - `subsystems[*].description` — one sentence on the hardware function this subsystem implements
-- `subsystems[*].source_groups[*].name` — matches the subdirectory or logical name of the source group. A **source group** is a `.v`/`.sv` file or a tightly-coupled set of files — it is NOT a single Verilog `module`. One `.v`/`.sv` file may declare several modules; that is fine
-- `subsystems[*].source_groups[*].source_files` — relative paths from repo root of all Verilog source files in this group. **Exclude all testbench/test files** (files named `*_tb.v`, `*_tb.sv`, `tb_*.v`, `tb_*.sv`, `*_test.sv`, `*_testbench.sv`, or living under a `tb/`, `test/`, or `sim/` directory)
+- `subsystems[*].source_groups[*].name` — matches the subdirectory or logical name of the source group. A **source group** is a `.v`/`.sv`/`.svh` file or a tightly-coupled set of files — it is NOT a single Verilog `module`. One `.v`/`.sv`/`.svh` file may declare several modules; that is fine
+- `subsystems[*].source_groups[*].source_files` — relative paths from repo root of all Verilog source files in this group. **Exclude all testbench/test files** (files named `*_tb.v`/`*_tb.sv`/`*_tb.svh`, `tb_*.v`/`tb_*.sv`/`tb_*.svh`, `*_test.sv`/`*_test.svh`, `*_testbench.sv`/`*_testbench.svh`, or living under a `tb/`, `test/`, or `sim/` directory)
 - `subsystems[*].depends_on_subsystems` — list of subsystem numbers whose hardware this subsystem instantiates (empty list when there is no cross-subsystem dependency)
 
 Each source file must belong to **at most one subsystem**. If the same file appears in more than one subsystem's `source_groups[*].source_files`, the `groups.json` is invalid and must be corrected before proceeding.
@@ -81,7 +81,7 @@ Each subsystem must be **self-contained**: all source files for a group in that 
 
 If the design is small or has no clear subsystem boundaries, a single subsystem containing all sources is valid.
 
-**Implementation tip:** Use a glob or `find` command to list `.v`/`.sv` files per directory. Do not enumerate files by hand. Filter out testbench files (`*_tb.*`, `tb_*.*`, `*_test.sv`, `*_testbench.sv`, and `tb/`/`test/`/`sim/` directories). Write `fm_agent/groups.json` immediately after listing files — do not delay.
+**Implementation tip:** Use a glob or `find` command to list `.v`/`.sv`/`.svh` files per directory. Do not enumerate files by hand. Filter out testbench files (`*_tb.*`, `tb_*.*`, `*_test.sv`/`*_test.svh`, `*_testbench.sv`/`*_testbench.svh`, and `tb/`/`test/`/`sim/` directories). Write `fm_agent/groups.json` immediately after listing files — do not delay.
 
 **IMPORTANT: After writing `fm_agent/groups.json`, proceed to Step 2 immediately. Do not revisit or refactor Step 1.**
 

--- a/src/chisel_spec_generator.py
+++ b/src/chisel_spec_generator.py
@@ -229,12 +229,15 @@ def _get_pending_batches_chisel(batches, proj_dir, expects_submodules=frozenset(
     pending = []
     for batch in batches:
         batch_pending = False
-        validation_errors = []
+        feedback = batch.get("validation_errors")
+        feedback = dict(feedback) if isinstance(feedback, dict) else {}
         for func_rel in batch.get("functions", []):
             module_path = os.path.join(proj_dir, func_rel)
             expects = func_rel in expects_submodules
+            module_errors = []
             if not chisel_spec_ready(module_path, expects_submodules=expects):
                 info_path = chisel_info_path(module_path)
+                spec_ok = _chisel_markdown_ready(chisel_spec_path(module_path))
                 if expects and os.path.exists(info_path):
                     try:
                         with open(info_path, "r", errors="replace") as f:
@@ -243,16 +246,34 @@ def _get_pending_batches_chisel(batches, proj_dir, expects_submodules=frozenset(
                         info_text = ""
                     if ("(no submodules)" in info_text
                             or _SUBMODULE_HEADING_RE.search(info_text) is None):
-                        validation_errors.append(
+                        module_errors.append(
                             f"{os.path.basename(info_path)}: this module instantiates "
                             f"other extracted modules — the info file must contain one "
                             f"'# Submodule: <name>' entry per instantiated submodule "
                             f"and must not claim '(no submodules)'"
                         )
+                if not module_errors and spec_ok:
+                    # chisel_spec_ready is False but the spec itself is fine
+                    # (leaf module, or the stub check above found nothing
+                    # this round — e.g. its own info file was just deleted
+                    # by US, pending regeneration). Only report a generic
+                    # info blocker when the CURRENTLY recorded feedback
+                    # blames the spec specifically (now moot) or there is
+                    # none yet — otherwise a more specific diagnosis from a
+                    # prior round must survive via inertia.
+                    spec_base = os.path.basename(chisel_spec_path(module_path))
+                    prior = feedback.get(func_rel) or []
+                    if not prior or any(spec_base in m for m in prior):
+                        module_errors.append(
+                            f"{os.path.basename(info_path)}: incomplete or missing "
+                            f"— regenerate it"
+                        )
                 _remove_incomplete_chisel_outputs(
                     module_path, expects_submodules=expects
                 )
                 batch_pending = True
+                if module_errors:
+                    feedback[func_rel] = module_errors
                 continue
             spec_path = chisel_spec_path(module_path)
             is_valid, spec_errors = validate_chisel_spec(spec_path)
@@ -266,21 +287,23 @@ def _get_pending_batches_chisel(batches, proj_dir, expects_submodules=frozenset(
                     os.remove(spec_path)
                 except OSError as exc:
                     logging.warning("Could not remove invalid spec %s: %s", spec_path, exc)
-                validation_errors.append(
+                feedback[func_rel] = [
                     f"{os.path.basename(spec_path)}: " + "; ".join(spec_errors[:3])
-                )
+                ]
                 batch_pending = True
-        # Exposed to the retry prompt so the LLM knows WHAT failed the
-        # checklist — without feedback regeneration rarely converges. The
-        # feedback must survive the retry loop's pre-launch rescan (which runs
-        # AFTER the offending files were deleted), so only overwrite it when
-        # new errors surface, and clear it once the batch completes.
-        if validation_errors:
-            batch["validation_errors"] = validation_errors
+            else:
+                # Ready and checklist-valid: this module is done — drop its
+                # stale feedback so the retry prompt stops demanding a fix
+                # for an issue that no longer exists.
+                feedback.pop(func_rel, None)
+        # Exposed to the retry prompt so the LLM knows WHAT failed — without
+        # feedback regeneration rarely converges. Keyed per module: an entry
+        # survives the pre-launch rescan (which runs AFTER the offending
+        # files were deleted) until ITS module passes, so a fixed module's
+        # errors do not ride along while batchmates are still regenerating.
+        batch["validation_errors"] = feedback if batch_pending else {}
         if batch_pending:
             pending.append(batch)
-        else:
-            batch["validation_errors"] = []
     return pending
 
 
@@ -315,7 +338,8 @@ def _reset_derived_state(work_dir):
     ctx_dir = os.path.join(spec_prompts_dir, "domain_context")
     if os.path.isdir(ctx_dir):
         shutil.rmtree(ctx_dir, ignore_errors=True)
-    for name in ("groups.json", "phases.json", "fm_agent_file_list.json"):
+    for name in ("groups.json", "phases.json", "fm_agent_file_list.json",
+                 "extracted_units.json"):
         try:
             os.remove(os.path.join(work_dir, name))
         except OSError:
@@ -402,7 +426,10 @@ def _groups_json_is_usable(groups_path, required_exts=None, required_languages=N
             for group in sub.get("source_groups", []):
                 if not isinstance(group, dict):
                     continue
-                for src in group.get("source_files", []) or []:
+                srcs = group.get("source_files", []) or []
+                if isinstance(srcs, str):
+                    srcs = [srcs]
+                for src in srcs:
                     base = os.path.basename(str(src))
                     ext = base.rsplit(".", 1)[-1].lower() if "." in base else ""
                     if ext in required_exts:
@@ -486,7 +513,14 @@ def _normalize_groups_source_paths(work_dir, proj_dir):
     for sub in groups.get("subsystems", []):
         for grp in sub.get("source_groups", []):
             new_files = []
-            for sf in grp.get("source_files", []):
+            srcs = grp.get("source_files", [])
+            if isinstance(srcs, str):
+                # First consumer of groups.json source files: heal the
+                # string shape here and persist the list for every
+                # downstream reader.
+                srcs = [srcs]
+                changed = True
+            for sf in srcs:
                 resolved = _resolve(sf)
                 if resolved is None:
                     unresolved.append(sf)
@@ -516,10 +550,15 @@ def _filter_phase_source_files(work_dir, allowed_exts, label):
     phases_path = os.path.join(work_dir, "phases.json")
     data = _load_json_file(phases_path, "phases.json")
     dropped = []
+    normalized = False
     for phase in data.get("phases", []):
         for module in phase.get("modules", []):
             kept = []
-            for src in module.get("source_files", []):
+            srcs = module.get("source_files", [])
+            if isinstance(srcs, str):
+                srcs = [srcs]
+                normalized = True
+            for src in srcs:
                 base = os.path.basename(str(src))
                 ext = base.rsplit(".", 1)[-1].lower() if "." in base else ""
                 if ext in allowed_exts:
@@ -533,6 +572,7 @@ def _filter_phase_source_files(work_dir, allowed_exts, label):
             "(the hardware flow cannot spec them): %s",
             label, len(dropped), label, ", ".join(map(str, dropped[:10])),
         )
+    if dropped or normalized:
         with open(phases_path, "w") as f:
             json.dump(data, f, indent=2)
     return dropped
@@ -556,9 +596,12 @@ def _groups_to_phases(work_dir):
         phase_num = _as_int(sub.get("subsystem"), "subsystems[*].subsystem")
         modules = []
         for grp in sub.get("source_groups", []):
+            srcs = grp.get("source_files", [])
+            if isinstance(srcs, str):
+                srcs = [srcs]
             modules.append({
                 "name": grp.get("name", ""),
-                "source_files": grp.get("source_files", []),
+                "source_files": srcs,
             })
         phases.append({
             "phase": phase_num,
@@ -566,13 +609,24 @@ def _groups_to_phases(work_dir):
             "modules": modules,
             "depends_on_phases": [
                 _as_int(dep, "subsystems[*].depends_on_subsystems[*]")
-                for dep in sub.get("depends_on_subsystems", [])
+                for dep in ([sub.get("depends_on_subsystems")]
+                            if isinstance(sub.get("depends_on_subsystems"), (str, int))
+                            else sub.get("depends_on_subsystems", []))
             ],
         })
 
     out = {
         "project": groups.get("project", os.path.basename(os.path.dirname(work_dir))),
-        "languages": groups.get("languages", ["chisel"]),
+        # This IS the Chisel flow by dispatch — languages=["chisel"] is an
+        # invariant the runner already knows, not a re-derivation. The
+        # resume veto accepts "scala" as a plausible LLM spelling (the
+        # source files literally have .scala extension), but
+        # build_ext_to_lang only routes to the hardware spec path when
+        # "chisel" is literally declared; passing groups.json's spelling
+        # through verbatim would misroute "scala"-declared modules to
+        # software-style prompts (mirrors verilog_spec_generator.py's
+        # _force_verilog_phase_languages).
+        "languages": ["chisel"],
         "file_extensions": groups.get("file_extensions", ["scala"]),
         "phases": phases,
     }
@@ -641,13 +695,15 @@ def _normalize_chisel_domain_context(work_dir):
 
 
 def _has_scala_source(proj_dir):
-    """Check whether proj_dir contains at least one Chisel (.scala) source file."""
+    """Check whether proj_dir contains at least one Chisel (.scala/.sc) source
+    file — both extensions are accepted throughout the flow (extraction,
+    resume veto, source filter), so the entry check must match."""
     for root, dirs, files in os.walk(proj_dir):
         # Skip hidden dirs and common non-source dirs (mirrors _has_source_code).
         dirs[:] = [d for d in dirs if not d.startswith('.') and d not in
                    {'node_modules', '__pycache__', 'venv', '.venv', 'fm_agent'}]
         for fname in files:
-            if fname.endswith('.scala'):
+            if fname.endswith(('.scala', '.sc')):
                 return True
     return False
 
@@ -668,10 +724,23 @@ def _report_undocumented_submodules(work_dir, info_path_fn, label,
     spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
     if not os.path.isdir(spec_prompts_dir):
         return []
+    layer_files = [
+        fname for fname in sorted(os.listdir(spec_prompts_dir))
+        if re.match(r"phase_\d+_topdown_layers\.json$", fname)
+    ]
+    # First pass: fqn -> declared name, stamped by generate_topdown_layers
+    # with the extractor's own declaration regex. Maps dedup aliases
+    # (Control_1) back to the name info headings use (Control); a genuine
+    # module named Stage_1 declares its own stem, so its gap is never hidden.
+    declared_names = {}
+    for fname in layer_files:
+        layers_data = _load_json_file(os.path.join(spec_prompts_dir, fname), fname)
+        for layer in layers_data.get("layers", []):
+            for fn in layer.get("functions", []):
+                if fn.get("declared_name"):
+                    declared_names[fn["name"]] = fn["declared_name"]
     gaps = []
-    for fname in sorted(os.listdir(spec_prompts_dir)):
-        if not re.match(r"phase_\d+_topdown_layers\.json$", fname):
-            continue
+    for fname in layer_files:
         layers_data = _load_json_file(os.path.join(spec_prompts_dir, fname), fname)
         for layer in layers_data.get("layers", []):
             for fn in layer.get("functions", []):
@@ -689,7 +758,7 @@ def _report_undocumented_submodules(work_dir, info_path_fn, label,
                 for c in callees:
                     name = str(c).split("::")[-1]
                     if strip_dedup_suffix:
-                        name = re.sub(r"_\d+$", "", name)
+                        name = declared_names.get(str(c), name)
                     expected.add(name)
                 missing = sorted(e for e in expected if e and e not in headings)
                 if missing:
@@ -721,7 +790,7 @@ def run_chisel_spec_generation(proj_dir, resume=False):
         sys.exit(1)
 
     if not _has_scala_source(proj_dir):
-        print(f"[Chisel] ERROR: No Scala (.scala) source files found in {proj_dir}.")
+        print(f"[Chisel] ERROR: No Scala (.scala/.sc) source files found in {proj_dir}.")
         sys.exit(1)
 
     work_dir = os.path.join(proj_dir, "fm_agent")
@@ -863,6 +932,30 @@ def run_chisel_spec_generation(proj_dir, resume=False):
     # Judge emptiness by the CURRENT phases' files: stale units from a
     # previous run (preserved by --resume) must not smuggle the run past
     # this guard by making the whole-tree walk non-empty.
+    # A reused manifest that lists source files which no longer exist
+    # describes a PAST tree: renamed/deleted files mean the new names are
+    # absent from phases/topdown/batches entirely, so surviving sources
+    # would spec fine while the rest silently never appear (partial-missing
+    # is invisible to the zero-units guard below). Discard the stale
+    # manifest and rerun setup against the tree as it exists now; completed
+    # specs for surviving sources are preserved and reused. The recursive
+    # call starts with no groups.json, so resume_setup is False there and
+    # this cannot loop.
+    if resume_setup and any(
+        not os.path.exists(os.path.join(proj_dir, src))
+        for phase in phases_data["phases"]
+        for module in phase["modules"]
+        for src in module["source_files"]
+    ):
+        print("[Chisel] Resume: the reused groups.json points at missing "
+              "source files; discarding it and rerunning setup.")
+        try:
+            os.remove(groups_path)
+        except OSError:
+            pass
+        _reset_derived_state(work_dir)
+        return run_chisel_spec_generation(proj_dir, resume=True)
+
     if not any(
         _get_phase_files(phases_data, phase["phase"], input_dir)
         for phase in phases_data["phases"]
@@ -985,8 +1078,11 @@ def run_chisel_spec_generation(proj_dir, resume=False):
                     fm_reminder = ("IMPORTANT: fm_agent/ is your output workspace, not project source. "
                                    "Do NOT modify any existing project files.")
                     checklist_note = ""
-                    failed = batch_info.get("validation_errors") or []
+                    failed = batch_info.get("validation_errors") or {}
                     if failed:
+                        issues = " | ".join(
+                            msg for key in sorted(failed) for msg in failed[key]
+                        )
                         checklist_note = (
                             " WARNING: the following previously generated specs FAILED the "
                             "quality checklist and were deleted — regenerate them and fix "
@@ -994,7 +1090,7 @@ def run_chisel_spec_generation(proj_dir, resume=False):
                             "fm_agent/spec_prompts/system_prompt.md: every tag is a plain "
                             "<FG-NAME>/<FC-NAME>/<CK-NAME> on its own line, sibling tag names "
                             "must be unique, and the <FG-API> group is mandatory): "
-                            + " | ".join(failed)
+                            + issues
                         )
                     if attempt == 1 and not resume:
                         prompt = (

--- a/src/chisel_spec_generator.py
+++ b/src/chisel_spec_generator.py
@@ -41,6 +41,7 @@ from config import (
 )
 from src.file_utils import collect_file_names
 from src.chisel_support import (
+    _SUBMODULE_HEADING_RE,
     _chisel_info_ready,
     _chisel_markdown_ready,
     chisel_info_path,
@@ -240,7 +241,8 @@ def _get_pending_batches_chisel(batches, proj_dir, expects_submodules=frozenset(
                             info_text = f.read()
                     except OSError:
                         info_text = ""
-                    if "(no submodules)" in info_text or "# Submodule:" not in info_text:
+                    if ("(no submodules)" in info_text
+                            or _SUBMODULE_HEADING_RE.search(info_text) is None):
                         validation_errors.append(
                             f"{os.path.basename(info_path)}: this module instantiates "
                             f"other extracted modules — the info file must contain one "
@@ -269,10 +271,16 @@ def _get_pending_batches_chisel(batches, proj_dir, expects_submodules=frozenset(
                 )
                 batch_pending = True
         # Exposed to the retry prompt so the LLM knows WHAT failed the
-        # checklist — without feedback regeneration rarely converges.
-        batch["validation_errors"] = validation_errors
+        # checklist — without feedback regeneration rarely converges. The
+        # feedback must survive the retry loop's pre-launch rescan (which runs
+        # AFTER the offending files were deleted), so only overwrite it when
+        # new errors surface, and clear it once the batch completes.
+        if validation_errors:
+            batch["validation_errors"] = validation_errors
         if batch_pending:
             pending.append(batch)
+        else:
+            batch["validation_errors"] = []
     return pending
 
 

--- a/src/chisel_spec_generator.py
+++ b/src/chisel_spec_generator.py
@@ -295,6 +295,20 @@ def _load_json_file(path, description):
         raise ValueError(f"{description} at {path} is not valid JSON: {exc}") from exc
 
 
+def _reset_domain_context(work_dir):
+    """Remove spec_prompts/domain_context so a rerun setup regenerates it.
+
+    The alias files (engine_overview.txt, phase_NN_types.txt) are only copied
+    when absent, and batch prompts read ONLY the aliases — leftovers from a
+    previous (possibly other-HDL) run would silently shadow the freshly
+    written context. Called on the resume path whenever the old manifest
+    cannot be reused and setup is rerun.
+    """
+    ctx_dir = os.path.join(work_dir, "spec_prompts", "domain_context")
+    if os.path.isdir(ctx_dir):
+        shutil.rmtree(ctx_dir, ignore_errors=True)
+
+
 def _groups_json_is_usable(groups_path, required_exts=None, required_languages=None):
     """Return True when groups.json is complete enough to resume from.
 
@@ -340,6 +354,15 @@ def _groups_json_is_usable(groups_path, required_exts=None, required_languages=N
             # A string-typed declaration is still a declaration — it must not
             # slip past the veto as "no languages".
             declared = [declared]
+        if declared is not None and not isinstance(declared, list):
+            # Any other shape (dict, number, ...) is declared-but-
+            # unintelligible; treating it as absence would reopen the
+            # mixed-manifest gap for mistyped manifests.
+            logging.warning(
+                "Cannot resume from groups.json: languages declaration has an "
+                "unintelligible shape (%s).", type(declared).__name__,
+            )
+            return False
         if isinstance(declared, list) and declared:
             langs = {str(lang).strip().lower() for lang in declared}
             if not langs & set(required_languages):
@@ -696,9 +719,11 @@ def run_chisel_spec_generation(proj_dir, resume=False):
         elif os.path.exists(groups_path):
             print("[Chisel] Resume requested but groups.json is missing or incomplete; "
                   "rerunning setup in the existing fm_agent/ workspace.")
+            _reset_domain_context(work_dir)
         else:
             print("[Chisel] Resume requested but no groups.json found; "
                   "starting setup in the existing fm_agent/ workspace.")
+            _reset_domain_context(work_dir)
     else:
         _clean_previous_run(work_dir)
     os.makedirs(work_dir, exist_ok=True)

--- a/src/chisel_spec_generator.py
+++ b/src/chisel_spec_generator.py
@@ -295,18 +295,37 @@ def _load_json_file(path, description):
         raise ValueError(f"{description} at {path} is not valid JSON: {exc}") from exc
 
 
-def _reset_domain_context(work_dir):
-    """Remove spec_prompts/domain_context so a rerun setup regenerates it.
+def _reset_derived_state(work_dir):
+    """Remove derived artifacts so a rerun setup regenerates them all.
 
-    The alias files (engine_overview.txt, phase_NN_types.txt) are only copied
-    when absent, and batch prompts read ONLY the aliases — leftovers from a
-    previous (possibly other-HDL) run would silently shadow the freshly
-    written context. Called on the resume path whenever the old manifest
-    cannot be reused and setup is rerun.
+    Called on the resume path whenever the old manifest cannot be reused and
+    setup is rerun. Everything below is cheaply rebuilt by the fresh
+    setup/extraction, but if left behind it silently poisons the new run:
+    the domain-context aliases shadow the fresh context (batch prompts read
+    ONLY the aliases), stale topdown/batch artifacts confuse the advisory
+    report, and a stale file list can smuggle the run past the zero-modules
+    guard. extracted_functions/ is deliberately PRESERVED — completed specs
+    live there, and keeping them is the point of --resume.
     """
-    ctx_dir = os.path.join(work_dir, "spec_prompts", "domain_context")
+    spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
+    ctx_dir = os.path.join(spec_prompts_dir, "domain_context")
     if os.path.isdir(ctx_dir):
         shutil.rmtree(ctx_dir, ignore_errors=True)
+    for name in ("phases.json", "fm_agent_file_list.json"):
+        try:
+            os.remove(os.path.join(work_dir, name))
+        except OSError:
+            pass
+    if os.path.isdir(spec_prompts_dir):
+        for entry in os.listdir(spec_prompts_dir):
+            path = os.path.join(spec_prompts_dir, entry)
+            if re.match(r"phase_\d+_topdown_layers\.json$", entry):
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+            elif entry.startswith("batch_prompts_") and os.path.isdir(path):
+                shutil.rmtree(path, ignore_errors=True)
 
 
 def _groups_json_is_usable(groups_path, required_exts=None, required_languages=None):
@@ -719,11 +738,11 @@ def run_chisel_spec_generation(proj_dir, resume=False):
         elif os.path.exists(groups_path):
             print("[Chisel] Resume requested but groups.json is missing or incomplete; "
                   "rerunning setup in the existing fm_agent/ workspace.")
-            _reset_domain_context(work_dir)
+            _reset_derived_state(work_dir)
         else:
             print("[Chisel] Resume requested but no groups.json found; "
                   "starting setup in the existing fm_agent/ workspace.")
-            _reset_domain_context(work_dir)
+            _reset_derived_state(work_dir)
     else:
         _clean_previous_run(work_dir)
     os.makedirs(work_dir, exist_ok=True)
@@ -834,15 +853,21 @@ def run_chisel_spec_generation(proj_dir, resume=False):
     _normalize_chisel_domain_context(work_dir)
 
     print("[Chisel] Stage 2/4: Collecting file list...")
-    file_list = collect_file_names(input_dir, os.path.join(work_dir, "fm_agent_file_list.json"))
+    collect_file_names(input_dir, os.path.join(work_dir, "fm_agent_file_list.json"))
 
-    if not file_list:
+    phases_data = _load_json_file(os.path.join(work_dir, "phases.json"), "phases.json")
+    # Judge emptiness by the CURRENT phases' files: stale units from a
+    # previous run (preserved by --resume) must not smuggle the run past
+    # this guard by making the whole-tree walk non-empty.
+    if not any(
+        _get_phase_files(phases_data, phase["phase"], input_dir)
+        for phase in phases_data["phases"]
+    ):
         print("[Chisel] No modules found to spec. Skipping spec generation.")
         return
 
     # --- Stage 3: Generate topdown layers ---
     print("[Chisel] Stage 3/4: Generating topdown layers...")
-    phases_data = _load_json_file(os.path.join(work_dir, "phases.json"), "phases.json")
     generate_topdown_layers(work_dir)
 
     # --- Stage 4: Execute spec generation (per phase, per layer) ---

--- a/src/chisel_spec_generator.py
+++ b/src/chisel_spec_generator.py
@@ -304,14 +304,18 @@ def _reset_derived_state(work_dir):
     the domain-context aliases shadow the fresh context (batch prompts read
     ONLY the aliases), stale topdown/batch artifacts confuse the advisory
     report, and a stale file list can smuggle the run past the zero-modules
-    guard. extracted_functions/ is deliberately PRESERVED — completed specs
+    guard. The rejected groups.json itself is removed too: leaving it in
+    place makes Stage 1 use the 'Continue where you left off… rewrite it if
+    malformed or incomplete' prompt, but a well-formed foreign-HDL manifest
+    is neither, so the retry loop would depend on the LLM volunteering a
+    rewrite. extracted_functions/ is deliberately PRESERVED — completed specs
     live there, and keeping them is the point of --resume.
     """
     spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
     ctx_dir = os.path.join(spec_prompts_dir, "domain_context")
     if os.path.isdir(ctx_dir):
         shutil.rmtree(ctx_dir, ignore_errors=True)
-    for name in ("phases.json", "fm_agent_file_list.json"):
+    for name in ("groups.json", "phases.json", "fm_agent_file_list.json"):
         try:
             os.remove(os.path.join(work_dir, name))
         except OSError:

--- a/src/chisel_spec_generator.py
+++ b/src/chisel_spec_generator.py
@@ -295,7 +295,7 @@ def _load_json_file(path, description):
         raise ValueError(f"{description} at {path} is not valid JSON: {exc}") from exc
 
 
-def _groups_json_is_usable(groups_path, required_exts=None):
+def _groups_json_is_usable(groups_path, required_exts=None, required_languages=None):
     """Return True when groups.json is complete enough to resume from.
 
     ``required_exts`` names the calling flow's source extensions: a manifest
@@ -303,6 +303,14 @@ def _groups_json_is_usable(groups_path, required_exts=None):
     groups.json found by ``--hardware --verilog --resume``) lists no matching
     sources, and reusing it would make the run silently spec nothing —
     rejecting it here makes resume fall back to rerunning setup instead.
+
+    ``required_languages`` closes the mixed-manifest gap: a foreign manifest
+    with a stray file of the right extension (an LLM behavior this flow
+    defends against elsewhere) passes the extension check, but its declared
+    ``languages`` still name the other HDL — resuming on it would inherit the
+    other flow's subsystems and domain context. When the manifest declares
+    languages and none matches, it is rejected; a manifest without declared
+    languages falls back to the extension judgement.
     """
     try:
         groups = _load_json_file(groups_path, "groups.json")
@@ -325,6 +333,23 @@ def _groups_json_is_usable(groups_path, required_exts=None):
         if not isinstance(sub.get("source_groups", []), list):
             logging.warning("Cannot resume from groups.json: subsystem %s source_groups is not a list.", idx)
             return False
+
+    if required_languages is not None:
+        declared = groups.get("languages")
+        if isinstance(declared, str):
+            # A string-typed declaration is still a declaration — it must not
+            # slip past the veto as "no languages".
+            declared = [declared]
+        if isinstance(declared, list) and declared:
+            langs = {str(lang).strip().lower() for lang in declared}
+            if not langs & set(required_languages):
+                logging.warning(
+                    "Cannot resume from groups.json: declared languages %s do "
+                    "not match this flow (%s) — it belongs to a different HDL "
+                    "flow.",
+                    sorted(langs), sorted(required_languages),
+                )
+                return False
 
     if required_exts is not None:
         for sub in subsystems:
@@ -581,15 +606,18 @@ def _has_scala_source(proj_dir):
     return False
 
 
-def _report_undocumented_submodules(work_dir, info_path_fn, label):
+def _report_undocumented_submodules(work_dir, info_path_fn, label,
+                                    strip_dedup_suffix=True):
     """Advisory (report only): list modules whose call graph shows submodules
     but whose info document lacks a parseable ``# Submodule:`` entry for them.
 
     Deliberately NOT enforced through readiness: graph edges can be noisy
     (Chisel companion objects, member access) and hard enforcement deadlocks
-    genuine leaf modules — a human reading the summary can judge. Dedup
-    suffixes (``Control_1``) are stripped, since info headings use declared
-    names. Returns ``[(module_fqn, [missing names...]), ...]``.
+    genuine leaf modules — a human reading the summary can judge.
+    ``strip_dedup_suffix`` maps extractor dedup aliases (``Control_1``) back
+    to the declared name the info headings use; pass False for Verilog, where
+    ``_<digits>`` endings are genuine module names (``fifo_64``) and stripping
+    them would hide real gaps. Returns ``[(module_fqn, [missing...]), ...]``.
     """
     spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
     if not os.path.isdir(spec_prompts_dir):
@@ -611,10 +639,12 @@ def _report_undocumented_submodules(work_dir, info_path_fn, label):
                 except OSError:
                     continue  # a missing info file is readiness's problem
                 headings = set(_SUBMODULE_HEADING_RE.findall(content))
-                expected = {
-                    re.sub(r"_\d+$", "", str(c).split("::")[-1])
-                    for c in callees
-                }
+                expected = set()
+                for c in callees:
+                    name = str(c).split("::")[-1]
+                    if strip_dedup_suffix:
+                        name = re.sub(r"_\d+$", "", name)
+                    expected.add(name)
                 missing = sorted(e for e in expected if e and e not in headings)
                 if missing:
                     gaps.append((fn["name"], missing))
@@ -657,7 +687,7 @@ def run_chisel_spec_generation(proj_dir, resume=False):
     # Clean files from the previous run, unless resuming an interrupted run.
     groups_path = os.path.join(work_dir, "groups.json")
     resume_setup = resume and os.path.exists(groups_path) and _groups_json_is_usable(
-        groups_path, required_exts={"scala", "sc"}
+        groups_path, required_exts={"scala", "sc"}, required_languages={"chisel", "scala"}
     )
     if resume:
         if resume_setup:
@@ -717,7 +747,7 @@ def run_chisel_spec_generation(proj_dir, resume=False):
         except subprocess.CalledProcessError as e:
             logging.warning(f"Stage 2 attempt {attempt}: opencode exited with code {e.returncode}")
 
-        if _groups_json_is_usable(groups_path, required_exts={"scala", "sc"}):
+        if _groups_json_is_usable(groups_path, required_exts={"scala", "sc"}, required_languages={"chisel", "scala"}):
             break
 
         if attempt < OPENCODE_MAX_RETRIES:

--- a/src/chisel_spec_generator.py
+++ b/src/chisel_spec_generator.py
@@ -240,12 +240,12 @@ def _get_pending_batches_chisel(batches, proj_dir, expects_submodules=frozenset(
                             info_text = f.read()
                     except OSError:
                         info_text = ""
-                    if "(no submodules)" in info_text:
+                    if "(no submodules)" in info_text or "# Submodule:" not in info_text:
                         validation_errors.append(
-                            f"{os.path.basename(info_path)}: claims '(no submodules)' "
-                            f"but this module instantiates other extracted modules — "
-                            f"write one '# Submodule: <name>' entry per instantiated "
-                            f"submodule"
+                            f"{os.path.basename(info_path)}: this module instantiates "
+                            f"other extracted modules — the info file must contain one "
+                            f"'# Submodule: <name>' entry per instantiated submodule "
+                            f"and must not claim '(no submodules)'"
                         )
                 _remove_incomplete_chisel_outputs(
                     module_path, expects_submodules=expects

--- a/src/chisel_spec_generator.py
+++ b/src/chisel_spec_generator.py
@@ -295,8 +295,15 @@ def _load_json_file(path, description):
         raise ValueError(f"{description} at {path} is not valid JSON: {exc}") from exc
 
 
-def _groups_json_is_usable(groups_path):
-    """Return True when groups.json is complete enough to resume from."""
+def _groups_json_is_usable(groups_path, required_exts=None):
+    """Return True when groups.json is complete enough to resume from.
+
+    ``required_exts`` names the calling flow's source extensions: a manifest
+    left behind by ANOTHER HDL flow in the same project (e.g. a Chisel
+    groups.json found by ``--hardware --verilog --resume``) lists no matching
+    sources, and reusing it would make the run silently spec nothing —
+    rejecting it here makes resume fall back to rerunning setup instead.
+    """
     try:
         groups = _load_json_file(groups_path, "groups.json")
     except (OSError, ValueError) as exc:
@@ -318,6 +325,23 @@ def _groups_json_is_usable(groups_path):
         if not isinstance(sub.get("source_groups", []), list):
             logging.warning("Cannot resume from groups.json: subsystem %s source_groups is not a list.", idx)
             return False
+
+    if required_exts is not None:
+        for sub in subsystems:
+            for group in sub.get("source_groups", []):
+                if not isinstance(group, dict):
+                    continue
+                for src in group.get("source_files", []) or []:
+                    base = os.path.basename(str(src))
+                    ext = base.rsplit(".", 1)[-1].lower() if "." in base else ""
+                    if ext in required_exts:
+                        return True
+        logging.warning(
+            "Cannot resume from groups.json: it lists no source file with "
+            "extension(s) %s — it likely belongs to a different HDL flow.",
+            sorted(required_exts),
+        )
+        return False
 
     return True
 
@@ -632,7 +656,9 @@ def run_chisel_spec_generation(proj_dir, resume=False):
 
     # Clean files from the previous run, unless resuming an interrupted run.
     groups_path = os.path.join(work_dir, "groups.json")
-    resume_setup = resume and os.path.exists(groups_path) and _groups_json_is_usable(groups_path)
+    resume_setup = resume and os.path.exists(groups_path) and _groups_json_is_usable(
+        groups_path, required_exts={"scala", "sc"}
+    )
     if resume:
         if resume_setup:
             print("[Chisel] Resume: preserving existing fm_agent/ workspace "
@@ -691,7 +717,7 @@ def run_chisel_spec_generation(proj_dir, resume=False):
         except subprocess.CalledProcessError as e:
             logging.warning(f"Stage 2 attempt {attempt}: opencode exited with code {e.returncode}")
 
-        if _groups_json_is_usable(groups_path):
+        if _groups_json_is_usable(groups_path, required_exts={"scala", "sc"}):
             break
 
         if attempt < OPENCODE_MAX_RETRIES:

--- a/src/chisel_spec_generator.py
+++ b/src/chisel_spec_generator.py
@@ -408,6 +408,41 @@ def _normalize_groups_source_paths(work_dir, proj_dir):
     return unresolved
 
 
+def _filter_phase_source_files(work_dir, allowed_exts, label):
+    """Drop phases.json source files whose extension is outside the flow.
+
+    The setup LLM sometimes mixes other supported source files into an HDL
+    source group (e.g. ``["Top.scala", "Helper.java"]``). Left in place, the
+    foreign files are extracted as software units whose batch prompts use the
+    embedded ``[SPEC]`` format, while the hardware runner waits for standalone
+    ``_spec.md``/``_info.md`` outputs that never appear — retrying until the
+    layer fails. Returns the dropped file names (already logged).
+    """
+    phases_path = os.path.join(work_dir, "phases.json")
+    data = _load_json_file(phases_path, "phases.json")
+    dropped = []
+    for phase in data.get("phases", []):
+        for module in phase.get("modules", []):
+            kept = []
+            for src in module.get("source_files", []):
+                base = os.path.basename(str(src))
+                ext = base.rsplit(".", 1)[-1].lower() if "." in base else ""
+                if ext in allowed_exts:
+                    kept.append(src)
+                else:
+                    dropped.append(src)
+            module["source_files"] = kept
+    if dropped:
+        logging.warning(
+            "[%s] Dropped %d non-%s source file(s) from phases.json "
+            "(the hardware flow cannot spec them): %s",
+            label, len(dropped), label, ", ".join(map(str, dropped[:10])),
+        )
+        with open(phases_path, "w") as f:
+            json.dump(data, f, indent=2)
+    return dropped
+
+
 def _groups_to_phases(work_dir):
     """Translate ``fm_agent/groups.json`` (subsystems) into the ``phases.json``
     schema the extraction / layer / batch tooling expects.
@@ -520,6 +555,53 @@ def _has_scala_source(proj_dir):
             if fname.endswith('.scala'):
                 return True
     return False
+
+
+def _report_undocumented_submodules(work_dir, info_path_fn, label):
+    """Advisory (report only): list modules whose call graph shows submodules
+    but whose info document lacks a parseable ``# Submodule:`` entry for them.
+
+    Deliberately NOT enforced through readiness: graph edges can be noisy
+    (Chisel companion objects, member access) and hard enforcement deadlocks
+    genuine leaf modules — a human reading the summary can judge. Dedup
+    suffixes (``Control_1``) are stripped, since info headings use declared
+    names. Returns ``[(module_fqn, [missing names...]), ...]``.
+    """
+    spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
+    if not os.path.isdir(spec_prompts_dir):
+        return []
+    gaps = []
+    for fname in sorted(os.listdir(spec_prompts_dir)):
+        if not re.match(r"phase_\d+_topdown_layers\.json$", fname):
+            continue
+        layers_data = _load_json_file(os.path.join(spec_prompts_dir, fname), fname)
+        for layer in layers_data.get("layers", []):
+            for fn in layer.get("functions", []):
+                callees = fn.get("all_callees") or []
+                if not callees:
+                    continue
+                info_path = info_path_fn(os.path.join(work_dir, fn["file"]))
+                try:
+                    with open(info_path, "r", errors="replace") as f:
+                        content = f.read()
+                except OSError:
+                    continue  # a missing info file is readiness's problem
+                headings = set(_SUBMODULE_HEADING_RE.findall(content))
+                expected = {
+                    re.sub(r"_\d+$", "", str(c).split("::")[-1])
+                    for c in callees
+                }
+                missing = sorted(e for e in expected if e and e not in headings)
+                if missing:
+                    gaps.append((fn["name"], missing))
+    if gaps:
+        print(f"[{label}] ADVISORY: {len(gaps)} module info document(s) lack "
+              f"entries for graph-detected submodules (report only):")
+        for name, missing in gaps[:20]:
+            print(f"[{label}]   {name}: missing {', '.join(missing)}")
+        if len(gaps) > 20:
+            print(f"[{label}]   ... and {len(gaps) - 20} more")
+    return gaps
 
 
 def run_chisel_spec_generation(proj_dir, resume=False):
@@ -640,8 +722,10 @@ def run_chisel_spec_generation(proj_dir, resume=False):
             f"First few: {unresolved[:5]}"
         )
 
-    # Bridge Chisel artifacts -> the generic-pipeline schema.
+    # Bridge Chisel artifacts -> the generic-pipeline schema. Foreign source
+    # files the setup LLM mixed into HDL groups are dropped with a warning.
     _groups_to_phases(work_dir)
+    _filter_phase_source_files(work_dir, {"scala", "sc"}, "Chisel")
 
     # Deduplicate source files across phases before aliasing subsystem context.
     # Otherwise phase_NN_types.txt can point at a subsystem that was removed and
@@ -707,22 +791,14 @@ def run_chisel_spec_generation(proj_dir, resume=False):
         layers_data = _load_json_file(layers_json_path, f"topdown layers for subsystem {phase_num}")
         total_layers = layers_data.get("total_layers", 1)
 
-        # Modules whose call graph shows submodules must not satisfy readiness
-        # with a '(no submodules)' info stub. Keyed both by the proj_dir-
-        # relative path (batch functions) and the input_dir-relative path
-        # (layer_files readiness counts).
-        _with_subs = {
-            fn["file"]
-            for layer in layers_data.get("layers", [])
-            for fn in layer.get("functions", [])
-            if fn.get("all_callees")
-        }
-        expects_submodules = {
-            os.path.relpath(os.path.join(work_dir, f), proj_dir) for f in _with_subs
-        }
-        expects_rel = {
-            os.path.relpath(os.path.join(work_dir, f), input_dir) for f in _with_subs
-        }
+        # Unlike Verilog (whose edges are precise instantiations), Chisel
+        # all_callees include companion-object and member-access noise —
+        # enforcing the non-leaf info rule on them deadlocks genuine leaf
+        # modules (their truthful '(no submodules)' info is deleted on every
+        # retry). Chisel therefore does NOT gate readiness on the graph; the
+        # end-of-run advisory report surfaces undocumented submodules instead.
+        expects_submodules = frozenset()
+        expects_rel = frozenset()
 
         batch_dir = os.path.join(
             spec_prompts_dir,
@@ -946,4 +1022,5 @@ def run_chisel_spec_generation(proj_dir, resume=False):
                 )
                 sys.exit(1)
 
+    _report_undocumented_submodules(work_dir, chisel_info_path, "Chisel")
     print("[Chisel] Done. Generated Chisel module spec/info files only; skipped reasoning and bug validation.")

--- a/src/chisel_support.py
+++ b/src/chisel_support.py
@@ -45,7 +45,7 @@ _CHISEL_SPEC_MIN_BYTES = 200
 
 # A parseable submodule entry heading — the exact per-line shape
 # generate_batch_prompts parses caller expectations from.
-_SUBMODULE_HEADING_RE = re.compile(r"^#[ \t]*Submodule:[ \t]*\S+[ \t]*$", re.M)
+_SUBMODULE_HEADING_RE = re.compile(r"^#[ \t]*Submodule:[ \t]*(\S+)[ \t]*$", re.M)
 
 
 def chisel_spec_path(module_file_path):

--- a/src/chisel_support.py
+++ b/src/chisel_support.py
@@ -43,6 +43,10 @@ import re
 # considered a real spec rather than an empty stub.
 _CHISEL_SPEC_MIN_BYTES = 200
 
+# A parseable submodule entry heading — the exact per-line shape
+# generate_batch_prompts parses caller expectations from.
+_SUBMODULE_HEADING_RE = re.compile(r"^#[ \t]*Submodule:[ \t]*\S+[ \t]*$", re.M)
+
 
 def chisel_spec_path(module_file_path):
     """Return the standalone spec ``.md`` path for an extracted Chisel module.
@@ -93,7 +97,7 @@ def _chisel_info_ready(path, allow_no_submodules=True):
         return (
             _chisel_markdown_ready(path)
             and "(no submodules)" not in content
-            and "# Submodule:" in content
+            and _SUBMODULE_HEADING_RE.search(content) is not None
         )
     if _chisel_markdown_ready(path):
         return True

--- a/src/chisel_support.py
+++ b/src/chisel_support.py
@@ -80,18 +80,23 @@ def _chisel_info_ready(path, allow_no_submodules=True):
     the anti-stub byte threshold.
 
     Pass ``allow_no_submodules=False`` for modules whose call graph shows
-    submodules: their info must document each submodule, so the small stub
-    must not satisfy readiness.
+    submodules: their info must contain at least one ``# Submodule:`` entry
+    and must not claim ``(no submodules)`` — regardless of file size, so a
+    padded stub cannot slip through the byte threshold.
     """
-    if _chisel_markdown_ready(path):
-        return True
-    if not allow_no_submodules:
-        return False
     try:
         with open(path, "r", errors="replace") as f:
             content = f.read()
     except OSError:
         return False
+    if not allow_no_submodules:
+        return (
+            _chisel_markdown_ready(path)
+            and "(no submodules)" not in content
+            and "# Submodule:" in content
+        )
+    if _chisel_markdown_ready(path):
+        return True
     return "#" in content and "(no submodules)" in content
 
 

--- a/src/chisel_support.py
+++ b/src/chisel_support.py
@@ -157,7 +157,7 @@ CHISEL_EXT_TO_LANG = {
 # src/test/scala (already caught by the test-dir check) but are also commonly
 # named *Spec/*Test/*Tester regardless of directory.
 CHISEL_TEST_FILE_PATTERNS = [
-    re.compile(r'^.*(?:Spec|Test|Tester)\.scala$'),
+    re.compile(r'^.*(?:Spec|Test|Tester)\.(?:scala|sc)$'),
 ]
 
 # Modifiers that may precede a top-level declaration keyword.
@@ -175,6 +175,24 @@ _CHISEL_DECL_RE = re.compile(
     r'(?P<kind>class|object|trait|def)\s+'
     r'(?P<name>[A-Za-z_$][\w$]*)'
 )
+
+
+def chisel_declared_name(text):
+    """Declared name of the first top-level declaration in an extracted unit.
+
+    Uses the SAME regex the extractor uses (``_CHISEL_DECL_RE``, scoped
+    modifiers like ``private[chisel]`` included) on the SAME comment-masked
+    text — re-deriving 'what counts as a declaration' with a second regex or
+    a second text preparation is exactly how declared names and file stems
+    drift apart. The extractor deduplicates same-named units by renaming the
+    FILE, never the declaration, so declared-name != file-stem is the proof
+    that a unit is a dedup alias.
+    """
+    for raw in strip_chisel_comments(text).splitlines():
+        m = _CHISEL_DECL_RE.match(raw.strip())
+        if m:
+            return m.group("name")
+    return None
 
 # Trailing tokens that mean "this signature continues on the next line".
 _CONT_WORDS = ("extends", "with")

--- a/src/extract.py
+++ b/src/extract.py
@@ -581,6 +581,79 @@ def extract_functions_from_file(filepath, lang_key):
     return results
 
 
+def _remove_stale_hdl_outputs(out_file, new_source, lang_cfg):
+    """Delete standalone ``_spec.md``/``_info.md`` siblings when the extracted
+    unit's content is about to change.
+
+    HDL specs are written against the extracted unit exactly as the agent read
+    it — the unit is written only here and never modified in between — so the
+    on-disk unit IS the record of which source version a surviving spec
+    describes. When re-extraction (``--resume`` after a source edit, or a
+    rerun setup) produces different content, the sibling documents are
+    definitionally stale: keeping them makes the run report success with
+    specs for the OLD source. Identical content keeps them — that is the
+    resume contract. Scoped to the standalone HDL outputs; the software
+    pipeline embeds specs in the unit itself and owns no sibling Markdown.
+
+    Deliberate stop-loss line: staleness is judged by UNIT CONTENT ONLY,
+    never by domain context. Batch prompts also read the domain context
+    (engine overview / phase types), but regenerated context prose never
+    reproduces byte-identically, so invalidating specs on context changes
+    would delete EVERY completed spec on every rerun setup — gutting
+    --resume for the corrupt-manifest case. The unit is the normative
+    object a spec describes; a checklist-valid spec of an unchanged unit
+    stays valid under refreshed background prose.
+    """
+    if lang_cfg.get("body") not in ("chisel", "verilog"):
+        return
+    if not os.path.exists(out_file):
+        return
+    try:
+        with open(out_file, 'r', errors='replace') as f:
+            old_source = f.read()
+    except OSError:
+        return
+    if old_source == new_source:
+        return
+    stem = os.path.splitext(out_file)[0]
+    for sibling in (stem + "_spec.md", stem + "_info.md"):
+        if os.path.exists(sibling):
+            logging.warning(
+                "Extracted unit content changed for %s; stale standalone "
+                "spec/info removed: %s", out_file, sibling
+            )
+            try:
+                os.remove(sibling)
+            except OSError as exc:
+                logging.warning("Could not remove stale output %s: %s", sibling, exc)
+
+
+def load_units_manifest(work_dir):
+    """Return the source->units mapping written by the last extraction round.
+
+    ``extracted_units.json`` records what the CURRENT sources actually
+    produce; phase-file consumers prefer it over directory enumeration so
+    stale units left behind by previous rounds are never consumed. Returns
+    None when the manifest is absent or unreadable — callers then fall back
+    to enumeration (pre-manifest workspaces; every pipeline flow runs
+    extraction before consuming phase files, so in practice the manifest is
+    always fresh).
+    """
+    path = os.path.join(work_dir, "extracted_units.json")
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except OSError:
+        return None
+    except json.JSONDecodeError:
+        logging.warning(
+            "extracted_units.json is corrupt; falling back to directory enumeration."
+        )
+        return None
+    units = data.get("units")
+    return units if isinstance(units, dict) else None
+
+
 def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     """Run function extraction on a project directory.
 
@@ -603,15 +676,25 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     source_files = []
     for phase in phases_data.get("phases", []):
         for module in phase.get("modules", []):
-            for sf in module.get("source_files", []):
+            srcs = module.get("source_files", [])
+            if isinstance(srcs, str):
+                srcs = [srcs]
+            for sf in srcs:
                 source_files.append(sf)
 
     output_base = os.path.join(work_dir, "extracted_functions")
     written = 0
     skipped = 0
     errors = []
+    # Single source of truth for "what did THIS round actually produce":
+    # consumers (_get_phase_files, topdown collection) read the manifest
+    # instead of enumerating directories, so stale files left by previous
+    # rounds (deleted/renamed modules, vanished sources, zero-unit results)
+    # are never consumed — and never need destructive cleanup.
+    manifest_units = {}
 
     for src_rel in source_files:
+        manifest_units.setdefault(src_rel, [])
         # Skip test files
         if _is_test_file(src_rel):
             if verbose:
@@ -651,6 +734,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
 
         for func_name, func_source in funcs:
             out_file = os.path.join(out_dir, f"{func_name}.{ext}")
+            manifest_units[src_rel].append(os.path.relpath(out_file, output_base))
 
             # Check if file already has spec marker
             if not force and os.path.exists(out_file):
@@ -665,11 +749,15 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
                 except OSError:
                     pass
 
+            _remove_stale_hdl_outputs(out_file, func_source, lang_cfg)
             with open(out_file, 'w') as f:
                 f.write(func_source)
             written += 1
             if verbose:
                 print(f"  WRITE: {os.path.relpath(out_file, proj_dir)}")
+
+    with open(os.path.join(work_dir, "extracted_units.json"), "w") as f:
+        json.dump({"units": {k: sorted(v) for k, v in manifest_units.items()}}, f, indent=2)
 
     print(f"Extraction complete: {written} written, {skipped} skipped.")
 

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -126,10 +126,15 @@ def extract_submodule_spec_from_chisel_info(module_file: Path, submodule_fqn: st
     # The extractor deduplicates same-named units (companion object + class)
     # by suffixing later ones with _<n>, but info headings use the DECLARED
     # name — fall back to the suffix-stripped stem when the exact one misses.
+    # The dedup suffix only arises for Scala companion pairs, so the fallback
+    # is gated on the caller being a Scala unit: genuine Verilog module names
+    # routinely end in _<digits> (fifo_64), and stripping those would hand a
+    # module the WRONG caller contract.
     candidates = [stem]
-    stripped = re.sub(r"_\d+$", "", stem)
-    if stripped and stripped != stem:
-        candidates.append(stripped)
+    if module_file.suffix in (".scala", ".sc"):
+        stripped = re.sub(r"_\d+$", "", stem)
+        if stripped and stripped != stem:
+            candidates.append(stripped)
     entries: Dict[str, List[str]] = {}
     current: Optional[List[str]] = None
     for line in content.splitlines():

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -109,7 +109,9 @@ def standalone_info_path(module_file: Path) -> Path:
     return module_file.with_name(module_file.stem + "_info.md")
 
 
-def extract_submodule_spec_from_chisel_info(module_file: Path, submodule_fqn: str) -> Optional[str]:
+def extract_submodule_spec_from_chisel_info(
+    module_file: Path, submodule_fqn: str, submodule_declared: Optional[str] = None
+) -> Optional[str]:
     """Return the expected-spec entry for ``submodule_fqn`` from a Chisel
     ``<stem>_info.md`` document, or None.
 
@@ -124,17 +126,17 @@ def extract_submodule_spec_from_chisel_info(module_file: Path, submodule_fqn: st
     content = info_file.read_text(errors="replace")
     stem = submodule_fqn.split("::")[-1]
     # The extractor deduplicates same-named units (companion object + class)
-    # by suffixing later ones with _<n>, but info headings use the DECLARED
-    # name — fall back to the suffix-stripped stem when the exact one misses.
-    # The dedup suffix only arises for Scala companion pairs, so the fallback
-    # is gated on the caller being a Scala unit: genuine Verilog module names
-    # routinely end in _<digits> (fifo_64), and stripping those would hand a
-    # module the WRONG caller contract.
+    # by renaming the FILE with a _<n> suffix, but info headings use the
+    # DECLARED name. ``submodule_declared`` is that name, stamped into the
+    # layer metadata by generate_topdown_layers using the extractor's own
+    # declaration regex (this script runs as a standalone workspace copy and
+    # must not re-derive it). declared != stem is the proof of a dedup
+    # alias; a genuine module whose name merely ends in digits (Chisel
+    # Stage_1, Verilog fifo_64) declares its own stem, so no fallback fires
+    # and it can never receive another module's caller contract.
     candidates = [stem]
-    if module_file.suffix in (".scala", ".sc"):
-        stripped = re.sub(r"_\d+$", "", stem)
-        if stripped and stripped != stem:
-            candidates.append(stripped)
+    if submodule_declared and submodule_declared != stem:
+        candidates.append(submodule_declared)
     entries: Dict[str, List[str]] = {}
     current: Optional[List[str]] = None
     for line in content.splitlines():
@@ -240,12 +242,23 @@ def build_ext_to_lang(exts: List[str], languages: List[str]) -> Dict[str, str]:
     Chisel setup usually records languages=["chisel"] and file_extensions=["scala"].
     If additional Scala extensions are listed, they should still map to Chisel.
     """
+    if isinstance(exts, str):
+        exts = [exts]
+    if isinstance(languages, str):
+        languages = [languages]
     normalized_exts = [ext.lower().lstrip(".") for ext in exts]
     normalized_langs = [lang.lower() for lang in languages]
     if "chisel" in normalized_langs:
-        return {ext: "chisel" for ext in normalized_exts or ["scala"]}
+        # Cover the whole (two-element) Chisel extension universe rather than
+        # trusting the LLM-declared list: an undeclared .sc would otherwise
+        # be detected as non-hardware and get an embedded-[SPEC] software
+        # prompt the Chisel runner never accepts.
+        return {ext: "chisel" for ext in set(normalized_exts) | {"scala", "sc"}}
     if "verilog" in normalized_langs or "systemverilog" in normalized_langs:
-        return {ext: "verilog" for ext in normalized_exts or ["v", "sv"]}
+        # Same rationale as the Chisel branch: cover the whole (three-element)
+        # Verilog extension universe so a degenerate declared list can never
+        # route .svh/.v/.sv away from the hardware spec path.
+        return {ext: "verilog" for ext in set(normalized_exts) | {"v", "sv", "svh"}}
     return {ext: lang for ext, lang in zip(normalized_exts, normalized_langs)}
 
 
@@ -324,7 +337,9 @@ def build_prompt(
                 spec_block = extract_standalone_spec(caller_file)
                 if spec_block and (caller_name, spec_block) not in caller_specs:
                     caller_specs.append((caller_name, spec_block))
-                entry = extract_submodule_spec_from_chisel_info(caller_file, fn_name)
+                entry = extract_submodule_spec_from_chisel_info(
+                    caller_file, fn_name, submodule_declared=fn.get("declared_name")
+                )
                 if entry:
                     caller_expectations.setdefault(fn_name, []).append((caller_name, entry))
                 continue

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -123,21 +123,29 @@ def extract_submodule_spec_from_chisel_info(module_file: Path, submodule_fqn: st
         return None
     content = info_file.read_text(errors="replace")
     stem = submodule_fqn.split("::")[-1]
-    entry_lines: Optional[List[str]] = None
+    # The extractor deduplicates same-named units (companion object + class)
+    # by suffixing later ones with _<n>, but info headings use the DECLARED
+    # name — fall back to the suffix-stripped stem when the exact one misses.
+    candidates = [stem]
+    stripped = re.sub(r"_\d+$", "", stem)
+    if stripped and stripped != stem:
+        candidates.append(stripped)
+    entries: Dict[str, List[str]] = {}
+    current: Optional[List[str]] = None
     for line in content.splitlines():
         m = re.match(r"^#\s*Submodule:\s*(\S+)\s*$", line)
         if m:
-            if entry_lines is not None:
-                break
-            if m.group(1) == stem:
-                entry_lines = [line]
+            current = entries.setdefault(m.group(1), [line])
             continue
-        if entry_lines is not None:
-            entry_lines.append(line)
-    if not entry_lines:
-        return None
-    entry = "\n".join(entry_lines).strip()
-    return entry or None
+        if current is not None:
+            current.append(line)
+    for name in candidates:
+        entry_lines = entries.get(name)
+        if entry_lines:
+            entry = "\n".join(entry_lines).strip()
+            if entry:
+                return entry
+    return None
 
 
 def extract_info_block(filepath: Path) -> Optional[str]:

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -6,16 +6,16 @@ from pathlib import Path
 from collections import defaultdict
 
 try:
-    from src.extract import EXT_TO_LANG, LANG_CONFIG
-    from src.chisel_support import find_chisel_call_sites, strip_chisel_comments
-    from src.verilog_support import find_verilog_call_sites
+    from src.extract import EXT_TO_LANG, LANG_CONFIG, load_units_manifest
+    from src.chisel_support import chisel_declared_name, find_chisel_call_sites, strip_chisel_comments
+    from src.verilog_support import find_verilog_call_sites, verilog_declared_name
 except ModuleNotFoundError:
     # Allow standalone execution as `python3 src/generate_topdown_layers.py`.
     import sys
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-    from src.extract import EXT_TO_LANG, LANG_CONFIG
-    from src.chisel_support import find_chisel_call_sites, strip_chisel_comments
-    from src.verilog_support import find_verilog_call_sites
+    from src.extract import EXT_TO_LANG, LANG_CONFIG, load_units_manifest
+    from src.chisel_support import chisel_declared_name, find_chisel_call_sites, strip_chisel_comments
+    from src.verilog_support import find_verilog_call_sites, verilog_declared_name
 
 
 # ---------------------------------------------------------------------------
@@ -36,14 +36,29 @@ def _load_phases(proj_dir):
 def _collect_phase_files(proj_dir, phase_data):
     """For a phase, collect all extracted function file paths.
 
-    Returns list of (file_path, module_name) tuples.
+    Returns list of (file_path, module_name) tuples. Prefers the extraction
+    round's manifest (extracted_units.json) so stale units from previous
+    rounds never enter the layer graph; enumeration is the fallback for
+    pre-manifest workspaces.
     """
     extracted_base = os.path.join(proj_dir, "extracted_functions")
+    manifest = load_units_manifest(proj_dir)
     results = []
 
     for module in phase_data.get("modules", []):
         module_name = module["name"]
-        for src_file in module.get("source_files", []):
+        src_files = module.get("source_files", [])
+        if isinstance(src_files, str):
+            # Same normalization as _get_phase_files: iterating a bare string
+            # walks characters, and '/' collapses os.path.join to the root.
+            src_files = [src_files]
+        for src_file in src_files:
+            if manifest is not None:
+                for rel in sorted(manifest.get(src_file, [])):
+                    fpath = os.path.join(extracted_base, rel)
+                    if os.path.isfile(fpath):
+                        results.append((fpath, module_name))
+                continue
             # Derive extracted directory: xxx/yyy/zzz.ext -> xxx/yyy/zzz-ext
             src_dir = os.path.dirname(src_file)
             src_base = os.path.basename(src_file)
@@ -126,6 +141,29 @@ def _detect_lang_from_ext(filepath):
     base = os.path.basename(filepath)
     ext = base.rsplit(".", 1)[-1] if "." in base else ""
     return EXT_TO_LANG.get(ext)
+
+
+def _declared_name_for(filepath):
+    """Name declared INSIDE an extracted HDL unit file, or None.
+
+    Stamped into the layer metadata as ``declared_name`` — the single place
+    it is derived. Consumers (caller-expectation lookup, the advisory) read
+    the field instead of re-parsing files with their own regexes: the
+    extractor deduplicates same-named units by renaming the FILE, never the
+    declaration, so declared-name != file-stem proves a dedup alias.
+    """
+    lang_key = _detect_lang_from_ext(filepath)
+    body = LANG_CONFIG.get(lang_key, {}).get("body")
+    if body not in ("chisel", "verilog"):
+        return None
+    try:
+        with open(filepath, "r", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return None
+    if body == "chisel":
+        return chisel_declared_name(text)
+    return verilog_declared_name(text)
 
 
 def _strip_comments_from_source(text, lang_key):
@@ -673,6 +711,7 @@ def generate_topdown_layers(proj_dir, phase_numbers=None):
                 filepath = file_map[fqn]
                 rel_path = os.path.relpath(filepath, proj_dir)
                 unit = module_map.get(fqn, "")
+                declared = _declared_name_for(filepath)
 
                 phase_callers = sorted(callers_map.get(fqn, set()) & phase_fqns)
                 phase_callees = sorted(callees_map.get(fqn, set()) & phase_fqns)
@@ -682,6 +721,7 @@ def generate_topdown_layers(proj_dir, phase_numbers=None):
                     "name": fqn,
                     "file": rel_path,
                     "unit": unit,
+                    "declared_name": declared,
                     phase_callers_key: phase_callers,
                     phase_callees_key: phase_callees,
                     "all_callees": all_callees,

--- a/src/verilog_spec_generator.py
+++ b/src/verilog_spec_generator.py
@@ -105,16 +105,23 @@ def _force_verilog_phase_languages(work_dir):
         json.dump(data, f, indent=2)
 
 
-def _remove_incomplete_verilog_outputs(module_path, expects_submodules=False):
+def _remove_incomplete_verilog_outputs(module_path, expected_submodules=frozenset()):
     """Delete spec/info outputs that exist but are incomplete (e.g. truncated).
 
     The retry prompt tells the agent to only generate outputs for modules that
     do not yet have both output files, so an incomplete file left in place
     would make every retry skip the module. Complete files (including a small
     legal ``(no submodules)`` info document for actual leaf modules) are kept.
+    An info missing one of ``expected_submodules``'s entries counts as
+    incomplete for the same reason: leaving it in place would strand the batch
+    in a bounded retry failure.
     """
     def _info_ready(path):
-        return _verilog_info_ready(path, allow_no_submodules=not expects_submodules)
+        return _verilog_info_ready(
+            path,
+            allow_no_submodules=not expected_submodules,
+            expected_submodules=expected_submodules,
+        )
 
     checks = (
         (verilog_spec_path(module_path), _verilog_markdown_ready),
@@ -131,7 +138,7 @@ def _remove_incomplete_verilog_outputs(module_path, expects_submodules=False):
                 logging.warning("Could not remove incomplete output %s: %s", path, exc)
 
 
-def _get_pending_batches_verilog(batches, proj_dir, expects_submodules=frozenset()):
+def _get_pending_batches_verilog(batches, proj_dir, expected_submodules=None):
     """Return batches that still have at least one module without a complete,
     valid spec/info output.
 
@@ -142,36 +149,49 @@ def _get_pending_batches_verilog(batches, proj_dir, expects_submodules=frozenset
     fail validation are deleted so the retry loop regenerates them instead of
     skipping modules whose output files merely exist.
 
-    ``expects_submodules`` lists the function rel-paths whose instantiation
-    graph shows submodules: for those, a ``(no submodules)`` info stub is
-    rejected (and removed) instead of accepted, so the children do not lose
-    their caller expectations downstream.
+    ``expected_submodules`` maps function rel-paths to the module names their
+    instantiation graph shows as submodules: for those, a ``(no submodules)``
+    info stub is rejected, and the info must contain a ``# Submodule:`` entry
+    for EVERY expected name (Verilog edges are precise — verible CST,
+    in-project modules only — unlike Chisel's, which stay advisory). Invalid
+    infos are removed and the miss is fed back with the FULL required set, so
+    the next attempt regenerates a complete info instead of ping-ponging on
+    whichever single entry was last reported missing.
     """
+    expected_submodules = expected_submodules or {}
     pending = []
     for batch in batches:
         batch_pending = False
         validation_errors = []
         for func_rel in batch.get("functions", []):
             module_path = os.path.join(proj_dir, func_rel)
-            expects = func_rel in expects_submodules
-            if not verilog_spec_ready(module_path, expects_submodules=expects):
+            expected = expected_submodules.get(func_rel, frozenset())
+            if not verilog_spec_ready(module_path, expected_submodules=expected):
                 info_path = verilog_info_path(module_path)
-                if expects and os.path.exists(info_path):
+                if expected and os.path.exists(info_path):
                     try:
                         with open(info_path, "r", errors="replace") as f:
                             info_text = f.read()
                     except OSError:
                         info_text = ""
-                    if ("(no submodules)" in info_text
-                            or _SUBMODULE_HEADING_RE.search(info_text) is None):
+                    documented = set(_SUBMODULE_HEADING_RE.findall(info_text))
+                    if "(no submodules)" in info_text or not documented:
                         validation_errors.append(
                             f"{os.path.basename(info_path)}: this module instantiates "
                             f"other extracted modules — the info file must contain one "
                             f"'# Submodule: <name>' entry per instantiated submodule "
                             f"and must not claim '(no submodules)'"
                         )
+                    elif expected - documented:
+                        validation_errors.append(
+                            f"{os.path.basename(info_path)}: missing submodule "
+                            f"entries: {', '.join(sorted(expected - documented))}; "
+                            f"the regenerated info must contain one "
+                            f"'# Submodule: <name>' entry for EVERY required "
+                            f"entry: {', '.join(sorted(expected))}"
+                        )
                 _remove_incomplete_verilog_outputs(
-                    module_path, expects_submodules=expects
+                    module_path, expected_submodules=expected
                 )
                 batch_pending = True
                 continue
@@ -416,21 +436,25 @@ def run_verilog_spec_generation(proj_dir, resume=False):
         layers_data = _load_json_file(layers_json_path, f"topdown layers for subsystem {phase_num}")
         total_layers = layers_data.get("total_layers", 1)
 
-        # Modules whose instantiation graph shows submodules must not satisfy
-        # readiness with a '(no submodules)' info stub. Keyed both by the
-        # proj_dir-relative path (batch functions) and the input_dir-relative
-        # path (layer_files readiness counts).
+        # Modules whose instantiation graph shows submodules must document an
+        # info entry for EVERY instantiated module name (FQN tail, compared
+        # exactly — numeric suffixes like fifo_64 are real Verilog names, not
+        # dedup aliases). Keyed both by the proj_dir-relative path (batch
+        # functions) and the input_dir-relative path (layer_files readiness
+        # counts).
         _with_subs = {
-            fn["file"]
+            fn["file"]: {c.split("::")[-1] for c in fn["all_callees"]}
             for layer in layers_data.get("layers", [])
             for fn in layer.get("functions", [])
             if fn.get("all_callees")
         }
-        expects_submodules = {
-            os.path.relpath(os.path.join(work_dir, f), proj_dir) for f in _with_subs
+        expected_submodules = {
+            os.path.relpath(os.path.join(work_dir, f), proj_dir): names
+            for f, names in _with_subs.items()
         }
-        expects_rel = {
-            os.path.relpath(os.path.join(work_dir, f), input_dir) for f in _with_subs
+        expected_rel = {
+            os.path.relpath(os.path.join(work_dir, f), input_dir): names
+            for f, names in _with_subs.items()
         }
 
         batch_dir = os.path.join(
@@ -469,14 +493,14 @@ def run_verilog_spec_generation(proj_dir, resume=False):
 
             layer_complete = False
             for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
-                pending_batches = _get_pending_batches_verilog(all_batches, proj_dir, expects_submodules=expects_submodules)
+                pending_batches = _get_pending_batches_verilog(all_batches, proj_dir, expected_submodules=expected_submodules)
                 if not pending_batches:
                     layer_complete = True
                     break
 
                 ready_before = sum(
                     1 for rel in layer_files
-                    if verilog_spec_ready(os.path.join(input_dir, rel), expects_submodules=(rel in expects_rel))
+                    if verilog_spec_ready(os.path.join(input_dir, rel), expected_submodules=expected_rel.get(rel, frozenset()))
                 )
 
                 def _start_batch(batch_info):
@@ -499,12 +523,15 @@ def run_verilog_spec_generation(proj_dir, resume=False):
                     failed = batch_info.get("validation_errors") or []
                     if failed:
                         checklist_note = (
-                            " WARNING: the following previously generated specs FAILED the "
-                            "quality checklist and were deleted — regenerate them and fix "
-                            "exactly these issues (re-read the Coverage Tags rules in "
+                            " WARNING: the following previously generated outputs FAILED "
+                            "validation and were deleted — regenerate them and fix "
+                            "exactly these issues (for *_spec.md checklist failures, "
+                            "re-read the Coverage Tags rules in "
                             "fm_agent/spec_prompts/system_prompt.md: every tag is a plain "
                             "<FG-NAME>/<FC-NAME>/<CK-NAME> on its own line, sibling tag names "
-                            "must be unique, and the <FG-API> group is mandatory): "
+                            "must be unique, and the <FG-API> group is mandatory; for "
+                            "*_info.md failures, write one '# Submodule: <name>' section "
+                            "for EVERY required entry listed, not only the missing ones): "
                             + " | ".join(failed)
                         )
                     if attempt == 1 and not resume:
@@ -590,9 +617,9 @@ def run_verilog_spec_generation(proj_dir, resume=False):
 
                 ready_after = sum(
                     1 for rel in layer_files
-                    if verilog_spec_ready(os.path.join(input_dir, rel), expects_submodules=(rel in expects_rel))
+                    if verilog_spec_ready(os.path.join(input_dir, rel), expected_submodules=expected_rel.get(rel, frozenset()))
                 )
-                if not _get_pending_batches_verilog(all_batches, proj_dir, expects_submodules=expects_submodules):
+                if not _get_pending_batches_verilog(all_batches, proj_dir, expected_submodules=expected_submodules):
                     layer_complete = True
                     break
 
@@ -626,10 +653,10 @@ def run_verilog_spec_generation(proj_dir, resume=False):
                     )
                     sys.exit(1)
 
-            if not layer_complete and _get_pending_batches_verilog(all_batches, proj_dir, expects_submodules=expects_submodules):
+            if not layer_complete and _get_pending_batches_verilog(all_batches, proj_dir, expected_submodules=expected_submodules):
                 ready_count = sum(
                     1 for rel in layer_files
-                    if verilog_spec_ready(os.path.join(input_dir, rel), expects_submodules=(rel in expects_rel))
+                    if verilog_spec_ready(os.path.join(input_dir, rel), expected_submodules=expected_rel.get(rel, frozenset()))
                 )
                 print(
                     f"[Verilog] ERROR: Stage 4 Subsystem {phase_num} Layer {layer_idx} "

--- a/src/verilog_spec_generator.py
+++ b/src/verilog_spec_generator.py
@@ -40,6 +40,7 @@ from config import (
 )
 from src.file_utils import collect_file_names
 from src.verilog_support import (
+    _SUBMODULE_HEADING_RE,
     _verilog_info_ready,
     _verilog_markdown_ready,
     verilog_info_path,
@@ -158,7 +159,8 @@ def _get_pending_batches_verilog(batches, proj_dir, expects_submodules=frozenset
                             info_text = f.read()
                     except OSError:
                         info_text = ""
-                    if "(no submodules)" in info_text or "# Submodule:" not in info_text:
+                    if ("(no submodules)" in info_text
+                            or _SUBMODULE_HEADING_RE.search(info_text) is None):
                         validation_errors.append(
                             f"{os.path.basename(info_path)}: this module instantiates "
                             f"other extracted modules — the info file must contain one "
@@ -187,10 +189,16 @@ def _get_pending_batches_verilog(batches, proj_dir, expects_submodules=frozenset
                 )
                 batch_pending = True
         # Exposed to the retry prompt so the LLM knows WHAT failed the
-        # checklist — without feedback regeneration rarely converges.
-        batch["validation_errors"] = validation_errors
+        # checklist — without feedback regeneration rarely converges. The
+        # feedback must survive the retry loop's pre-launch rescan (which runs
+        # AFTER the offending files were deleted), so only overwrite it when
+        # new errors surface, and clear it once the batch completes.
+        if validation_errors:
+            batch["validation_errors"] = validation_errors
         if batch_pending:
             pending.append(batch)
+        else:
+            batch["validation_errors"] = []
     return pending
 
 

--- a/src/verilog_spec_generator.py
+++ b/src/verilog_spec_generator.py
@@ -92,10 +92,16 @@ def _force_verilog_phase_languages(work_dir):
     phases_path = os.path.join(work_dir, "phases.json")
     data = _load_json_file(phases_path, "phases.json")
     data["languages"] = ["verilog"]
-    exts = {str(e).lower().lstrip(".") for e in data.get("file_extensions", [])}
+    declared = data.get("file_extensions", [])
+    if isinstance(declared, str):
+        declared = [declared]
+    exts = {str(e).lower().lstrip(".") for e in declared}
     for phase in data.get("phases", []):
         for module in phase.get("modules", []):
-            for src in module.get("source_files", []):
+            srcs = module.get("source_files", [])
+            if isinstance(srcs, str):
+                srcs = [srcs]
+            for src in srcs:
                 base = os.path.basename(str(src))
                 if "." in base:
                     exts.add(base.rsplit(".", 1)[-1].lower())
@@ -157,17 +163,29 @@ def _get_pending_batches_verilog(batches, proj_dir, expected_submodules=None):
     infos are removed and the miss is fed back with the FULL required set, so
     the next attempt regenerates a complete info instead of ping-ponging on
     whichever single entry was last reported missing.
+
+    Design intent, pinned: this gate enforces the info document as a
+    DELIVERABLE — the design's submodule contracts must cover every
+    instantiated child, same-phase or not. It does NOT promise that every
+    callee prompt consumes every caller expectation: batch prompts propagate
+    expectations within a phase only, and cross-phase prompt propagation is
+    a recorded enhancement (upstream issue), not an unfinished part of this
+    feature. Weakening the gate to same-phase would delete correct
+    documentation to match a prompt limitation.
     """
     expected_submodules = expected_submodules or {}
     pending = []
     for batch in batches:
         batch_pending = False
-        validation_errors = []
+        feedback = batch.get("validation_errors")
+        feedback = dict(feedback) if isinstance(feedback, dict) else {}
         for func_rel in batch.get("functions", []):
             module_path = os.path.join(proj_dir, func_rel)
             expected = expected_submodules.get(func_rel, frozenset())
+            module_errors = []
             if not verilog_spec_ready(module_path, expected_submodules=expected):
                 info_path = verilog_info_path(module_path)
+                spec_ok = _verilog_markdown_ready(verilog_spec_path(module_path))
                 if expected and os.path.exists(info_path):
                     try:
                         with open(info_path, "r", errors="replace") as f:
@@ -176,24 +194,44 @@ def _get_pending_batches_verilog(batches, proj_dir, expected_submodules=None):
                         info_text = ""
                     documented = set(_SUBMODULE_HEADING_RE.findall(info_text))
                     if "(no submodules)" in info_text or not documented:
-                        validation_errors.append(
+                        module_errors.append(
                             f"{os.path.basename(info_path)}: this module instantiates "
                             f"other extracted modules — the info file must contain one "
                             f"'# Submodule: <name>' entry per instantiated submodule "
                             f"and must not claim '(no submodules)'"
                         )
                     elif expected - documented:
-                        validation_errors.append(
+                        module_errors.append(
                             f"{os.path.basename(info_path)}: missing submodule "
                             f"entries: {', '.join(sorted(expected - documented))}; "
                             f"the regenerated info must contain one "
                             f"'# Submodule: <name>' entry for EVERY required "
                             f"entry: {', '.join(sorted(expected))}"
                         )
+                if not module_errors and spec_ok:
+                    # verilog_spec_ready is False but the spec itself is fine
+                    # (no-expected leaf, or the per-name checks above found
+                    # nothing this round — e.g. their own info file was just
+                    # deleted by US, pending regeneration). Only report a
+                    # generic info blocker when the CURRENTLY recorded
+                    # feedback blames the spec specifically (now moot, since
+                    # the spec is fine) or there is none yet — otherwise a
+                    # more specific info diagnosis from a prior round (also
+                    # deleted pending regeneration) must survive via inertia,
+                    # not be replaced by a weaker generic message.
+                    spec_base = os.path.basename(verilog_spec_path(module_path))
+                    prior = feedback.get(func_rel) or []
+                    if not prior or any(spec_base in m for m in prior):
+                        module_errors.append(
+                            f"{os.path.basename(info_path)}: incomplete or missing "
+                            f"— regenerate it"
+                        )
                 _remove_incomplete_verilog_outputs(
                     module_path, expected_submodules=expected
                 )
                 batch_pending = True
+                if module_errors:
+                    feedback[func_rel] = module_errors
                 continue
             spec_path = verilog_spec_path(module_path)
             is_valid, spec_errors = validate_hw_spec(spec_path)
@@ -207,21 +245,23 @@ def _get_pending_batches_verilog(batches, proj_dir, expected_submodules=None):
                     os.remove(spec_path)
                 except OSError as exc:
                     logging.warning("Could not remove invalid spec %s: %s", spec_path, exc)
-                validation_errors.append(
+                feedback[func_rel] = [
                     f"{os.path.basename(spec_path)}: " + "; ".join(spec_errors[:3])
-                )
+                ]
                 batch_pending = True
-        # Exposed to the retry prompt so the LLM knows WHAT failed the
-        # checklist — without feedback regeneration rarely converges. The
-        # feedback must survive the retry loop's pre-launch rescan (which runs
-        # AFTER the offending files were deleted), so only overwrite it when
-        # new errors surface, and clear it once the batch completes.
-        if validation_errors:
-            batch["validation_errors"] = validation_errors
+            else:
+                # Ready and checklist-valid: this module is done — drop its
+                # stale feedback so the retry prompt stops demanding a fix
+                # for an issue that no longer exists.
+                feedback.pop(func_rel, None)
+        # Exposed to the retry prompt so the LLM knows WHAT failed — without
+        # feedback regeneration rarely converges. Keyed per module: an entry
+        # survives the pre-launch rescan (which runs AFTER the offending
+        # files were deleted) until ITS module passes, so a fixed module's
+        # errors do not ride along while batchmates are still regenerating.
+        batch["validation_errors"] = feedback if batch_pending else {}
         if batch_pending:
             pending.append(batch)
-        else:
-            batch["validation_errors"] = []
     return pending
 
 
@@ -399,6 +439,30 @@ def run_verilog_spec_generation(proj_dir, resume=False):
     # Judge emptiness by the CURRENT phases' files: stale units from a
     # previous run (preserved by --resume) must not smuggle the run past
     # this guard by making the whole-tree walk non-empty.
+    # A reused manifest that lists source files which no longer exist
+    # describes a PAST tree: renamed/deleted files mean the new names are
+    # absent from phases/topdown/batches entirely, so surviving sources
+    # would spec fine while the rest silently never appear (partial-missing
+    # is invisible to the zero-units guard below). Discard the stale
+    # manifest and rerun setup against the tree as it exists now; completed
+    # specs for surviving sources are preserved and reused. The recursive
+    # call starts with no groups.json, so resume_setup is False there and
+    # this cannot loop.
+    if resume_setup and any(
+        not os.path.exists(os.path.join(proj_dir, src))
+        for phase in phases_data["phases"]
+        for module in phase["modules"]
+        for src in module["source_files"]
+    ):
+        print("[Verilog] Resume: the reused groups.json points at missing "
+              "source files; discarding it and rerunning setup.")
+        try:
+            os.remove(groups_path)
+        except OSError:
+            pass
+        _reset_derived_state(work_dir)
+        return run_verilog_spec_generation(proj_dir, resume=True)
+
     if not any(
         _get_phase_files(phases_data, phase["phase"], input_dir)
         for phase in phases_data["phases"]
@@ -412,6 +476,25 @@ def run_verilog_spec_generation(proj_dir, resume=False):
 
     # --- Stage 4: Execute spec generation (per phase, per layer) ---
     print("[Verilog] Stage 4/4: Generating Verilog module specs...")
+    if os.environ.get("FM_AGENT_NO_VERIBLE"):
+        # The per-callee gate below is blocking specifically because
+        # verible's instantiation edges are precise (unlike Chisel's noisy
+        # edges, which is why THAT gate stays advisory). The regex fallback
+        # can only MISS edges (false negatives), never invent ones that
+        # don't exist — so a missed instantiation is invisible everywhere
+        # (topdown layers, the gate's expected-submodule set) and the gate
+        # cannot flag what it never learned exists. Downgrading the gate
+        # here would gain nothing (missed edges stay invisible to advisory
+        # mode too) while giving up enforcement on the edges the fallback
+        # DID find — so the gate stays blocking; this warning names the
+        # narrower guarantee instead.
+        print(
+            "[Verilog] WARNING: FM_AGENT_NO_VERIBLE=1 is set — instantiation "
+            "edges may be incomplete (the regex fallback misses one-line "
+            "modules and generate blocks). The submodule documentation gate "
+            "can only enforce the edges it detected; an undetected "
+            "submodule instantiation will not be flagged as missing."
+        )
     batch_md_src = os.path.join(md_dir, "workflow_spec_verilog.md")
     batch_md_dst = os.path.join(work_dir, "workflow_spec_verilog.md")
     shutil.copy2(batch_md_src, batch_md_dst)
@@ -520,8 +603,11 @@ def run_verilog_spec_generation(proj_dir, resume=False):
                     fm_reminder = ("IMPORTANT: fm_agent/ is your output workspace, not project source. "
                                    "Do NOT modify any existing project files.")
                     checklist_note = ""
-                    failed = batch_info.get("validation_errors") or []
+                    failed = batch_info.get("validation_errors") or {}
                     if failed:
+                        issues = " | ".join(
+                            msg for key in sorted(failed) for msg in failed[key]
+                        )
                         checklist_note = (
                             " WARNING: the following previously generated outputs FAILED "
                             "validation and were deleted — regenerate them and fix "
@@ -532,7 +618,7 @@ def run_verilog_spec_generation(proj_dir, resume=False):
                             "must be unique, and the <FG-API> group is mandatory; for "
                             "*_info.md failures, write one '# Submodule: <name>' section "
                             "for EVERY required entry listed, not only the missing ones): "
-                            + " | ".join(failed)
+                            + issues
                         )
                     if attempt == 1 and not resume:
                         prompt = (

--- a/src/verilog_spec_generator.py
+++ b/src/verilog_spec_generator.py
@@ -255,7 +255,7 @@ def run_verilog_spec_generation(proj_dir, resume=False):
 
     # Clean files from the previous run, unless resuming an interrupted run.
     groups_path = os.path.join(work_dir, "groups.json")
-    resume_setup = resume and os.path.exists(groups_path) and _groups_json_is_usable(groups_path, required_exts={"v", "sv", "svh"})
+    resume_setup = resume and os.path.exists(groups_path) and _groups_json_is_usable(groups_path, required_exts={"v", "sv", "svh"}, required_languages={"verilog", "systemverilog", "system_verilog"})
     if resume:
         if resume_setup:
             print("[Verilog] Resume: preserving existing fm_agent/ workspace "
@@ -311,7 +311,7 @@ def run_verilog_spec_generation(proj_dir, resume=False):
         except subprocess.CalledProcessError as e:
             logging.warning(f"Stage 1 attempt {attempt}: opencode exited with code {e.returncode}")
 
-        if _groups_json_is_usable(groups_path, required_exts={"v", "sv", "svh"}):
+        if _groups_json_is_usable(groups_path, required_exts={"v", "sv", "svh"}, required_languages={"verilog", "systemverilog", "system_verilog"}):
             break
 
         if attempt < OPENCODE_MAX_RETRIES:
@@ -629,5 +629,6 @@ def run_verilog_spec_generation(proj_dir, resume=False):
                 )
                 sys.exit(1)
 
-    _report_undocumented_submodules(work_dir, verilog_info_path, "Verilog")
+    _report_undocumented_submodules(work_dir, verilog_info_path, "Verilog",
+                                    strip_dedup_suffix=False)
     print("[Verilog] Done. Generated Verilog module spec/info files only; skipped reasoning and bug validation.")

--- a/src/verilog_spec_generator.py
+++ b/src/verilog_spec_generator.py
@@ -158,12 +158,12 @@ def _get_pending_batches_verilog(batches, proj_dir, expects_submodules=frozenset
                             info_text = f.read()
                     except OSError:
                         info_text = ""
-                    if "(no submodules)" in info_text:
+                    if "(no submodules)" in info_text or "# Submodule:" not in info_text:
                         validation_errors.append(
-                            f"{os.path.basename(info_path)}: claims '(no submodules)' "
-                            f"but this module instantiates other extracted modules — "
-                            f"write one '# Submodule: <name>' entry per instantiated "
-                            f"submodule"
+                            f"{os.path.basename(info_path)}: this module instantiates "
+                            f"other extracted modules — the info file must contain one "
+                            f"'# Submodule: <name>' entry per instantiated submodule "
+                            f"and must not claim '(no submodules)'"
                         )
                 _remove_incomplete_verilog_outputs(
                     module_path, expects_submodules=expects

--- a/src/verilog_spec_generator.py
+++ b/src/verilog_spec_generator.py
@@ -69,6 +69,7 @@ from src.chisel_spec_generator import (
     _normalize_chisel_domain_context as _normalize_hw_domain_context,
     _load_json_file,
     _report_undocumented_submodules,
+    _reset_domain_context,
 )
 from main import (
     _clean_previous_run,
@@ -263,9 +264,11 @@ def run_verilog_spec_generation(proj_dir, resume=False):
         elif os.path.exists(groups_path):
             print("[Verilog] Resume requested but groups.json is missing or incomplete; "
                   "rerunning setup in the existing fm_agent/ workspace.")
+            _reset_domain_context(work_dir)
         else:
             print("[Verilog] Resume requested but no groups.json found; "
                   "starting setup in the existing fm_agent/ workspace.")
+            _reset_domain_context(work_dir)
     else:
         _clean_previous_run(work_dir)
     os.makedirs(work_dir, exist_ok=True)

--- a/src/verilog_spec_generator.py
+++ b/src/verilog_spec_generator.py
@@ -69,7 +69,7 @@ from src.chisel_spec_generator import (
     _normalize_chisel_domain_context as _normalize_hw_domain_context,
     _load_json_file,
     _report_undocumented_submodules,
-    _reset_domain_context,
+    _reset_derived_state,
 )
 from main import (
     _clean_previous_run,
@@ -264,11 +264,11 @@ def run_verilog_spec_generation(proj_dir, resume=False):
         elif os.path.exists(groups_path):
             print("[Verilog] Resume requested but groups.json is missing or incomplete; "
                   "rerunning setup in the existing fm_agent/ workspace.")
-            _reset_domain_context(work_dir)
+            _reset_derived_state(work_dir)
         else:
             print("[Verilog] Resume requested but no groups.json found; "
                   "starting setup in the existing fm_agent/ workspace.")
-            _reset_domain_context(work_dir)
+            _reset_derived_state(work_dir)
     else:
         _clean_previous_run(work_dir)
     os.makedirs(work_dir, exist_ok=True)
@@ -373,15 +373,21 @@ def run_verilog_spec_generation(proj_dir, resume=False):
     _normalize_hw_domain_context(work_dir)
 
     print("[Verilog] Stage 2/4: Collecting file list...")
-    file_list = collect_file_names(input_dir, os.path.join(work_dir, "fm_agent_file_list.json"))
+    collect_file_names(input_dir, os.path.join(work_dir, "fm_agent_file_list.json"))
 
-    if not file_list:
+    phases_data = _load_json_file(os.path.join(work_dir, "phases.json"), "phases.json")
+    # Judge emptiness by the CURRENT phases' files: stale units from a
+    # previous run (preserved by --resume) must not smuggle the run past
+    # this guard by making the whole-tree walk non-empty.
+    if not any(
+        _get_phase_files(phases_data, phase["phase"], input_dir)
+        for phase in phases_data["phases"]
+    ):
         print("[Verilog] No modules found to spec. Skipping spec generation.")
         return
 
     # --- Stage 3: Generate topdown layers ---
     print("[Verilog] Stage 3/4: Generating topdown layers...")
-    phases_data = _load_json_file(os.path.join(work_dir, "phases.json"), "phases.json")
     generate_topdown_layers(work_dir)
 
     # --- Stage 4: Execute spec generation (per phase, per layer) ---

--- a/src/verilog_spec_generator.py
+++ b/src/verilog_spec_generator.py
@@ -62,11 +62,13 @@ from src.opencode_trace import (
 # imported under a neutral name.
 from src.chisel_spec_generator import (
     validate_chisel_spec as validate_hw_spec,
+    _filter_phase_source_files,
     _groups_json_is_usable,
     _normalize_groups_source_paths,
     _groups_to_phases,
     _normalize_chisel_domain_context as _normalize_hw_domain_context,
     _load_json_file,
+    _report_undocumented_submodules,
 )
 from main import (
     _clean_previous_run,
@@ -337,9 +339,12 @@ def run_verilog_spec_generation(proj_dir, resume=False):
             f"First few: {unresolved[:5]}"
         )
 
-    # Bridge groups.json -> the generic-pipeline schema, then force Verilog language.
+    # Bridge groups.json -> the generic-pipeline schema, then force Verilog
+    # language. Foreign source files the setup LLM mixed into HDL groups are
+    # dropped with a warning.
     _groups_to_phases(work_dir)
     _force_verilog_phase_languages(work_dir)
+    _filter_phase_source_files(work_dir, {"v", "sv", "svh"}, "Verilog")
 
     # Deduplicate source files across phases before aliasing subsystem context.
     _deduplicate_phases(work_dir)
@@ -624,4 +629,5 @@ def run_verilog_spec_generation(proj_dir, resume=False):
                 )
                 sys.exit(1)
 
+    _report_undocumented_submodules(work_dir, verilog_info_path, "Verilog")
     print("[Verilog] Done. Generated Verilog module spec/info files only; skipped reasoning and bug validation.")

--- a/src/verilog_spec_generator.py
+++ b/src/verilog_spec_generator.py
@@ -255,7 +255,7 @@ def run_verilog_spec_generation(proj_dir, resume=False):
 
     # Clean files from the previous run, unless resuming an interrupted run.
     groups_path = os.path.join(work_dir, "groups.json")
-    resume_setup = resume and os.path.exists(groups_path) and _groups_json_is_usable(groups_path)
+    resume_setup = resume and os.path.exists(groups_path) and _groups_json_is_usable(groups_path, required_exts={"v", "sv", "svh"})
     if resume:
         if resume_setup:
             print("[Verilog] Resume: preserving existing fm_agent/ workspace "
@@ -311,7 +311,7 @@ def run_verilog_spec_generation(proj_dir, resume=False):
         except subprocess.CalledProcessError as e:
             logging.warning(f"Stage 1 attempt {attempt}: opencode exited with code {e.returncode}")
 
-        if _groups_json_is_usable(groups_path):
+        if _groups_json_is_usable(groups_path, required_exts={"v", "sv", "svh"}):
             break
 
         if attempt < OPENCODE_MAX_RETRIES:

--- a/src/verilog_support.py
+++ b/src/verilog_support.py
@@ -70,18 +70,23 @@ def _verilog_info_ready(path, allow_no_submodules=True):
     the anti-stub byte threshold.
 
     Pass ``allow_no_submodules=False`` for modules whose instantiation graph
-    shows submodules: their info must document each submodule, so the small
-    stub must not satisfy readiness.
+    shows submodules: their info must contain at least one ``# Submodule:``
+    entry and must not claim ``(no submodules)`` — regardless of file size, so
+    a padded stub cannot slip through the byte threshold.
     """
-    if _verilog_markdown_ready(path):
-        return True
-    if not allow_no_submodules:
-        return False
     try:
         with open(path, "r", errors="replace") as f:
             content = f.read()
     except OSError:
         return False
+    if not allow_no_submodules:
+        return (
+            _verilog_markdown_ready(path)
+            and "(no submodules)" not in content
+            and "# Submodule:" in content
+        )
+    if _verilog_markdown_ready(path):
+        return True
     return "#" in content and "(no submodules)" in content
 
 

--- a/src/verilog_support.py
+++ b/src/verilog_support.py
@@ -163,10 +163,10 @@ VERILOG_EXT_TO_LANG = {
 # Test-bench files (e.g. foo_tb.sv, tb_foo.v, foo_test.sv) — excluded from spec
 # generation, mirroring CHISEL_TEST_FILE_PATTERNS.
 VERILOG_TEST_FILE_PATTERNS = [
-    re.compile(r'^.*_tb\.s?v$'),
-    re.compile(r'^tb_.*\.s?v$'),
-    re.compile(r'^.*_test\.s?v$'),
-    re.compile(r'^.*_testbench\.s?v$'),
+    re.compile(r'^.*_tb\.s?vh?$'),
+    re.compile(r'^tb_.*\.s?vh?$'),
+    re.compile(r'^.*_test\.s?vh?$'),
+    re.compile(r'^.*_testbench\.s?vh?$'),
 ]
 
 # Directories that conventionally hold Verilog testbench/simulation code with
@@ -423,6 +423,17 @@ _MODULE_KW_RE = re.compile(r'\bmodule\b')
 _ENDMODULE_RE = re.compile(r'\bendmodule\b')
 
 
+def verilog_declared_name(text):
+    """Name of the first module declared in an extracted Verilog unit.
+
+    Counterpart of :func:`src.chisel_support.chisel_declared_name`, using the
+    scanner's own module regex on comment-masked text. Verilog units normally
+    declare their file stem; a differing name marks an extractor dedup alias.
+    """
+    m = _MODULE_OPEN_RE.search(strip_verilog_comments(text))
+    return m.group(1) if m else None
+
+
 def _extract_via_scan(lines):
     """Fallback extractor: pair ``module NAME`` with the next ``endmodule``.
 
@@ -465,11 +476,15 @@ def extract_verilog_functions(lines, lang_key, lang_cfg):
     ``extract_chisel_functions``: returns a list of ``(name, start_idx,
     end_idx)`` inclusive line-index tuples, one per ``module ... endmodule``.
 
-    Uses verible when available, falling back to the pure-Python scanner.
+    Uses verible when available, falling back to the pure-Python scanner —
+    including when verible parses but recognizes ZERO modules: CST tag drift
+    (e.g. a verible upgrade) must not masquerade as an authoritative empty
+    result, because downstream a zero-unit extraction is what invalidates
+    stale outputs. The scanner gets the final word on emptiness.
     """
     text = "\n".join(lines)
     units = _extract_via_verible(text)
-    if units is not None:
+    if units:
         return units
     return _extract_via_scan(lines)
 
@@ -494,11 +509,8 @@ _INSTANTIATION_RE = re.compile(
 )
 
 
-def _find_verible_instantiations(text, known_stems, keywords):
-    """Return module-type names instantiated in ``text`` per the verible CST."""
-    tree = _run_verible_tree(text)
-    if tree is None:
-        return None
+def _walk_verible_instantiations(tree, known_stems, keywords):
+    """Collect instantiated module-type names from a verible CST."""
     found = set()
 
     def walk(node):
@@ -516,6 +528,67 @@ def _find_verible_instantiations(text, known_stems, keywords):
 
     walk(tree)
     return found
+
+
+# One-time canary verdict: None = untested, True = the instantiation walker
+# recognizes this verible version's tags, False = drifted (use the fallback).
+_EDGE_CANARY_RESULT = None
+
+_EDGE_CANARY_TEXT = "module __fm_canary(input a);\n  __fm_dep u0(a);\nendmodule\n"
+
+
+def _verible_edge_walker_works():
+    """Return False when this verible version's instantiation tags drifted.
+
+    The module-node sentinel in :func:`_find_verible_instantiations` catches
+    FULL tag drift, but partial drift — module tags intact, instantiation
+    tags renamed — yields a sane-looking tree with zero edges, failing the
+    per-callee gate open. The canary parses a fixture with a KNOWN
+    instantiation once per process: if verible parses it but the walker sees
+    no edge, edge-finding is declared drifted and every call falls back to
+    the regex. Real leaves are unaffected — their authority over emptiness
+    only stands while the walker demonstrably works.
+    """
+    global _EDGE_CANARY_RESULT
+    if _EDGE_CANARY_RESULT is None:
+        tree = _run_verible_tree(_EDGE_CANARY_TEXT)
+        if tree is None or not _collect_top_level_modules(tree):
+            # verible itself unusable here — the per-call None/no-module
+            # paths already route to the fallback; nothing to judge, and
+            # the verdict is deliberately NOT cached.
+            return True
+        _EDGE_CANARY_RESULT = bool(
+            _walk_verible_instantiations(tree, {"__fm_dep"}, frozenset())
+        )
+        if not _EDGE_CANARY_RESULT:
+            logging.warning(
+                "verible parses but its instantiation CST tags are not "
+                "recognized (version drift?); using the regex fallback for "
+                "edge detection."
+            )
+    return _EDGE_CANARY_RESULT
+
+
+def _find_verible_instantiations(text, known_stems, keywords):
+    """Return module-type names instantiated in ``text`` per the verible CST.
+
+    Returns None when the tree is unusable so the caller falls back to the
+    regex. ``text`` is always an extracted module unit, so a CST containing
+    no recognizable module declaration is drift (verible upgrade renamed
+    tags), not a real answer — an EMPTY edge set from such a tree would fail
+    the per-callee gate OPEN. A tree that does contain the module node keeps
+    authority over emptiness — real leaves must not be second-guessed by the
+    fallback's looser matching — provided the canary confirms the
+    instantiation walker recognizes this verible version at all.
+    """
+    tree = _run_verible_tree(text)
+    if tree is None:
+        return None
+    if not _collect_top_level_modules(tree):
+        return None
+    if not _verible_edge_walker_works():
+        return None
+    return _walk_verible_instantiations(tree, known_stems, keywords)
 
 
 def find_verilog_call_sites(text, known_stems, keywords):

--- a/src/verilog_support.py
+++ b/src/verilog_support.py
@@ -67,7 +67,7 @@ def _verilog_markdown_ready(path):
         return False
 
 
-def _verilog_info_ready(path, allow_no_submodules=True):
+def _verilog_info_ready(path, allow_no_submodules=True, expected_submodules=frozenset()):
     """Readiness for ``_info.md``: as ``_verilog_markdown_ready``, except that a
     leaf module's info file may legitimately be just a heading plus
     ``(no submodules)`` — the system prompt allows it — which is smaller than
@@ -76,7 +76,11 @@ def _verilog_info_ready(path, allow_no_submodules=True):
     Pass ``allow_no_submodules=False`` for modules whose instantiation graph
     shows submodules: their info must contain at least one ``# Submodule:``
     entry and must not claim ``(no submodules)`` — regardless of file size, so
-    a padded stub cannot slip through the byte threshold.
+    a padded stub cannot slip through the byte threshold. ``expected_submodules``
+    names the instantiated modules; every one of them must have its own
+    parseable heading, or the missing children would later be specced without
+    their caller expectations. Names are compared exactly — Verilog numeric
+    suffixes like ``fifo_64`` are real module names, never dedup aliases.
     """
     try:
         with open(path, "r", errors="replace") as f:
@@ -88,23 +92,27 @@ def _verilog_info_ready(path, allow_no_submodules=True):
             _verilog_markdown_ready(path)
             and "(no submodules)" not in content
             and _SUBMODULE_HEADING_RE.search(content) is not None
+            and set(expected_submodules) <= set(_SUBMODULE_HEADING_RE.findall(content))
         )
     if _verilog_markdown_ready(path):
         return True
     return "#" in content and "(no submodules)" in content
 
 
-def verilog_spec_ready(module_file_path, expects_submodules=False):
+def verilog_spec_ready(module_file_path, expected_submodules=frozenset()):
     """True when both standalone Verilog Markdown outputs are non-trivial.
 
-    ``expects_submodules=True`` (the instantiation graph shows the module has
-    submodules) disallows the small ``(no submodules)`` info stub.
+    A non-empty ``expected_submodules`` (the module's instantiated submodule
+    names per the instantiation graph) disallows the small ``(no submodules)``
+    info stub and requires a ``# Submodule:`` entry for EVERY expected name.
+    Pure check — never mutates files; the pending scan owns cleanup.
     """
     return (
         _verilog_markdown_ready(verilog_spec_path(module_file_path))
         and _verilog_info_ready(
             verilog_info_path(module_file_path),
-            allow_no_submodules=not expects_submodules,
+            allow_no_submodules=not expected_submodules,
+            expected_submodules=expected_submodules,
         )
     )
 

--- a/src/verilog_support.py
+++ b/src/verilog_support.py
@@ -38,6 +38,10 @@ import subprocess
 
 _VERILOG_SPEC_MIN_BYTES = 200
 
+# A parseable submodule entry heading — the exact per-line shape
+# generate_batch_prompts parses caller expectations from.
+_SUBMODULE_HEADING_RE = re.compile(r"^#[ \t]*Submodule:[ \t]*\S+[ \t]*$", re.M)
+
 
 def verilog_spec_path(module_file_path):
     """Return the standalone ``<module-stem>_spec.md`` path for an extracted module."""
@@ -83,7 +87,7 @@ def _verilog_info_ready(path, allow_no_submodules=True):
         return (
             _verilog_markdown_ready(path)
             and "(no submodules)" not in content
-            and "# Submodule:" in content
+            and _SUBMODULE_HEADING_RE.search(content) is not None
         )
     if _verilog_markdown_ready(path):
         return True

--- a/src/verilog_support.py
+++ b/src/verilog_support.py
@@ -40,7 +40,7 @@ _VERILOG_SPEC_MIN_BYTES = 200
 
 # A parseable submodule entry heading — the exact per-line shape
 # generate_batch_prompts parses caller expectations from.
-_SUBMODULE_HEADING_RE = re.compile(r"^#[ \t]*Submodule:[ \t]*\S+[ \t]*$", re.M)
+_SUBMODULE_HEADING_RE = re.compile(r"^#[ \t]*Submodule:[ \t]*(\S+)[ \t]*$", re.M)
 
 
 def verilog_spec_path(module_file_path):


### PR DESCRIPTION
## Summary

Ten commits hardening the Verilog/SystemVerilog + Chisel spec-generation flows added in #86, driven by multiple rounds of independent review plus real end-to-end validation (gpt-5.5 and DeepSeek, riscv-mini Chisel/Verilog and hand-written SERV RTL).

### Resume trust chain
- **Stale derived state on rerun-setup resume**: when a reused `groups.json` can't be resumed, derived artifacts (domain context, phases.json, file list, topdown layers, batch prompts, and the rejected `groups.json` itself) are reset before setup reruns — previously a stale manifest could steer Stage 1 into a "continue where you left off" prompt for a manifest this flow already rejected.
- **Partial-missing sources**: the zero-modules guard's fallback now triggers on *any* missing listed source under a reused manifest, not only when every source is gone — a manifest with one surviving and one renamed/deleted file used to spec the survivor and silently never spec the renamed one.
- **Language normalization**: `_groups_to_phases` forces `languages=["chisel"]` unconditionally (mirrors the existing Verilog `_force_verilog_phase_languages`) — the resume veto accepts `"scala"` as a plausible LLM spelling, but the batch-prompt language router only recognized the literal `"chisel"` token, so an accepted `"scala"` manifest silently misrouted to software-style prompts.
- **Hardware-language guard**: the default pipeline's guard now harvests hardware-language tokens from any JSON shape (string/list/dict) with an unambiguous-extension/source-suffix backstop when no token is found, closing a fail-open gap for declared-but-unintelligible language shapes.

### Verilog per-callee submodule gate
- Verilog's instantiation graph is precise (verible CST), so non-leaf modules now must document a `# Submodule: <name>` entry for *every* instantiated child, not just claim `(no submodules)` or contain any single heading. Missing entries are deleted and fed back to the retry prompt with the full required set (avoiding ping-pong on partial fixes). Chisel deliberately keeps its existing advisory-only gate — real-run data shows its graph gaps are ~100% false edges (companion objects, IO bundles, constant objects), so blocking there would strand runs on phantom documentation demands.
- A verible-drift canary detects when the installed verible version's instantiation CST tags are no longer recognized (partial drift beyond a full parse failure) and falls back to the regex scanner instead of silently under-reporting edges.
- `FM_AGENT_NO_VERIBLE=1` (regex-fallback) mode keeps the gate blocking (the fallback only ever misses edges, never invents ones — unlike Chisel's problem) but prints a one-time warning naming the narrower guarantee.

### LLM-JSON shape safety
`groups.json`/`phases.json` are LLM-written, so a single-element field is plausibly emitted as a bare string instead of a one-element list, and a single dependency as a bare int/string. Normalized at the point each fact is established (not re-derived per consumer) across `source_files`, `depends_on_phases`/`depends_on_subsystems`, `languages`, and `file_extensions` — closing several silent mis-parses (character-by-character iteration, phase-id lookup misses, `build_ext_to_lang` routing failures).

### Declared-name single source of truth
`generate_topdown_layers` now stamps a `declared_name` field (via the extractor's own declaration regex on the same comment-masked text) into each layer function entry; the batch-prompt caller-expectation lookup and the undocumented-submodules advisory both consume this stamped field instead of independently re-deriving "is this a dedup alias" — closing a gap where scoped Chisel declarations (`private[chisel] object Foo`) were missed by a weaker ad-hoc regex.

### Test-file filters and extensions
`.sc`/`.svh` (already accepted for extraction) are now also recognized by the Chisel/Verilog test-file name filters and the two setup-prompt docs, and `build_ext_to_lang` unconditionally covers the whole Chisel/Verilog extension universe once the language token is present.

## Test plan
- [x] 9 standalone test files (`uv run python tests/test_*.py`), all passing — not included in this PR per repo convention on `tests/`
- [x] Real end-to-end runs on riscv-mini (Chisel + generated Verilog) and hand-written SERV RTL, with both `gpt-5.5` and `deepseek-chat` as the OpenCode backend model — 6/6 runs completed successfully (49/49, 14/14, 18/18 modules specced), including a DeepSeek+SERV combination that previously failed to converge before the retry-feedback mechanism landed
- [x] Repeated the DeepSeek run against the final state of this PR's commits — 3/3 designs still complete (45/45, 14/14, 18/18), no regressions from the accumulated hardening