### PR TITLE
feat(fqn): qualify C++ member functions with their class name

### DIFF
--- a/src/entry_reasoning_pipeline.py
+++ b/src/entry_reasoning_pipeline.py
@@ -87,11 +87,11 @@ def _extracted_file_to_source_rel(extracted_rel):
     Inverse of the extraction layout: ``src/engine/loader-cpp/loadData.cpp``
     (a function file) -> ``src/engine/loader.cpp`` (the source file). Extraction
     builds the function directory by replacing the source filename's last dot
-    with a hyphen (``loader.cpp`` -> ``loader-cpp``). Member functions add a class
-    subdirectory below that (``.../loader-cpp/MyClass/method.cpp``), so we locate
-    the ``<base>-<ext>`` directory itself — scanning from the right so a class
-    dir (which never ends in ``-<known extension>``) is skipped — rather than
-    assuming it is the function file's immediate parent.
+    with a hyphen (``loader.cpp`` -> ``loader-cpp``). Member functions keep the
+    class qualifier in the flat filename (``.../loader-cpp/MyClass::method.cpp``),
+    so the ``<base>-<ext>`` directory is the function file's immediate parent; we
+    still locate it by scanning the path components from the right (matching a
+    component that ends in ``-<known extension>``) so the mapping is robust.
     """
     parts = extracted_rel.split(os.sep)
     for i in range(len(parts) - 2, -1, -1):          # skip the trailing func file
@@ -117,7 +117,7 @@ def _fqn_to_ident(fqn):
         src::storage-cpp::LocalStorage::Flush -> LocalStorage::Flush
         src::checkpoint-cpp::RunCheckpoint     -> RunCheckpoint
 
-    This is exactly the name run_extraction wrote (via the class subdirectory)
+    This is exactly the name run_extraction wrote (as the flat filename stem)
     and _function_spans reports, so trim keeps/removes the right same-name method
     instead of collapsing LocalStorage::Flush and WriteAheadLog::Flush together.
     """

--- a/src/entry_reasoning_pipeline.py
+++ b/src/entry_reasoning_pipeline.py
@@ -87,27 +87,57 @@ def _extracted_file_to_source_rel(extracted_rel):
     Inverse of the extraction layout: ``src/engine/loader-cpp/loadData.cpp``
     (a function file) -> ``src/engine/loader.cpp`` (the source file). Extraction
     builds the function directory by replacing the source filename's last dot
-    with a hyphen (``loader.cpp`` -> ``loader-cpp``), so we reverse the last
-    hyphen of the directory name.
+    with a hyphen (``loader.cpp`` -> ``loader-cpp``). Member functions add a class
+    subdirectory below that (``.../loader-cpp/MyClass/method.cpp``), so we locate
+    the ``<base>-<ext>`` directory itself — scanning from the right so a class
+    dir (which never ends in ``-<known extension>``) is skipped — rather than
+    assuming it is the function file's immediate parent.
     """
-    func_dir = os.path.dirname(extracted_rel)        # src/engine/loader-cpp
-    src_dir = os.path.dirname(func_dir)              # src/engine
-    dir_name = os.path.basename(func_dir)            # loader-cpp
+    parts = extracted_rel.split(os.sep)
+    for i in range(len(parts) - 2, -1, -1):          # skip the trailing func file
+        comp = parts[i]
+        hyphen = comp.rfind("-")
+        if hyphen > 0 and comp[hyphen + 1:] in EXT_TO_LANG:
+            src_dir = os.sep.join(parts[:i])
+            source_base = comp[:hyphen] + "." + comp[hyphen + 1:]
+            return os.path.join(src_dir, source_base) if src_dir else source_base
+    # Fallback: original immediate-parent behaviour (no recognised -ext dir).
+    func_dir = os.path.dirname(extracted_rel)
+    src_dir = os.path.dirname(func_dir)
+    dir_name = os.path.basename(func_dir)
     hyphen = dir_name.rfind("-")
-    if hyphen > 0:
-        source_base = dir_name[:hyphen] + "." + dir_name[hyphen + 1:]
-    else:
-        source_base = dir_name
+    source_base = dir_name[:hyphen] + "." + dir_name[hyphen + 1:] if hyphen > 0 else dir_name
     return os.path.join(src_dir, source_base) if src_dir else source_base
+
+
+def _fqn_to_ident(fqn):
+    """Return a function's class-qualified identifier: the FQN tail after the
+    ``<base>-<ext>`` source-file component.
+
+        src::storage-cpp::LocalStorage::Flush -> LocalStorage::Flush
+        src::checkpoint-cpp::RunCheckpoint     -> RunCheckpoint
+
+    This is exactly the name run_extraction wrote (via the class subdirectory)
+    and _function_spans reports, so trim keeps/removes the right same-name method
+    instead of collapsing LocalStorage::Flush and WriteAheadLog::Flush together.
+    """
+    parts = fqn.split("::")
+    for i in range(len(parts) - 1, -1, -1):
+        comp = parts[i]
+        hyphen = comp.rfind("-")
+        if hyphen > 0 and comp[hyphen + 1:] in EXT_TO_LANG:
+            return "::".join(parts[i + 1:])
+    return parts[-1]
 
 
 def _entry_func_source_rel(entry_func):
     """Map an entry_func FQN back to its source file (project-relative path).
 
-    ``src::engine::loader-cpp::loadData`` -> ``src/engine/loader.cpp``. The FQN's
-    last component is the function name and the second-to-last is the extraction
-    function directory (``loader-cpp``); reuse the extracted-file inverse mapping
-    by treating the ``::``-joined FQN as an extracted-file path.
+    ``src::engine::loader-cpp::loadData`` -> ``src/engine/loader.cpp``;
+    ``src::storage-cpp::LocalStorage::Flush`` -> ``src/storage.cpp``. Reuse the
+    extracted-file inverse mapping by treating the ``::``-joined FQN as an
+    extracted-file path; _extracted_file_to_source_rel finds the ``<base>-<ext>``
+    directory regardless of any class components after it.
     """
     extracted_rel = os.path.join(*entry_func.split("::"))
     return _extracted_file_to_source_rel(extracted_rel).replace(os.sep, "/")
@@ -371,7 +401,7 @@ def _select_functions_by_source(proj_dir, entry_func, end_funcs):
         # Every extractable function, grouped by source file.
         all_by_source = defaultdict(set)
         for fqn in all_fqns:
-            all_by_source[_entry_func_source_rel(fqn)].add(fqn.split("::")[-1])
+            all_by_source[_entry_func_source_rel(fqn)].add(_fqn_to_ident(fqn))
     finally:
         shutil.rmtree(sel_dir, ignore_errors=True)
 
@@ -394,10 +424,10 @@ def _select_functions_by_source(proj_dir, entry_func, end_funcs):
         f"from entry {entry_func}."
     )
 
-    # Map the selected FQNs back to their (source file, function name).
+    # Map the selected FQNs back to their (source file, function identifier).
     keep_by_source = defaultdict(set)
     for fqn in call_graph:
-        keep_by_source[_entry_func_source_rel(fqn)].add(fqn.split("::")[-1])
+        keep_by_source[_entry_func_source_rel(fqn)].add(_fqn_to_ident(fqn))
 
     return all_by_source, keep_by_source
 

--- a/src/extract.py
+++ b/src/extract.py
@@ -740,16 +740,16 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         os.makedirs(out_dir, exist_ok=True)
 
         for func_name, func_source in funcs:
-            # A class-qualified identifier ("LocalStorage::Flush") is laid out as
-            # nested directories ("LocalStorage/Flush.ext") so its FQN — rebuilt
-            # from the path by generate_topdown_layers._file_to_fqn — comes out as
-            # "...-cpp::LocalStorage::Flush", matching the call-edge FQNs. A bare
-            # name (free function, or the regex fallback which cannot know classes)
-            # has no "::" and lands directly in out_dir as before.
-            ident_parts = func_name.split("::")
-            func_out_dir = os.path.join(out_dir, *ident_parts[:-1])
-            os.makedirs(func_out_dir, exist_ok=True)
-            out_file = os.path.join(func_out_dir, f"{ident_parts[-1]}.{ext}")
+            # A class-qualified identifier ("LocalStorage::Flush") is written as a
+            # single flat file that keeps the "::" in its name
+            # ("LocalStorage::Flush.ext"). generate_topdown_layers._file_to_fqn
+            # rebuilds the FQN by joining the path components with "::", so the "::"
+            # already inside the filename yields "...-cpp::LocalStorage::Flush",
+            # matching the call-edge FQNs. A bare name (free function, or the regex
+            # fallback which cannot know classes) has no "::" and is written the same
+            # way. ":" is a legal filename character on Linux/macOS (this pipeline
+            # does not target Windows extraction).
+            out_file = os.path.join(out_dir, f"{func_name}.{ext}")
 
             # Skip only when the file already has both [SPEC] and [INFO] blocks
             if not force and os.path.exists(out_file) and is_file_ready(out_file):

--- a/src/extract.py
+++ b/src/extract.py
@@ -740,7 +740,16 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         os.makedirs(out_dir, exist_ok=True)
 
         for func_name, func_source in funcs:
-            out_file = os.path.join(out_dir, f"{func_name}.{ext}")
+            # A class-qualified identifier ("LocalStorage::Flush") is laid out as
+            # nested directories ("LocalStorage/Flush.ext") so its FQN — rebuilt
+            # from the path by generate_topdown_layers._file_to_fqn — comes out as
+            # "...-cpp::LocalStorage::Flush", matching the call-edge FQNs. A bare
+            # name (free function, or the regex fallback which cannot know classes)
+            # has no "::" and lands directly in out_dir as before.
+            ident_parts = func_name.split("::")
+            func_out_dir = os.path.join(out_dir, *ident_parts[:-1])
+            os.makedirs(func_out_dir, exist_ok=True)
+            out_file = os.path.join(func_out_dir, f"{ident_parts[-1]}.{ext}")
 
             # Skip only when the file already has both [SPEC] and [INFO] blocks
             if not force and os.path.exists(out_file) and is_file_ready(out_file):

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -133,9 +133,10 @@ def _get_phase_files(phases_data, phase_num, input_dir):
                 subdir = base
             extracted_dir = os.path.join(input_dir, dir_part, subdir)
             if os.path.isdir(extracted_dir):
-                # Walk recursively: member functions live one level deeper under a
-                # class directory (<file>-cpp/LocalStorage/Flush.cpp), free
-                # functions sit directly in extracted_dir.
+                # Every extracted function is a flat file directly in
+                # extracted_dir, member functions keeping the class qualifier in
+                # the name (<file>-cpp/LocalStorage::Flush.cpp). os.walk stays
+                # robust to any legacy nested file.
                 for root, _dirs, fnames in os.walk(extracted_dir):
                     for fname in sorted(fnames):
                         fpath = os.path.join(root, fname)

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -133,10 +133,14 @@ def _get_phase_files(phases_data, phase_num, input_dir):
                 subdir = base
             extracted_dir = os.path.join(input_dir, dir_part, subdir)
             if os.path.isdir(extracted_dir):
-                for fname in sorted(os.listdir(extracted_dir)):
-                    fpath = os.path.join(extracted_dir, fname)
-                    if os.path.isfile(fpath):
-                        phase_files.append(os.path.relpath(fpath, input_dir))
+                # Walk recursively: member functions live one level deeper under a
+                # class directory (<file>-cpp/LocalStorage/Flush.cpp), free
+                # functions sit directly in extracted_dir.
+                for root, _dirs, fnames in os.walk(extracted_dir):
+                    for fname in sorted(fnames):
+                        fpath = os.path.join(root, fname)
+                        if os.path.isfile(fpath):
+                            phase_files.append(os.path.relpath(fpath, input_dir))
     return phase_files
 
 

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -48,9 +48,10 @@ def _collect_phase_files(proj_dir, phase_data):
             if not os.path.isdir(func_dir):
                 continue
 
-            # Walk recursively: member functions are nested one level deeper under
-            # a class directory ("<file>-cpp/LocalStorage/Flush.cpp"), while free
-            # functions sit directly in func_dir.
+            # Every extracted function is a flat file directly in func_dir, member
+            # functions keeping the class qualifier in the name
+            # ("<file>-cpp/LocalStorage::Flush.cpp"). os.walk stays robust to any
+            # legacy nested file.
             for root, _dirs, fnames in os.walk(func_dir):
                 for fname in fnames:
                     fpath = os.path.join(root, fname)

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -48,10 +48,14 @@ def _collect_phase_files(proj_dir, phase_data):
             if not os.path.isdir(func_dir):
                 continue
 
-            for fname in os.listdir(func_dir):
-                fpath = os.path.join(func_dir, fname)
-                if os.path.isfile(fpath):
-                    results.append((fpath, module_name))
+            # Walk recursively: member functions are nested one level deeper under
+            # a class directory ("<file>-cpp/LocalStorage/Flush.cpp"), while free
+            # functions sit directly in func_dir.
+            for root, _dirs, fnames in os.walk(func_dir):
+                for fname in fnames:
+                    fpath = os.path.join(root, fname)
+                    if os.path.isfile(fpath):
+                        results.append((fpath, module_name))
 
     return results
 

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -423,18 +423,33 @@ def _src_rel_to_func_dir(proj_dir, abs_src):
 
 
 def _extracted_files_by_method(func_dir):
-    """``{method_stem: [abs_path, ...]}`` for every extracted-function file under
-    ``func_dir``, walked recursively. The key is the file's stem (its final path
-    component minus extension), so a source-level name (which the regex change
-    detector reports without a class) matches both a free function
-    (``func_dir/foo.ext``) and a class member (``func_dir/Class/foo.ext``)."""
+    """``{key: [abs_path, ...]}`` for every extracted-function file under
+    ``func_dir``, walked recursively. Each file is registered under BOTH keys so a
+    caller can look it up whichever kind of name it holds:
+
+      - its bare stem (``Flush``) — the regex change detector reports names
+        without a class, so a bare name matches every same-named member;
+      - its class-qualified identifier (``LocalStorage::Flush``) — scope ranking
+        gets qualified names from codegraph spans, so this gives an exact match.
+
+    A free function (``func_dir/foo.ext``) has identical stem and identifier, so it
+    is registered once."""
     index = defaultdict(list)
     if not os.path.isdir(func_dir):
         return index
     for root, _dirs, fnames in os.walk(func_dir):
         for fn in fnames:
+            abs_path = os.path.join(root, fn)
+            # Flat layout: the filename stem is the full identifier, keeping any
+            # "::" ("LocalStorage::Flush"). Register it under both the full
+            # identifier and the bare tail ("Flush") so both codegraph's qualified
+            # names and the regex detector's bare names resolve. (os.walk still
+            # tolerates a legacy nested file, whose stem is already bare.)
             stem = fn[: fn.rfind(".")] if "." in fn else fn
-            index[stem].append(os.path.join(root, fn))
+            index[stem].append(abs_path)
+            bare = stem.split("::")[-1]
+            if bare != stem:
+                index[bare].append(abs_path)
     return index
 
 
@@ -447,11 +462,11 @@ def _modified_function_targets(
     modified_functions is the mapping returned by _collect_changed_functions: an
     absolute source-file path -> {"added", "removed", "modified"} lists of function
     names, which the regex change detector reports without a class (``Flush``,
-    ``Flush_1``). The extracted files, however, live under a class subdirectory
-    when codegraph qualifies members (``.../storage-cpp/LocalStorage/Flush.cpp``),
-    so we do not reconstruct a flat path from the name — we walk the function
-    directory and match each changed name against the actual files by method stem
-    (tolerating the regex dedup suffix). When two classes in one file share a
+    ``Flush_1``). The extracted files, however, keep codegraph's class qualifier in
+    the filename (``.../storage-cpp/LocalStorage::Flush.cpp``), so we do not
+    reconstruct a path from the bare name — we walk the function directory and match
+    each changed name against the actual files by their bare method tail (tolerating
+    the regex dedup suffix). When two classes in one file share a
     method name, a changed bare name maps to both members; that is a safe
     over-approximation for the callers (spec/verify seeds).
 
@@ -469,7 +484,8 @@ def _modified_function_targets(
             paths = list(by_method.get(name, ()))
             if not paths:
                 # The regex extractor disambiguates same-name funcs as foo/foo_1;
-                # codegraph uses the class dir instead, so fall back to the stem.
+                # codegraph uses the class qualifier instead, so fall back to the
+                # stem.
                 stem = re.sub(r"_\d+$", "", name)
                 paths = by_method.get(stem, ())
             for path in paths:
@@ -477,43 +493,67 @@ def _modified_function_targets(
     return targets
 
 
+def _reconcile_extracted_dir(proj_dir, abs_src):
+    """Delete extracted-function files under abs_src's function directory that
+    codegraph no longer produces for it, then prune emptied directories.
+
+    ``valid`` is computed with the same backend (codegraph when it indexes the
+    file, else regex) that run_extraction used to write the files, so their
+    identifiers — and therefore the on-disk layout — agree; only genuinely orphaned
+    files are removed. A source file that no longer exists yields an empty ``valid``
+    set, so all of its extracted files are removed.
+    """
+    func_dir, ext = _src_rel_to_func_dir(proj_dir, abs_src)
+    if not os.path.isdir(func_dir):
+        return
+
+    valid = set()
+    lang_key = EXT_TO_LANG.get(ext)
+    if lang_key and os.path.isfile(abs_src):
+        spans, _raw = _function_spans(abs_src, lang_key, proj_dir)
+        for ident, _s, _e in spans:
+            # ident is the class-qualified, deduped identifier written by
+            # run_extraction as a flat file that keeps the "::" in its name.
+            path = os.path.join(func_dir, ident) + (f".{ext}" if ext else "")
+            valid.add(os.path.abspath(path))
+
+    for root, _dirs, fnames in os.walk(func_dir):
+        for fn in fnames:
+            abs_path = os.path.abspath(os.path.join(root, fn))
+            if abs_path not in valid:
+                os.remove(abs_path)
+
+    # Prune empty directories left behind (deepest first).
+    for root, _dirs, _files in os.walk(func_dir, topdown=False):
+        if root != func_dir and os.path.isdir(root) and not os.listdir(root):
+            os.rmdir(root)
+
+
 def _remove_stale_extracted(proj_dir, modified_functions):
     """
-    Delete extracted-function files that no longer correspond to a function in the
-    current source, for every changed source file, and prune any directory left
-    empty. Rather than reconstructing removed functions' paths from their (regex,
-    class-less) names — which cannot address a specific class member — we reconcile
-    each changed file's function directory against the set codegraph now produces
-    for it (re-extraction and the index rebuild have already run at this point):
-    any extracted file not in that valid set is stale and removed. A deleted source
-    file yields an empty valid set, so all of its extracted files are removed.
+    Reconcile the extracted-function tree against what codegraph now produces,
+    deleting any file that no longer corresponds to a current source function and
+    pruning emptied directories.
+
+    We reconcile every source file in the current phases.json plus any file
+    reported changed or deleted — not only files whose regex-visible function names
+    changed. A qualifier-only edit (e.g. renaming a C++ namespace around an
+    otherwise identical ``void foo(){...}``) moves the extracted file to a new
+    qualified directory without changing the regex name or body, so the old
+    qualified file would otherwise linger as a stale, orphaned spec. Reconciling by
+    path rather than by (class-less) name handles it.
     """
-    for abs_src in modified_functions:
-        func_dir, ext = _src_rel_to_func_dir(proj_dir, abs_src)
-        if not os.path.isdir(func_dir):
-            continue
-
-        valid = set()
-        lang_key = EXT_TO_LANG.get(ext)
-        if lang_key and os.path.isfile(abs_src):
-            spans, _raw = _function_spans(abs_src, lang_key, proj_dir)
-            for ident, _s, _e in spans:
-                # ident is the class-qualified, deduped identifier written by
-                # run_extraction; "::" maps to the class subdirectory layout.
-                parts = ident.split("::")
-                path = os.path.join(func_dir, *parts) + (f".{ext}" if ext else "")
-                valid.add(os.path.abspath(path))
-
-        for root, _dirs, fnames in os.walk(func_dir):
-            for fn in fnames:
-                abs_path = os.path.abspath(os.path.join(root, fn))
-                if abs_path not in valid:
-                    os.remove(abs_path)
-
-        # Prune empty directories left behind (deepest first).
-        for root, dirs, _files in os.walk(func_dir, topdown=False):
-            if root != func_dir and os.path.isdir(root) and not os.listdir(root):
-                os.rmdir(root)
+    srcs = set(modified_functions)  # abs paths; includes deleted source files
+    try:
+        phases_data = _load_phases(os.path.join(proj_dir, "fm_agent"))
+        for phase in phases_data.get("phases", []):
+            for module in phase.get("modules", []):
+                for rel in module.get("source_files", []):
+                    srcs.add(os.path.abspath(os.path.join(proj_dir, rel)))
+    except (OSError, ValueError, KeyError):
+        pass
+    for abs_src in srcs:
+        _reconcile_extracted_dir(proj_dir, abs_src)
 
 
 def _extract_leading_spec_comments(content, comment_prefix, spec_marker):
@@ -1185,9 +1225,9 @@ def collect_relevent_function_scope(proj_dir, developer_intent, changed_function
 
             if ranked:
                 # Keep the extracted-function file for each selected function name.
-                # scope.py reports class-less names, but members live under a class
-                # subdirectory, so match against the actual files by method stem
-                # (a same-name method in two classes keeps both — safe for scope).
+                # The dual-key index resolves the name whether scope reports it bare
+                # ("Flush") or class-qualified ("LocalStorage::Flush"); a bare name
+                # matching two classes keeps both members — safe for scope.
                 by_method = _extracted_files_by_method(func_dir)
                 for f in ranked:
                     cands = by_method.get(f["name"]) or by_method.get(
@@ -1202,7 +1242,8 @@ def collect_relevent_function_scope(proj_dir, developer_intent, changed_function
                 )
             else:
                 # scope.py could not localize within this file — keep all of its
-                # functions, walking recursively so nested class members are kept.
+                # extracted-function files (walked; the layout is flat but os.walk
+                # stays robust to any legacy nested file).
                 for root, _dirs, fnames in os.walk(func_dir):
                     for fname in fnames:
                         cand = os.path.join(root, fname)

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -2,12 +2,14 @@ import os
 import sys
 import glob
 import json
+import re
 import time
 import shutil
 import logging
 import subprocess
 import tempfile
 import concurrent.futures
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 
@@ -21,6 +23,7 @@ from config import (
 from .extract import (
     EXT_TO_LANG,
     LANG_CONFIG,
+    _function_spans,
     extract_functions_from_file,
     run_extraction,
 )
@@ -401,6 +404,40 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
     return result
 
 
+def _src_rel_to_func_dir(proj_dir, abs_src):
+    """(func_dir, ext) for a source file: the extracted-functions directory that
+    holds its functions (``.../loader-cpp``) and the source extension."""
+    extracted_base = os.path.join(proj_dir, "fm_agent", "extracted_functions")
+    rel = os.path.relpath(abs_src, proj_dir)
+    src_dir = os.path.dirname(rel)
+    src_base = os.path.basename(rel)
+    last_dot = src_base.rfind(".")
+    if last_dot > 0:
+        dir_name = src_base[:last_dot] + "-" + src_base[last_dot + 1:]
+        ext = src_base[last_dot + 1:]
+    else:
+        dir_name = src_base
+        ext = ""
+    func_dir = os.path.join(extracted_base, src_dir, dir_name) if src_dir else os.path.join(extracted_base, dir_name)
+    return func_dir, ext
+
+
+def _extracted_files_by_method(func_dir):
+    """``{method_stem: [abs_path, ...]}`` for every extracted-function file under
+    ``func_dir``, walked recursively. The key is the file's stem (its final path
+    component minus extension), so a source-level name (which the regex change
+    detector reports without a class) matches both a free function
+    (``func_dir/foo.ext``) and a class member (``func_dir/Class/foo.ext``)."""
+    index = defaultdict(list)
+    if not os.path.isdir(func_dir):
+        return index
+    for root, _dirs, fnames in os.walk(func_dir):
+        for fn in fnames:
+            stem = fn[: fn.rfind(".")] if "." in fn else fn
+            index[stem].append(os.path.join(root, fn))
+    return index
+
+
 def _modified_function_targets(
     proj_dir, modified_functions, classes=("added", "removed", "modified")
 ):
@@ -409,57 +446,74 @@ def _modified_function_targets(
 
     modified_functions is the mapping returned by _collect_changed_functions: an
     absolute source-file path -> {"added", "removed", "modified"} lists of function
-    names. For each (file, name) pair whose change class is in classes, this computes
-    the FQN used by the call graph and the path of the function's file under
-    proj_dir/fm_agent/extracted_functions/, both matching that layout (the source
-    file's final dot becomes a hyphen and path components are joined with "::"), e.g.
-    an "load" function in "<proj_dir>/src/engine/loader.cpp" -> FQN
-    "src::engine::loader-cpp::load" at ".../extracted_functions/src/engine/loader-cpp/load.cpp".
+    names, which the regex change detector reports without a class (``Flush``,
+    ``Flush_1``). The extracted files, however, live under a class subdirectory
+    when codegraph qualifies members (``.../storage-cpp/LocalStorage/Flush.cpp``),
+    so we do not reconstruct a flat path from the name — we walk the function
+    directory and match each changed name against the actual files by method stem
+    (tolerating the regex dedup suffix). When two classes in one file share a
+    method name, a changed bare name maps to both members; that is a safe
+    over-approximation for the callers (spec/verify seeds).
 
     Returns a dict mapping FQN -> absolute extracted-file path.
     """
-    extracted_base = os.path.join(proj_dir, "fm_agent", "extracted_functions")
+    work_dir = os.path.join(proj_dir, "fm_agent")
     targets = {}
     for abs_src, changes in modified_functions.items():
-        rel = os.path.relpath(abs_src, proj_dir)
-        src_dir = os.path.dirname(rel)
-        src_base = os.path.basename(rel)
-        last_dot = src_base.rfind(".")
-        if last_dot > 0:
-            dir_name = src_base[:last_dot] + "-" + src_base[last_dot + 1:]
-            ext = src_base[last_dot + 1:]
-        else:
-            dir_name = src_base
-            ext = ""
-        func_dir = os.path.join(extracted_base, src_dir, dir_name) if src_dir else os.path.join(extracted_base, dir_name)
+        func_dir, _ext = _src_rel_to_func_dir(proj_dir, abs_src)
+        by_method = _extracted_files_by_method(func_dir)
         names = set()
         for cls in classes:
             names.update(changes.get(cls, []))
         for name in names:
-            fname = f"{name}.{ext}" if ext else name
-            path = os.path.join(func_dir, fname)
-            fqn = _file_to_fqn(path, os.path.join(proj_dir, "fm_agent"))
-            targets[fqn] = path
+            paths = list(by_method.get(name, ()))
+            if not paths:
+                # The regex extractor disambiguates same-name funcs as foo/foo_1;
+                # codegraph uses the class dir instead, so fall back to the stem.
+                stem = re.sub(r"_\d+$", "", name)
+                paths = by_method.get(stem, ())
+            for path in paths:
+                targets[_file_to_fqn(path, work_dir)] = path
     return targets
 
 
 def _remove_stale_extracted(proj_dir, modified_functions):
     """
-    Delete extracted-function files for functions reported as removed (including every
-    function of a deleted source file), and prune any function directory left empty as
-    a result. Re-extraction never rewrites these files, so without this they linger as
-    stale specs under fm_agent/extracted_functions/.
+    Delete extracted-function files that no longer correspond to a function in the
+    current source, for every changed source file, and prune any directory left
+    empty. Rather than reconstructing removed functions' paths from their (regex,
+    class-less) names — which cannot address a specific class member — we reconcile
+    each changed file's function directory against the set codegraph now produces
+    for it (re-extraction and the index rebuild have already run at this point):
+    any extracted file not in that valid set is stale and removed. A deleted source
+    file yields an empty valid set, so all of its extracted files are removed.
     """
-    removed = _modified_function_targets(
-        proj_dir, modified_functions, classes=("removed",)
-    )
-    for path in removed.values():
-        if os.path.isfile(path):
-            os.remove(path)
-    for path in removed.values():
-        func_dir = os.path.dirname(path)
-        if os.path.isdir(func_dir) and not os.listdir(func_dir):
-            os.rmdir(func_dir)
+    for abs_src in modified_functions:
+        func_dir, ext = _src_rel_to_func_dir(proj_dir, abs_src)
+        if not os.path.isdir(func_dir):
+            continue
+
+        valid = set()
+        lang_key = EXT_TO_LANG.get(ext)
+        if lang_key and os.path.isfile(abs_src):
+            spans, _raw = _function_spans(abs_src, lang_key, proj_dir)
+            for ident, _s, _e in spans:
+                # ident is the class-qualified, deduped identifier written by
+                # run_extraction; "::" maps to the class subdirectory layout.
+                parts = ident.split("::")
+                path = os.path.join(func_dir, *parts) + (f".{ext}" if ext else "")
+                valid.add(os.path.abspath(path))
+
+        for root, _dirs, fnames in os.walk(func_dir):
+            for fn in fnames:
+                abs_path = os.path.abspath(os.path.join(root, fn))
+                if abs_path not in valid:
+                    os.remove(abs_path)
+
+        # Prune empty directories left behind (deepest first).
+        for root, dirs, _files in os.walk(func_dir, topdown=False):
+            if root != func_dir and os.path.isdir(root) and not os.listdir(root):
+                os.rmdir(root)
 
 
 def _extract_leading_spec_comments(content, comment_prefix, spec_marker):
@@ -1131,9 +1185,15 @@ def collect_relevent_function_scope(proj_dir, developer_intent, changed_function
 
             if ranked:
                 # Keep the extracted-function file for each selected function name.
+                # scope.py reports class-less names, but members live under a class
+                # subdirectory, so match against the actual files by method stem
+                # (a same-name method in two classes keeps both — safe for scope).
+                by_method = _extracted_files_by_method(func_dir)
                 for f in ranked:
-                    cand = os.path.join(func_dir, f"{f['name']}.{ext}")
-                    if os.path.isfile(cand):
+                    cands = by_method.get(f["name"]) or by_method.get(
+                        re.sub(r"_\d+$", "", f["name"]), []
+                    )
+                    for cand in cands:
                         _record(os.path.relpath(cand, extracted_dir), f.get("score", 0.0))
                 logging.info(
                     "    [scope] pass 3/3: %s -> %s",
@@ -1141,11 +1201,13 @@ def collect_relevent_function_scope(proj_dir, developer_intent, changed_function
                     ", ".join(f"{f['name']}={f.get('score', 0.0):.2f}" for f in ranked),
                 )
             else:
-                # scope.py could not localize within this file — keep all of its functions.
-                for fname in os.listdir(func_dir):
-                    cand = os.path.join(func_dir, fname)
-                    if os.path.isfile(cand):
-                        _record(os.path.relpath(cand, extracted_dir), 0.0)
+                # scope.py could not localize within this file — keep all of its
+                # functions, walking recursively so nested class members are kept.
+                for root, _dirs, fnames in os.walk(func_dir):
+                    for fname in fnames:
+                        cand = os.path.join(root, fname)
+                        if os.path.isfile(cand):
+                            _record(os.path.relpath(cand, extracted_dir), 0.0)
 
     # Order by descending relevance score (path as a deterministic tie-breaker), then keep
     # only the first `range` functions when a limit is given.

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -40,6 +40,7 @@ def canonicalize(func_name):
             return func_name.translate(_SAFE_REPLACE)
     return func_name
 
+
 def _qualified_parts(name: str, qualified_name: str) -> list:
     """Split codegraph's ``qualified_name`` into ``[*scope_parts, name]``.
 

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -243,7 +243,7 @@ class CodeGraphExtractor:
                 # different parameters), which would otherwise overwrite each other
                 # ("LocalStorage::Flush", "LocalStorage::Flush_1"). funcs are
                 # line-ordered (SQL ORDER BY start_line), so the suffix is
-                # deterministic. run_extraction turns the "::" into subdirectories.
+                # deterministic. run_extraction keeps the "::" in the flat filename.
                 count = ident_counts.get(ident, 0)
                 ident_counts[ident] = count + 1
                 deduped = ident if count == 0 else f"{ident}_{count}"

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -11,6 +11,7 @@ REGISTRY in src/languages/registry.py. No other files need to change.
 import hashlib
 import logging
 import os
+import re
 import shutil
 import sqlite3
 import subprocess
@@ -38,6 +39,47 @@ def canonicalize(func_name):
         if ch in func_name:
             return func_name.translate(_SAFE_REPLACE)
     return func_name
+
+
+def _qualified_parts(name: str, qualified_name: str) -> list:
+    """Split codegraph's ``qualified_name`` into ``[*scope_parts, name]``.
+
+    Member functions carry their enclosing class (and namespace) so they can be
+    told apart by class instead of by an opaque line-order suffix:
+
+        free function ``main``                 -> ``['main']``
+        C++ ``LocalStorage::Flush``            -> ``['LocalStorage', 'Flush']``
+        nested ``ns::Widget::draw``            -> ``['ns', 'Widget', 'draw']``
+        dot-scoped (Python/Java) ``Foo.bar``   -> ``['Foo', 'bar']``
+
+    codegraph joins scopes with ``::`` (C/C++) or ``.`` (Python, Java, ...); both
+    are normalised here. If ``qualified_name`` is missing or does not end with
+    ``name`` (unexpected shape), we fall back to the bare name so behaviour never
+    regresses below the previous name-only scheme.
+    """
+    q = (qualified_name or "").strip()
+    if not q or not q.endswith(name):
+        return [name]
+    scope = q[: -len(name)].rstrip(":.")
+    if not scope:
+        return [name]
+    parts = [p for p in re.split(r"::|\.", scope) if p]
+    return parts + [name]
+
+
+def _extraction_ident(name: str, qualified_name: str) -> str:
+    """Return the class-qualified, filesystem-safe identifier for a function.
+
+    Each component is passed through :func:`canonicalize` (so a class-scoped
+    operator like ``Store::operator/`` stays path/FQN-safe), then joined with
+    ``::``. This single string is used both as a function's FQN tail and — with
+    ``::`` turned into path separators — as its extracted-file location, so the
+    call edges (via :func:`_node_fqn_map`) and the extracted files (via
+    ``run_extraction`` + ``_file_to_fqn``) always agree. Examples:
+    ``main`` -> ``"main"``; ``LocalStorage::Flush`` -> ``"LocalStorage::Flush"``.
+    """
+    return "::".join(canonicalize(p) for p in _qualified_parts(name, qualified_name))
+
 
 # Maps FM-Agent lang_key → the language string stored in codegraph's SQLite
 # nodes.language column. Only includes languages that codegraph actually supports.
@@ -107,7 +149,7 @@ def _node_fqn_map(cur, cg_langs) -> dict:
     placeholders = ",".join("?" * len(cg_langs))
     cur.execute(
         f"""
-        SELECT id, name, file_path, start_line
+        SELECT id, name, qualified_name, file_path, start_line
         FROM nodes
         WHERE kind IN ('function', 'method') AND language IN ({placeholders})
         ORDER BY file_path, start_line
@@ -116,12 +158,12 @@ def _node_fqn_map(cur, cg_langs) -> dict:
     )
     counts: dict = {}
     result: dict = {}
-    for node_id, name, file_path, _start in cur.fetchall():
-        cname = canonicalize(name)
-        key = (file_path, cname)
+    for node_id, name, qualified_name, file_path, _start in cur.fetchall():
+        ident = _extraction_ident(name, qualified_name)
+        key = (file_path, ident)
         c = counts.get(key, 0)
         counts[key] = c + 1
-        deduped = cname if c == 0 else f"{cname}_{c}"
+        deduped = ident if c == 0 else f"{ident}_{c}"
         result[node_id] = _fqn_for(file_path, deduped)
     return result
 
@@ -165,7 +207,7 @@ class CodeGraphExtractor:
         placeholders = ",".join("?" * len(cg_langs))
         cur.execute(
             f"""
-            SELECT name, file_path, start_line, end_line
+            SELECT name, qualified_name, file_path, start_line, end_line
             FROM nodes
             WHERE kind IN ('function', 'method') AND language IN ({placeholders})
             ORDER BY file_path, start_line
@@ -176,8 +218,9 @@ class CodeGraphExtractor:
         conn.close()
 
         by_file = defaultdict(list)
-        for name, file_path, start_line, end_line in rows:
-            by_file[file_path].append((name, int(start_line), int(end_line)))
+        for name, qualified_name, file_path, start_line, end_line in rows:
+            ident = _extraction_ident(name, qualified_name)
+            by_file[file_path].append((ident, int(start_line), int(end_line)))
 
         result = {}
         for file_path, funcs in by_file.items():
@@ -188,22 +231,22 @@ class CodeGraphExtractor:
             except OSError:
                 continue
 
-            name_counts = {}
+            ident_counts = {}
             file_funcs = []
-            for name, start_line, end_line in funcs:
-                # Disambiguate functions sharing a name within one file
-                # (LocalStorage::Flush vs RemoteCache::Flush, overloads, a method
-                # and a same-named free function, ...). codegraph stores them all
-                # under the same bare name; run_extraction writes each to
-                # "<name>.<ext>", so without a suffix the later definition
-                # silently overwrites the earlier one — dropping functions from
-                # both extraction and the call graph. Mirror the regex path's
-                # dedup ("Flush", "Flush_1", ...). funcs are line-ordered (SQL
-                # ORDER BY start_line), so suffix assignment is deterministic.
-                cname = canonicalize(name)
-                count = name_counts.get(cname, 0)
-                name_counts[cname] = count + 1
-                deduped = cname if count == 0 else f"{cname}_{count}"
+            for ident, start_line, end_line in funcs:
+                # ``ident`` is the class-qualified identifier ("LocalStorage::Flush",
+                # or the bare name for a free function). Member functions in
+                # different classes are already distinct here, so the class name —
+                # not an opaque line-order suffix — is what tells them apart.
+                # A suffix is still appended only when two functions share the exact
+                # same qualified identifier (e.g. overloads: same class + same name,
+                # different parameters), which would otherwise overwrite each other
+                # ("LocalStorage::Flush", "LocalStorage::Flush_1"). funcs are
+                # line-ordered (SQL ORDER BY start_line), so the suffix is
+                # deterministic. run_extraction turns the "::" into subdirectories.
+                count = ident_counts.get(ident, 0)
+                ident_counts[ident] = count + 1
+                deduped = ident if count == 0 else f"{ident}_{count}"
                 # codegraph uses 1-indexed lines, end_line is inclusive
                 body_lines = all_lines[start_line - 1 : end_line]
                 body = "".join(body_lines)
@@ -243,7 +286,7 @@ class CodeGraphExtractor:
         placeholders = ",".join("?" * len(cg_langs))
         cur.execute(
             f"""
-            SELECT name, start_line, end_line
+            SELECT name, qualified_name, start_line, end_line
             FROM nodes
             WHERE kind IN ('function', 'method') AND language IN ({placeholders})
               AND file_path = ?
@@ -256,8 +299,13 @@ class CodeGraphExtractor:
 
         if not rows:
             return None
-        # codegraph uses 1-indexed lines with an inclusive end_line.
-        return [(canonicalize(name), int(start) - 1, int(end) - 1) for name, start, end in rows]
+        # codegraph uses 1-indexed lines with an inclusive end_line. Return the
+        # class-qualified identifier so the caller's dedup + name matching (trim)
+        # stays consistent with the extracted files and the call graph.
+        return [
+            (_extraction_ident(name, qualified_name), int(start) - 1, int(end) - 1)
+            for name, qualified_name, start, end in rows
+        ]
 
     def get_call_edges(self, lang_key: str) -> dict:
         """Return {caller_fqn: {callee_fqn, ...}} for the given language.


### PR DESCRIPTION
## Motivation — resolves #97

Member functions used to get an opaque line-order suffix in their FQN
(`main-cpp::action_1`), so entry-func could not name a specific class's method
and same-name methods across classes were indistinguishable to the user. gdb,
compilers, and humans all identify member functions as `Class::method`.

This makes FM-Agent do the same: `Class2::action`, `LocalStorage::Flush`, etc.
Free functions keep their bare name; the numeric suffix (`_1`, `_2`) is now
kept **only** for true overloads (same class + name, different parameters —
which codegraph's `qualified_name`/`signature` cannot yet separate).

## What changed

- **codegraph**: derive the FQN / extracted-file identifier / spans from
  codegraph's `qualified_name`, canonicalizing each component so a class-scoped
  operator (`Store::operator/`) stays path/FQN-safe. Falls back to the bare name
  for free functions and any unexpected `qualified_name` shape.
- **extract**: write a class-qualified identifier as a flat file that keeps the
  `::` in its name (`Class2::action.cpp`), so `_file_to_fqn` rebuilds
  `...-cpp::Class2::action`.
- **generate_topdown_layers**: collect extracted functions with `os.walk`.
- **entry pipeline**: reverse-map the extracted file to its source, and trim
  by the class-qualified identifier so same-name methods aren't collapsed.

The FQN is produced by the *same* rule in the call edges and the on-disk
extracted files, so the call graph, trimming and entry-func addressing stay
consistent.

## Note — member-function FQN change

This is a sizeable change to how member functions are named. Member-function
FQNs change from bare (`…local_storage-cpp::Flush`) to class-qualified
(`…local_storage-cpp::LocalStorage::Flush`). Any hard-coded FQN downstream must
add the class name (e.g. saved `--entry-func` / `--end-func` arguments). Free
functions are unaffected.

## Verification

Using the example from #97 — one file with four `action` functions (a global
`action` plus `Class1::action`, `Class2::action`, `Class3::action`), where
`main` calls only `Class2::action`:

- Extraction now yields distinct, class-qualified functions:
  `main-cpp::action` (global), `main-cpp::Class1::action`,
  `main-cpp::Class2::action`, `main-cpp::Class3::action` — each specced and
  reasoned about independently.
- `main.py <proj> --entry-func main-cpp::main --end-func main-cpp::Class2::action`
  builds the chain and keeps exactly `main` + `Class2::action.cpp`.
- `main.py <proj> --entry-func main-cpp::main --end-func main-cpp::Class1::action`
  correctly fails — `main` does not call `Class1::action`, so no chain exists.
  Before this change the class name could not be given at all, so the two were
  indistinguishable.

Overloads (`Store::Flush` twice) still fall back to `Store::Flush` /
`Store::Flush_1`; `Store::operator/` becomes the safe `Store::operator_`.
