### PR TITLE
fix: prevent OSError from raw function signatures used as filenames (fixes #82, v2)

### DIFF
--- a/src/entry_reasoning_pipeline.py
+++ b/src/entry_reasoning_pipeline.py
@@ -12,6 +12,7 @@ from src.extract import (
     _extract_functions_brace,
     _extract_functions_indent,
     _is_test_file,
+    _safe_filename,
     add_test_file_exemption,
     clear_test_file_exemptions,
     extract_functions_from_file,
@@ -75,7 +76,7 @@ def _extract_for_selection(proj_dir, tmp_root):
             out_dir = os.path.join(output_base, src_dir, dir_name)
             os.makedirs(out_dir, exist_ok=True)
             for func_name, func_source in funcs:
-                with open(os.path.join(out_dir, f"{func_name}.{ext}"), "w") as f:
+                with open(os.path.join(out_dir, _safe_filename(func_name, ext)), "w") as f:
                     f.write(func_source)
                 count += 1
     return count

--- a/src/extract.py
+++ b/src/extract.py
@@ -214,6 +214,20 @@ def _is_test_file(rel_path):
 # ---------------------------------------------------------------------------
 
 
+def _safe_filename(name: str, ext: str) -> str:
+    """Return a safe filename from a function name and extension.
+
+    Replaces "/" (directory separator) with "_" and falls back to
+    "_function" for empty names.  Does *not* strip leading or trailing
+    underscores so that names like __init__ and _private stay consistent
+    with codegraph call-edge keys and FQN resolution.
+    """
+    safe = name.replace('/', '_')
+    if not safe:
+        safe = "_function"
+    return f"{safe}.{ext}"
+
+
 def _strip_angle_brackets(text):
     """Remove balanced <...> segments from text (for template parameters)."""
     result = []
@@ -718,7 +732,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         os.makedirs(out_dir, exist_ok=True)
 
         for func_name, func_source in funcs:
-            out_file = os.path.join(out_dir, f"{func_name}.{ext}")
+            out_file = os.path.join(out_dir, _safe_filename(func_name, ext))
 
             # Skip only when the file already has both [SPEC] and [INFO] blocks
             if not force and os.path.exists(out_file) and is_file_ready(out_file):

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -10,6 +10,7 @@ REGISTRY in src/languages/registry.py. No other files need to change.
 
 import logging
 import os
+import re
 import sqlite3
 import subprocess
 from collections import defaultdict
@@ -48,6 +49,55 @@ _CONSTRUCTOR_FILTER = {
     "java":       "ctor.name = cls.name",
     "cpp":        "ctor.name = cls.name",
 }
+
+def _bare_function_name(name: str) -> str:
+    """Extract the bare function identifier from a potentially decorated name.
+
+    Tree-sitter sometimes stores a full function signature in the name column
+    for macro-generated C/C++ declarations (e.g. ``(*func)(type *param)``
+    instead of ``func``).  Strips decorations so the result can be used as a
+    filename stem and call-edge key.
+
+    Handled patterns (language-agnostic — safe for all codegraph languages):
+    - Simple identifier: ``"my_func"`` -> ``"my_func"``
+    - Qualified name: ``"ns::Cls::method"`` -> ``"method"``
+    - Go pointer receiver: ``"(*T).Method"`` -> ``"Method"``
+    - Function-pointer: ``"(*func)(type *param)"`` -> ``"func"``
+    - Pointer return: ``"*func_name(...)"`` -> ``"func_name"``
+    - this-dot: ``"this.onClick"`` -> ``"onClick"``
+    - Empty: ``""`` -> ``""`` (caller falls back to ``_function``)
+    """
+    name = name.strip()
+    if not name:
+        return ""
+
+    # 1. Qualified names (:: / . / (*T). / ) — take the last component.
+    #    Must come BEFORE the function-pointer check so that Go receiver
+    #    syntax "(*T).Method" returns "Method", not "T".
+    #    C++: "ns::Cls::method" -> "method"
+    #    Go:  "(*T).Method"     -> "Method"
+    #    JS:  "this.onClick"    -> "onClick"
+    m = re.search(r'(?:[:\.)])(\w+)$', name)
+    if m:
+        return m.group(1)
+
+    # 2. Function-pointer signature: (*identifier)(...)
+    #    Example from issue #82: (*yyjson_mut_obj_iter_next)(yyjson_mut_doc *, ...)
+    m = re.match(r'\(\s*\*\s*(\w+)\s*\)', name)
+    if m:
+        return m.group(1)
+
+    # 3. Pointer return: *identifier(...)
+    m = re.match(r'\*\s*(\w+)', name)
+    if m:
+        return m.group(1)
+
+    # 4. Plain identifier (__init__, _private, normal_func, etc.)
+    m = re.match(r'^(\w+)', name)
+    if m:
+        return m.group(1)
+
+    return name
 
 
 class CodeGraphExtractor:
@@ -101,7 +151,8 @@ class CodeGraphExtractor:
 
         by_file = defaultdict(list)
         for name, file_path, start_line, end_line in rows:
-            by_file[file_path].append((name, int(start_line), int(end_line)))
+            bare = _bare_function_name(name)
+            by_file[file_path].append((bare, int(start_line), int(end_line)))
 
         result = {}
         for file_path, funcs in by_file.items():
@@ -162,7 +213,7 @@ class CodeGraphExtractor:
             base = os.path.basename(caller_file)
             last_dot = base.rfind(".")
             dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
-            result[(caller, dashed)].add(callee)
+            result[(_bare_function_name(caller), dashed)].add(_bare_function_name(callee))
 
         # Query 2: constructor calls synthesised from instantiates edges.
         # For each `caller instantiates ClassName` edge, find the constructor
@@ -187,7 +238,7 @@ class CodeGraphExtractor:
                 base = os.path.basename(caller_file)
                 last_dot = base.rfind(".")
                 dashed = base[:last_dot] + "-" + base[last_dot + 1:] if last_dot > 0 else base
-                result[(caller, dashed)].add(ctor_name)
+                result[(_bare_function_name(caller), dashed)].add(_bare_function_name(ctor_name))
 
         conn.close()
         return dict(result)


### PR DESCRIPTION
Fixes #82. Tree-sitter sometimes stores full function signatures in
its name column for macro-generated C/C++ declarations (e.g. DuckDB's
yyjson), which were used directly as filenames and exceeded filesystem
limits, causing `OSError: [Errno 36] File name too long`.

This is a revised version of the original PR, addressing review feedback.

### Changes

**`src/languages/codegraph.py`**
- New `_bare_function_name()` extracts the bare function identifier from
  potentially decorated name strings (e.g. `(*func)(type *param)` → `func`)
- Applied in all three codegraph name-outflow paths: `get_functions_by_file`,
  `get_call_edges` Query 1 (calls), and Query 2 (constructor edges)
- Pattern ordering: qualified names / Go receivers checked before
  function-pointer syntax so `(*T).Method` returns `Method`, not `T`

**`src/extract.py`**
- New `_safe_filename(name, ext)` replaces `/` with `_` and falls back
  to `_function` for empty names
- Does NOT strip leading/trailing underscores — `__init__` and `_private`
  remain intact, preventing filename collisions and keeping stems
  consistent with codegraph call-edge keys

**`src/entry_reasoning_pipeline.py`**
- `_extract_for_selection` also uses `_safe_filename` so both extraction
  paths are consistent

### Review feedback addressed

| Review | Fix |
|--------|-----|
| Codex P1: `strip('_.')` causes filename collisions | No stripping — `__init__` and `_private` stay as-is |
| Codex P2: sanitized names diverge from call-edge keys | Names flow through the same `_bare_function_name` → extraction preserves identity |
| haoran-ding: is `_bare_function_name` safe for all languages? | Tested across C/C++/Python/Go/Rust/Java/JS/TS. Pattern ordering handles Go receiver syntax correctly. |
| haoran-ding: resolve merge conflict with PR #81 | Compatible — both replace `/` in filenames |

### Tested