### PR TITLE
Add opt-in --chisel-modules-only filter for Chisel spec generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ uv run python main.py <proj_dir>
 | `--chisel`   | With `--hardware`: treat the design as Chisel (Scala). This is the default HDL, so `--hardware` alone is equivalent to `--hardware --chisel` |
 | `--verilog`  | With `--hardware`: treat the design as Verilog/SystemVerilog (`.v`/`.sv`/`.svh`) |
 | `--resume`   | Resume an interrupted `--hardware` run: reuse `groups.json` and only regenerate missing module specs |
+| `--chisel-modules-only` | With `--hardware --chisel`: skip spec generation for Chisel classes confidently identified as non-hardware (IO Bundles, constant objects, and similar), keeping units that transitively extend `Module`/`RawModule`/`ExtModule`/`BlackBox`/`MultiIOModule`. Classes whose module-ness can't be determined heuristically (unresolved external bases, ambiguous or cyclic inheritance) are conservatively kept, not excluded. This is a text-only heuristic with no real Scala import/package resolution, so an unrelated class elsewhere in the project sharing a parent's bare name can, in rare cases, still cause a misclassification. An import alias that renames a base to `Module`/`RawModule`/`ExtModule`/`BlackBox`/`MultiIOModule`/`Bundle`/`Record`/`Data` (e.g. `import chisel3.{Module => Bundle}`) is treated as if it named that class directly, which can deterministically misclassify a real module. Extraction is unaffected; this only filters spec generation. |
 
 ### Generating Specs for Hardware Designs (`--hardware`)
 
@@ -144,6 +145,12 @@ For Chisel (Scala) hardware designs:
 
 ```bash
 uv run python main.py <proj_dir> --hardware
+```
+
+To skip spec generation for non-hardware Chisel units (IO Bundles, constant objects, `Main` entry points):
+
+```bash
+uv run python main.py <proj_dir> --hardware --chisel-modules-only
 ```
 
 For Verilog/SystemVerilog hardware designs:
@@ -155,6 +162,8 @@ uv run python main.py <proj_dir> --hardware --verilog
 In this mode FM-Agent runs a **spec-only** pipeline tailored to hardware: it understands the design, splits it into subsystems, and generates verification-oriented module specifications. It does **not** run the code reasoner or bug validation — only spec generation.
 
 The `proj_dir` must contain Scala (`.scala`) source files for Chisel, or Verilog (`.v`/`.sv`/`.svh`) source files for Verilog. For each extracted module, FM-Agent writes spec Markdown files next to the extracted module under `fm_agent/`:
+
+Chisel support is scoped to official Chisel syntax, corresponding to Scala 2 (2.12/2.13), consistent with the Scala version used by current Chisel releases. Scala 2's deprecated early-initializer syntax and Scala 3 are not within the supported scope.
 
 | Output                  | Content                                                              |
 | ----------------------- | ------------------------------------------------------------------- |

--- a/README_zh.md
+++ b/README_zh.md
@@ -116,6 +116,7 @@ uv run python main.py <proj_dir>
 | `--chisel` | 搭配 `--hardware`：将设计视为 Chisel（Scala）。这是默认 HDL，`--hardware` 单独使用等价于 `--hardware --chisel` |
 | `--verilog` | 搭配 `--hardware`：将设计视为 Verilog/SystemVerilog（`.v`/`.sv`/`.svh`） |
 | `--resume` | 恢复中断的 `--hardware` 运行：复用 `groups.json`，仅重新生成缺失的模块规约 |
+| `--chisel-modules-only` | 搭配 `--hardware --chisel`：对可明确判定为非硬件的 Chisel 类（IO Bundle、常量 object 等）跳过规约生成，保留传递继承 `Module`/`RawModule`/`ExtModule`/`BlackBox`/`MultiIOModule` 的单元。模块归属无法通过启发式规则确定的类（父类无法解析、存在歧义或循环继承）一律保守判定为需保留，不予排除。该判定基于纯文本启发式规则，不执行 Scala import/package 解析，故项目中若存在与某父类同名的无关类，仍存在低概率误判风险。若 import 别名将某个基类重命名为 `Module`/`RawModule`/`ExtModule`/`BlackBox`/`MultiIOModule`/`Bundle`/`Record`/`Data`（例如 `import chisel3.{Module => Bundle}`），该判定会将其等同于直接使用该名称，可能导致对真实模块的确定性误判。此选项不影响提取（extraction）阶段，仅作用于规约生成阶段。 |
 
 ### 为硬件设计生成规约（`--hardware`）
 
@@ -123,6 +124,12 @@ uv run python main.py <proj_dir>
 
 ```bash
 uv run python main.py <proj_dir> --hardware
+```
+
+跳过非硬件 Chisel 单元（IO Bundle、常量 object、`Main` 入口）的规约生成：
+
+```bash
+uv run python main.py <proj_dir> --hardware --chisel-modules-only
 ```
 
 对于 Verilog/SystemVerilog 硬件设计：
@@ -135,6 +142,8 @@ uv run python main.py <proj_dir> --hardware --verilog
 
 Chisel 设计的 `proj_dir` 中必须包含 Scala（`.scala`）源文件，Verilog 设计则必须包含 Verilog（`.v`/`.sv`/`.svh`）源文件。对于每个提取出的模块，FM-Agent 会在 `fm_agent/` 下、提取出的模块文件旁写入独立的 Markdown 文件描述硬件规约：
 
+Chisel 支持范围限定为官方 Chisel 语法，对应 Scala 2（2.12/2.13）版本，与当前 Chisel 发行版所使用的 Scala 版本一致。Scala 2 已废弃的 early-initializer 语法，Scala 3 不属于支持范围。
+
 | 输出 | 内容 |
 |---|---|
 | `<ModuleName>_spec.md` | 模块行为的面向验证的规约 |
@@ -142,7 +151,7 @@ Chisel 设计的 `proj_dir` 中必须包含 Scala（`.scala`）源文件，Veril
 
 生成的规约会在运行过程中按质量检查清单进行校验；未通过校验的规约会被自动删除并重新生成。若运行中断，可加 `--resume` 重新运行：已完成的规约会保留，仅重新生成缺失部分。
 
-**Verilog 流程要求安装 [Verible](https://github.com/chipsalliance/verible)**：`verible-verilog-syntax` 必须在 `PATH` 上，以保证模块提取和实例化依赖分析的准确性。未安装时 Verilog 流程会拒绝启动（可设置 `FM_AGENT_NO_VERIBLE=1` 强制使用精度较低的纯 Python 兜底解析器）。
+**Verilog 流程要求安装 [Verible](https://github.com/chipsalliance/verible)**：`verible-verilog-syntax` 必须在 `PATH` 上，以保证模块提取和实例化依赖分析的准确性。未安装时 Verilog 流程会拒绝启动（可设置 `FM_AGENT_NO_VERIBLE=1` 强制使用精度较低的纯 Python 备用解析器）。
 
 ### 输出说明
 

--- a/main.py
+++ b/main.py
@@ -606,6 +606,25 @@ if __name__ == "__main__":
         help="Resume a previous --hardware run: reuse groups.json and only "
         "regenerate missing module specs.",
     )
+    parser.add_argument(
+        "--chisel-modules-only",
+        action="store_true",
+        help="With --hardware --chisel: skip spec generation for Chisel classes "
+        "confidently identified as non-hardware (IO Bundles, constant objects, "
+        "and similar), keeping units that transitively extend "
+        "Module/RawModule/ExtModule/BlackBox/MultiIOModule. Classes whose "
+        "module-ness can't be determined heuristically (unresolved external "
+        "bases, ambiguous or cyclic inheritance) are conservatively kept, not "
+        "excluded. This is a text-only heuristic with no real Scala import/"
+        "package resolution, so an unrelated class elsewhere in the project "
+        "sharing a parent's bare name can, in rare cases, still cause a "
+        "misclassification. An import alias that renames a base to "
+        "Module/RawModule/ExtModule/BlackBox/MultiIOModule/Bundle/Record/Data "
+        "(e.g. `import chisel3.{Module => Bundle}`) is treated as if it named "
+        "that class directly, which can deterministically misclassify a real "
+        "module. Extraction itself is unaffected; this only filters spec "
+        "generation.",
+    )
     args = parser.parse_args()
 
     if (args.chisel or args.verilog) and not args.hardware:
@@ -616,6 +635,12 @@ if __name__ == "__main__":
         # exact workspace --resume promises to preserve.
         parser.error("--resume only applies to --hardware runs; "
                      "add --hardware (and --verilog for Verilog designs)")
+    if args.chisel_modules_only and not args.hardware:
+        parser.error("--chisel-modules-only only applies to --hardware Chisel runs; "
+                     "add --hardware")
+    if args.chisel_modules_only and args.verilog:
+        parser.error("--chisel-modules-only is Chisel-only and cannot be combined "
+                     "with --verilog")
 
     start_time = time.time()
     if args.hardware and args.verilog:
@@ -625,7 +650,8 @@ if __name__ == "__main__":
     elif args.hardware:
         from src.chisel_spec_generator import run_chisel_spec_generation
 
-        run_chisel_spec_generation(os.path.abspath(args.proj_dir), resume=args.resume)
+        run_chisel_spec_generation(os.path.abspath(args.proj_dir), resume=args.resume,
+                                    chisel_modules_only=args.chisel_modules_only)
     else:
         run_pipeline(os.path.abspath(args.proj_dir))
     end_time = time.time()

--- a/src/chisel_spec_generator.py
+++ b/src/chisel_spec_generator.py
@@ -708,8 +708,151 @@ def _has_scala_source(proj_dir):
     return False
 
 
+def _scan_chisel_module_classification(work_dir, valid_phase_numbers=None):
+    """Aggregate is_module/module_classification_reason across ALL phases'
+    topdown layer JSON.
+
+    Returns ``(classification, excluded)`` where ``classification`` maps
+    fqn -> ``(is_module, reason)`` and ``excluded`` lists ``(fqn, reason)``
+    for every ``is_module=False`` entry. generate_topdown_layers stamps both
+    fields on every Chisel entry unconditionally, so either field missing
+    here means a corrupted or foreign topdown layer JSON, not an
+    unclassified unit -- raised loudly rather than silently defaulted.
+
+    ``valid_phase_numbers``, when given, restricts the scan to those phase
+    numbers -- callers with a live ``phases.json`` should always pass the
+    CURRENT phase numbers. Without it, an orphaned ``phase_NN_topdown_
+    layers.json`` surviving on disk from a prior run whose phases.json no
+    longer lists phase NN (a removed subsystem, or a phase whose source
+    files vanished between runs without the manifest being reset) could
+    smuggle a stale real module's classification into the result, letting
+    the zero-post-filter-modules guard silently miss that the CURRENT
+    phases have zero real modules.
+    """
+    spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
+    if not os.path.isdir(spec_prompts_dir):
+        return {}, []
+    layer_files = [
+        fname for fname in sorted(os.listdir(spec_prompts_dir))
+        if re.match(r"phase_\d+_topdown_layers\.json$", fname)
+    ]
+    if valid_phase_numbers is not None:
+        layer_files = [
+            fname for fname in layer_files
+            if int(re.match(r"phase_(\d+)_topdown_layers\.json$", fname).group(1))
+            in valid_phase_numbers
+        ]
+    classification = {}
+    excluded = []
+    for fname in layer_files:
+        layers_data = _load_json_file(os.path.join(spec_prompts_dir, fname), fname)
+        for layer in layers_data.get("layers", []):
+            for fn in layer.get("functions", []):
+                fqn = fn.get("name", "<unknown>")
+                if "is_module" not in fn or "module_classification_reason" not in fn:
+                    raise RuntimeError(
+                        f"Chisel unit {fqn!r} in {fname} is missing 'is_module' or "
+                        f"'module_classification_reason' -- generate_topdown_layers "
+                        f"stamps both fields on every Chisel unit unconditionally; a "
+                        f"missing field means a corrupted or foreign topdown layer JSON."
+                    )
+                is_module = fn["is_module"]
+                reason = fn["module_classification_reason"]
+                if not isinstance(is_module, bool) or not isinstance(reason, str) or not reason:
+                    raise RuntimeError(
+                        f"Chisel unit {fqn!r} in {fname} has 'is_module'/"
+                        f"'module_classification_reason' of the wrong type "
+                        f"(is_module={is_module!r}, reason={reason!r}) -- "
+                        f"generate_topdown_layers always stamps is_module as a "
+                        f"bool and reason as a non-empty string; this means a "
+                        f"corrupted or foreign topdown layer JSON."
+                    )
+                classification[fqn] = (is_module, reason)
+                if not is_module:
+                    excluded.append((fqn, reason))
+    return classification, excluded
+
+
+def _log_would_be_excluded_chisel_units(excluded):
+    """Print the one-time 'if --chisel-modules-only were on, these units
+    would be excluded' advisory. No-op when nothing would be excluded."""
+    if not excluded:
+        return
+    print(f"[Chisel] --chisel-modules-only is off; if it were set, "
+          f"{len(excluded)} unit(s) would be excluded from spec generation:")
+    for fqn, reason in sorted(excluded):
+        print(f"[Chisel]   {fqn} ({reason})")
+
+
+def _fail_if_chisel_modules_only_excludes_everything(classification, excluded, chisel_modules_only):
+    """Exit loudly if --chisel-modules-only would leave zero real modules
+    despite Chisel units existing, aggregated across ALL phases.
+
+    No-op when the flag is off, when there are no Chisel units at all (a
+    different, pre-existing guard already handles that), or when at least
+    one unit classifies True in ANY phase.
+    """
+    if not chisel_modules_only or not classification:
+        return
+    if any(is_module for is_module, _reason in classification.values()):
+        return
+    print(f"[Chisel] ERROR: --chisel-modules-only excludes ALL {len(classification)} "
+          f"Chisel unit(s) found across all phases; nothing would be generated. "
+          f"Excluded units:")
+    for fqn, reason in sorted(excluded):
+        print(f"[Chisel]   {fqn} ({reason})")
+    sys.exit(1)
+
+
+def _warn_stale_specs_for_excluded_units(work_dir, excluded, valid_phase_numbers=None):
+    """One-time warning (never deletion) when an ``is_module=False`` unit
+    --chisel-modules-only would now exclude still has a ``_spec.md``/
+    ``_info.md`` from a prior unfiltered run on the same workspace (e.g.
+    a normal run followed by ``--resume --chisel-modules-only``).
+
+    Path Boundaries explicitly forbid deleting these -- they are accepted
+    clutter, matching this repo's existing precedent for orphaned
+    extraction artifacts (FUT-4). But leaving the run fully silent gives a
+    false impression that all non-hardware output was actually filtered
+    out; this makes the otherwise-invisible leftover visible instead.
+    """
+    if not excluded:
+        return
+    excluded_reasons = dict(excluded)
+    spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
+    if not os.path.isdir(spec_prompts_dir):
+        return
+    layer_files = [
+        fname for fname in sorted(os.listdir(spec_prompts_dir))
+        if re.match(r"phase_\d+_topdown_layers\.json$", fname)
+    ]
+    if valid_phase_numbers is not None:
+        layer_files = [
+            fname for fname in layer_files
+            if int(re.match(r"phase_(\d+)_topdown_layers\.json$", fname).group(1))
+            in valid_phase_numbers
+        ]
+    stale = []
+    for fname in layer_files:
+        layers_data = _load_json_file(os.path.join(spec_prompts_dir, fname), fname)
+        for layer in layers_data.get("layers", []):
+            for fn in layer.get("functions", []):
+                fqn = fn.get("name")
+                if fqn not in excluded_reasons:
+                    continue
+                filepath = os.path.join(work_dir, fn["file"])
+                if os.path.exists(chisel_spec_path(filepath)) or os.path.exists(chisel_info_path(filepath)):
+                    stale.append((fqn, excluded_reasons[fqn]))
+    if stale:
+        print(f"[Chisel] WARNING: {len(stale)} unit(s) excluded by --chisel-modules-only "
+              f"still have spec/info file(s) from a prior run (not deleted, see FUT-4):")
+        for fqn, reason in sorted(stale):
+            print(f"[Chisel]   {fqn} ({reason})")
+
+
 def _report_undocumented_submodules(work_dir, info_path_fn, label,
-                                    strip_dedup_suffix=True):
+                                    strip_dedup_suffix=True, filter_non_modules=False,
+                                    valid_phase_numbers=None):
     """Advisory (report only): list modules whose call graph shows submodules
     but whose info document lacks a parseable ``# Submodule:`` entry for them.
 
@@ -720,6 +863,19 @@ def _report_undocumented_submodules(work_dir, info_path_fn, label,
     to the declared name the info headings use; pass False for Verilog, where
     ``_<digits>`` endings are genuine module names (``fifo_64``) and stripping
     them would hide real gaps. Returns ``[(module_fqn, [missing...]), ...]``.
+
+    ``filter_non_modules`` excludes ``is_module=False`` callees from the
+    expected-documentation set — Chisel-only, passed True only when
+    ``--chisel-modules-only`` is set. Verilog entries never carry an
+    ``is_module`` field, so this MUST stay an explicit opt-in rather than a
+    ``fn.get("is_module")`` truthiness check: ``None`` is falsy too, and an
+    unconditional check would silently empty the Verilog advisory.
+
+    ``valid_phase_numbers``, when given, limits both advisory passes to layer
+    files generated for those phases. Chisel passes the phases actually
+    written during the current run so orphaned layer files cannot overwrite
+    current classification metadata; Verilog leaves this unset to preserve
+    its existing behavior.
     """
     spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
     if not os.path.isdir(spec_prompts_dir):
@@ -728,23 +884,43 @@ def _report_undocumented_submodules(work_dir, info_path_fn, label,
         fname for fname in sorted(os.listdir(spec_prompts_dir))
         if re.match(r"phase_\d+_topdown_layers\.json$", fname)
     ]
+    if valid_phase_numbers is not None:
+        layer_files = [
+            fname for fname in layer_files
+            if int(re.match(r"phase_(\d+)_topdown_layers\.json$", fname).group(1))
+            in valid_phase_numbers
+        ]
     # First pass: fqn -> declared name, stamped by generate_topdown_layers
     # with the extractor's own declaration regex. Maps dedup aliases
     # (Control_1) back to the name info headings use (Control); a genuine
     # module named Stage_1 declares its own stem, so its gap is never hidden.
+    # is_module is collected in this SAME cross-phase pass so a callee's
+    # cross-phase FQN reference resolves correctly too.
     declared_names = {}
+    is_module_index = {}
     for fname in layer_files:
         layers_data = _load_json_file(os.path.join(spec_prompts_dir, fname), fname)
         for layer in layers_data.get("layers", []):
             for fn in layer.get("functions", []):
                 if fn.get("declared_name"):
                     declared_names[fn["name"]] = fn["declared_name"]
+                if filter_non_modules and "is_module" in fn:
+                    is_module_index[fn["name"]] = fn["is_module"]
     gaps = []
     for fname in layer_files:
         layers_data = _load_json_file(os.path.join(spec_prompts_dir, fname), fname)
         for layer in layers_data.get("layers", []):
             for fn in layer.get("functions", []):
+                if filter_non_modules and is_module_index.get(fn["name"]) is False:
+                    # This unit was never sent to the LLM for spec/info
+                    # generation under the filtered flow (batch generation
+                    # excludes it) -- its info file, if any, is either
+                    # absent or stale from a prior unfiltered run, so it
+                    # cannot fairly be held to a documentation standard.
+                    continue
                 callees = fn.get("all_callees") or []
+                if filter_non_modules:
+                    callees = [c for c in callees if is_module_index.get(c, True)]
                 if not callees:
                     continue
                 info_path = info_path_fn(os.path.join(work_dir, fn["file"]))
@@ -773,7 +949,7 @@ def _report_undocumented_submodules(work_dir, info_path_fn, label,
     return gaps
 
 
-def run_chisel_spec_generation(proj_dir, resume=False):
+def run_chisel_spec_generation(proj_dir, resume=False, chisel_modules_only=False):
     """Generate verification-oriented specs for a Chisel (Scala) design.
 
     Mirrors :func:`main.run_pipeline` but is Chisel-specific and spec-only: it
@@ -784,6 +960,9 @@ def run_chisel_spec_generation(proj_dir, resume=False):
     ``groups.json`` already exists, and Stage 5 only generates specs for modules
     that do not yet have valid spec/info files (via :func:`chisel_spec_ready`).
     This lets an interrupted run continue without regenerating completed specs.
+
+    ``chisel_modules_only`` restricts spec generation to Chisel classes that
+    transitively extend Module/RawModule/ExtModule/BlackBox/MultiIOModule.
     """
     if not os.path.isdir(proj_dir):
         print(f"[Chisel] ERROR: proj_dir does not exist or is not a directory: {proj_dir}")
@@ -954,7 +1133,7 @@ def run_chisel_spec_generation(proj_dir, resume=False):
         except OSError:
             pass
         _reset_derived_state(work_dir)
-        return run_chisel_spec_generation(proj_dir, resume=True)
+        return run_chisel_spec_generation(proj_dir, resume=True, chisel_modules_only=chisel_modules_only)
 
     if not any(
         _get_phase_files(phases_data, phase["phase"], input_dir)
@@ -965,7 +1144,31 @@ def run_chisel_spec_generation(proj_dir, resume=False):
 
     # --- Stage 3: Generate topdown layers ---
     print("[Chisel] Stage 3/4: Generating topdown layers...")
-    generate_topdown_layers(work_dir)
+    _written_topdown_files = generate_topdown_layers(work_dir)
+
+    # Aggregated across ALL phases ACTUALLY (re)written THIS run, before
+    # Stage 4's per-layer loop begins. Scoping to phases.json's declared
+    # phase numbers is not enough: a phase still listed there whose source
+    # extracted to nothing this run (vanished/emptied without the manifest
+    # being reset) is SKIPPED by generate_topdown_layers, leaving its OLD
+    # topdown JSON -- and any real module it once had -- untouched on disk.
+    # Scoping to generate_topdown_layers' own return value excludes that
+    # phase entirely, matching what Stage 4 will actually attempt this run.
+    # Validates is_module/module_classification_reason stamping; with the
+    # flag on, fails loudly if filtering would leave zero real modules,
+    # otherwise shows what filtering WOULD exclude (zero effect on generation).
+    _current_phase_numbers = {
+        int(re.match(r"phase_(\d+)_topdown_layers\.json$", os.path.basename(p)).group(1))
+        for p in _written_topdown_files
+    }
+    _classification, _excluded = _scan_chisel_module_classification(
+        work_dir, valid_phase_numbers=_current_phase_numbers)
+    if chisel_modules_only:
+        _fail_if_chisel_modules_only_excludes_everything(
+            _classification, _excluded, chisel_modules_only)
+        _warn_stale_specs_for_excluded_units(work_dir, _excluded, _current_phase_numbers)
+    else:
+        _log_would_be_excluded_chisel_units(_excluded)
 
     # --- Stage 4: Execute spec generation (per phase, per layer) ---
     print("[Chisel] Stage 4/4: Generating Chisel module specs...")
@@ -1013,11 +1216,13 @@ def run_chisel_spec_generation(proj_dir, resume=False):
                   f"Layer {layer_idx}/{total_layers - 1}")
 
             # Generate batch prompts for this layer
-            subprocess.run(
-                ["python3", "fm_agent/spec_prompts/generate_batch_prompts.py",
-                 "--phase", str(phase_num), "--layers", str(layer_idx)],
-                cwd=proj_dir, check=True,
-            )
+            batch_prompts_argv = [
+                "python3", "fm_agent/spec_prompts/generate_batch_prompts.py",
+                "--phase", str(phase_num), "--layers", str(layer_idx),
+            ]
+            if chisel_modules_only:
+                batch_prompts_argv.append("--chisel-modules-only")
+            subprocess.run(batch_prompts_argv, cwd=proj_dir, check=True)
 
             # Read manifest
             manifest_path = os.path.join(batch_dir, "manifest.json")
@@ -1228,5 +1433,9 @@ def run_chisel_spec_generation(proj_dir, resume=False):
                 )
                 sys.exit(1)
 
-    _report_undocumented_submodules(work_dir, chisel_info_path, "Chisel")
+    _report_undocumented_submodules(
+        work_dir, chisel_info_path, "Chisel",
+        filter_non_modules=chisel_modules_only,
+        valid_phase_numbers=_current_phase_numbers,
+    )
     print("[Chisel] Done. Generated Chisel module spec/info files only; skipped reasoning and bug validation.")

--- a/src/chisel_support.py
+++ b/src/chisel_support.py
@@ -581,6 +581,140 @@ def _unit_end(lines, start_idx, masked_lines=None):
     return n - 1
 
 
+def _signature_text(lines, start_idx):
+    """Join the declaration signature's lines starting at ``start_idx``.
+
+    Mirrors ``_unit_end``'s walk over continuation lines, but returns the
+    assembled signature text (up to, not including, any body ``{``) instead
+    of a line index. This is what lets an ``extends`` clause be found even
+    when it falls on a line after the declaration keyword, e.g. behind a
+    multi-line constructor parameter list.
+    """
+    n = len(lines)
+    i = start_idx
+    paren_depth = 0
+    parts = []
+    while i < n:
+        brace_col, paren_depth = _body_brace_and_paren(lines[i], paren_depth)
+        if brace_col >= 0:
+            parts.append(lines[i][:brace_col])
+            return "\n".join(parts)
+        parts.append(lines[i])
+        if _signature_continues(lines[i], paren_depth):
+            i += 1
+            continue
+        # Same continuation set as _unit_end: a next line opening with `(`
+        # is a further curried parameter clause (SLS: ClassParamClause ::=
+        # [nl] '(' ...), commonly a trailing `(implicit p: Parameters)`.
+        if _next_code_line_starts_with(lines, i, ("extends", "with", "(")):
+            i += 1
+            continue
+        return "\n".join(parts)
+    return "\n".join(parts)
+
+
+_EXTENDS_CLAUSE_RE = re.compile(r'\bextends\b')
+_WITH_CLAUSE_RE = re.compile(r'\bwith\b')
+
+
+def _extract_extends_expr(sig_text):
+    """Return the raw ``extends`` clause expression from assembled signature
+    text (stopping before any ``with`` mixin), or None if there is no clause.
+    """
+    m = _EXTENDS_CLAUSE_RE.search(sig_text)
+    if not m:
+        return None
+    rest = sig_text[m.end():]
+    wm = _WITH_CLAUSE_RE.search(rest)
+    if wm:
+        rest = rest[:wm.start()]
+    rest = rest.strip()
+    return rest or None
+
+
+def _strip_trailing_group(expr):
+    """Strip one trailing balanced ``(...)``/``[...]`` group from ``expr``.
+
+    Returns the shortened expression, or None if ``expr`` doesn't end with a
+    closing bracket or the brackets aren't balanced.
+    """
+    expr = expr.rstrip()
+    if not expr or expr[-1] not in ')]':
+        return None
+    close = expr[-1]
+    open_ch = '(' if close == ')' else '['
+    depth = 0
+    i = len(expr) - 1
+    while i >= 0:
+        if expr[i] == close:
+            depth += 1
+        elif expr[i] == open_ch:
+            depth -= 1
+            if depth == 0:
+                return expr[:i].rstrip()
+        i -= 1
+    return None
+
+
+def _normalize_parent_name(expr):
+    """Normalize an ``extends`` clause expression to ``(parent, prefix)``.
+
+    Repeatedly strips trailing constructor-argument/type-argument groups
+    (handling nesting, e.g. ``Foo[Vec[UInt]](x)``), then splits off the last
+    ``.``-qualified segment as ``parent``. ``prefix`` is everything before
+    that last segment (e.g. ``"chisel3"``, ``"_root_.chisel3"``, or a
+    project's own package like ``"mypkg"``), or None for a bare name.
+
+    Exposing the actual prefix -- not just a "was qualified" bool -- matters:
+    ``chisel3.Data`` and a project's own ``mypkg.Data`` both normalize to the
+    same bare ``parent="Data"``, but only the former is chisel3's own Data.
+    Callers must check ``prefix`` to tell them apart rather than treating any
+    qualified name ending in ``.Data`` as chisel3's.
+    """
+    expr = expr.strip()
+    if not expr:
+        return None, None
+    while True:
+        stripped = _strip_trailing_group(expr)
+        if stripped is None:
+            break
+        expr = stripped
+        if not expr:
+            return None, None
+    if '.' in expr:
+        prefix, _, name = expr.rpartition('.')
+        return (name or None), (prefix or None)
+    return (expr or None), None
+
+
+def chisel_decl_info(text):
+    """Single source of truth for ``(kind, name, parent, parent_prefix)``
+    of the first top-level Chisel/Scala declaration in an extracted unit.
+
+    Extends ``chisel_declared_name``'s declaration lookup with the parent
+    class/trait named in an ``extends`` clause, assembling the full
+    (possibly multi-line) signature first so an ``extends`` clause that
+    falls after the declaration keyword line is still found. ``parent`` is
+    the normalized bare name (trailing argument/type groups and package
+    qualification stripped), or None when there is no ``extends`` clause.
+    ``parent_prefix`` is the qualifying package portion of a qualified
+    ``extends`` clause (e.g. ``"chisel3"`` for ``chisel3.Module``), or None
+    for a bare name or when there is no ``extends`` clause. Returns
+    ``(None, None, None, None)`` when no declaration is found.
+    """
+    lines = strip_chisel_comments(text).splitlines()
+    for i, raw in enumerate(lines):
+        m = _CHISEL_DECL_RE.match(raw.strip())
+        if m:
+            extends_expr = _extract_extends_expr(_signature_text(lines, i))
+            if extends_expr:
+                parent, parent_prefix = _normalize_parent_name(extends_expr)
+            else:
+                parent, parent_prefix = None, None
+            return m.group("kind"), m.group("name"), parent, parent_prefix
+    return None, None, None, None
+
+
 # ---------------------------------------------------------------------------
 # Public entry point invoked by extract.py
 # ---------------------------------------------------------------------------

--- a/src/chisel_support.py
+++ b/src/chisel_support.py
@@ -507,13 +507,26 @@ def _signature_continues(line, paren_depth=0):
     return False
 
 
-def _next_code_line_starts_with(lines, start_idx, words):
-    """Return True if the next nonblank/comment line starts with one of words."""
+def _next_code_line_starts_with(lines, start_idx, tokens):
+    """Return True if the next nonblank line starts with one of tokens.
+
+    ``lines`` must already be comment-masked (:func:`strip_chisel_comments`);
+    both callers guarantee it, so comment-only lines arrive blank and are
+    skipped, and comment content can neither hide code sharing its line nor
+    fake a match. Blank lines are skipped, which per SLS 1.2 is slightly
+    over-permissive for the ``(`` token (a completely blank line yields two
+    ``nl`` tokens where the parameter-clause grammar allows one) --
+    accepted, since over-inclusion is the safe direction here and the case
+    only arises for top-level expressions in ``.sc`` scripts.
+    """
     for i in range(start_idx + 1, len(lines)):
-        stripped = _strip_trailing_comment(lines[i]).strip()
-        if not stripped or stripped.startswith(('//', '/*', '*')):
+        stripped = lines[i].strip()
+        if not stripped:
             continue
-        return any(re.match(r'^' + word + r'\b', stripped) for word in words)
+        return any(
+            re.match(r'^' + re.escape(token) + (r'\b' if token[-1].isalnum() else ''), stripped)
+            for token in tokens
+        )
     return False
 
 
@@ -526,25 +539,42 @@ def _package_block_line(line):
     )
 
 
-def _unit_end(lines, start_idx):
+def _unit_end(lines, start_idx, masked_lines=None):
     """Return the last line index of the declaration starting at ``start_idx``.
 
     If the declaration has a ``{ ... }`` body, returns the line of the matching
     closing brace.  Otherwise (a braceless ``def``/``class``, e.g.
     ``def double(x: UInt) = x + 1.U`` or ``abstract class Foo``) returns the last
     line of the (possibly multi-line) signature/expression.
+
+    The walk operates on the comment-masked counterpart of ``lines`` (the
+    same nested-comment/triple-string-aware :func:`strip_chisel_comments`
+    the extractor uses everywhere else), so a multi-line or nested block
+    comment anywhere in the signature -- including one whose ``*/`` closing
+    line carries a curried parameter clause -- cannot derail the per-line
+    state. Callers iterating over one file's declarations must mask once
+    and pass ``masked_lines`` -- re-masking per declaration is O(n^2) and
+    turns a generated ISA-definition-style file (thousands of top-level
+    declarations) from milliseconds into tens of seconds. Computed on
+    demand when omitted (single-declaration texts, tests).
     """
-    n = len(lines)
+    if masked_lines is None:
+        masked_lines = strip_chisel_comments("\n".join(lines)).splitlines()
+    n = len(masked_lines)
     i = start_idx
     paren_depth = 0
     while i < n:
-        brace_col, paren_depth = _body_brace_and_paren(lines[i], paren_depth)
+        brace_col, paren_depth = _body_brace_and_paren(masked_lines[i], paren_depth)
         if brace_col >= 0:
-            return _find_block_end(lines, i)
-        if _signature_continues(lines[i], paren_depth):
+            return _find_block_end(masked_lines, i)
+        if _signature_continues(masked_lines[i], paren_depth):
             i += 1
             continue
-        if _next_code_line_starts_with(lines, i, ("extends", "with")):
+        # `extends`/`with` may open the next line; so may a further curried
+        # parameter clause -- Scala 2 allows a single newline before each
+        # clause (``ClassParamClause ::= [nl] '(' ...``), the standard
+        # rocket-chip-ecosystem shape for trailing ``(implicit p: ...)``.
+        if _next_code_line_starts_with(masked_lines, i, ("extends", "with", "(")):
             i += 1
             continue
         return i
@@ -569,6 +599,9 @@ def extract_chisel_functions(lines, lang_key, lang_cfg):
     single extracted module re-parses to exactly one unit.
     """
     depth_start, clean_start = _scan_line_states(lines)
+    # Masked once for the whole file and shared by every _unit_end call --
+    # per-declaration re-masking is O(n^2) over the file (see _unit_end).
+    masked_lines = strip_chisel_comments("\n".join(lines)).splitlines()
     units = []
     i = 0
     n = len(lines)
@@ -604,7 +637,7 @@ def extract_chisel_functions(lines, lang_key, lang_cfg):
             continue
 
         name = m.group('name')
-        end = _unit_end(lines, i)
+        end = _unit_end(lines, i, masked_lines)
         units.append((name, i, end))
         i = end + 1
 

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -46,6 +46,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--batch-size", type=int, default=1, help="Functions per prompt file")
     parser.add_argument("--output-dir", default=None, help="Output directory for batch prompt files")
     parser.add_argument("--dry-run", action="store_true", help="Show plan without writing files")
+    parser.add_argument(
+        "--chisel-modules-only", action="store_true",
+        help="Only include is_module=True Chisel functions in batch generation "
+        "(all_funcs/func_to_layer stay unfiltered for caller/callee lookups).",
+    )
     return parser.parse_args()
 
 
@@ -213,6 +218,44 @@ def chunked(items: List[dict], size: int) -> List[List[dict]]:
     return [items[i : i + size] for i in range(0, len(items), size)]
 
 
+def _require_module_classification_fields(layer_functions: List[dict]) -> None:
+    """Raise loudly if any function entry is missing ``is_module``/
+    ``module_classification_reason``, or either has the wrong type.
+
+    generate_topdown_layers stamps ``is_module`` as a bool and
+    ``module_classification_reason`` as a non-empty string on every Chisel
+    unit unconditionally, so a missing field, or one of the wrong type,
+    means a corrupted or foreign topdown layer JSON, not an unclassified
+    unit. Checking this explicitly, before filtering, avoids the
+    truthiness trap of ``fn.get("is_module")``: not just a missing field
+    (``None`` is falsy), but also e.g. the STRING ``"false"`` (truthy in
+    Python) being silently treated as a real module, or ``0``/``None``
+    being silently treated as non-module without ever being flagged as
+    invalid. Mirrors the same validation in chisel_spec_generator.py's
+    ``_scan_chisel_module_classification``.
+    """
+    for fn in layer_functions:
+        if "is_module" not in fn or "module_classification_reason" not in fn:
+            name = fn.get("name", "<unknown>")
+            raise RuntimeError(
+                f"Chisel unit {name!r} is missing 'is_module' or "
+                f"'module_classification_reason' -- generate_topdown_layers "
+                f"stamps both fields on every Chisel unit unconditionally; a "
+                f"missing field means a corrupted or foreign topdown layer JSON."
+            )
+        is_module = fn["is_module"]
+        reason = fn["module_classification_reason"]
+        if not isinstance(is_module, bool) or not isinstance(reason, str) or not reason:
+            name = fn.get("name", "<unknown>")
+            raise RuntimeError(
+                f"Chisel unit {name!r} has 'is_module'/'module_classification_reason' "
+                f"of the wrong type (is_module={is_module!r}, reason={reason!r}) -- "
+                f"generate_topdown_layers always stamps is_module as a bool and "
+                f"reason as a non-empty string; this means a corrupted or foreign "
+                f"topdown layer JSON."
+            )
+
+
 def read_json(path: Path) -> dict:
     if not path.exists():
         raise FileNotFoundError(f"missing required file: {path}")
@@ -272,6 +315,7 @@ def build_prompt(
     work_dir: Path,
     fm_agent_prefix: str,
     ext_to_lang: Dict[str, str],
+    chisel_modules_only: bool = False,
 ) -> str:
     lines: List[str] = []
     sample_lang = "unknown"
@@ -329,6 +373,11 @@ def build_prompt(
                 continue
             caller_meta = all_funcs.get(caller_name)
             if not caller_meta:
+                continue
+            if chisel_modules_only and caller_meta.get("is_module") is False:
+                # Batch-generation-time filtering already excludes this
+                # caller from spec generation entirely; keep it out of the
+                # display-only name lists too, without touching all_funcs.
                 continue
             caller_file = work_dir / caller_meta["file"]
             if is_hw:
@@ -409,6 +458,11 @@ def build_prompt(
         caller_key = phase_callers_key(fn, phase)
         callers = fn.get(caller_key, [])
         earlier = [c for c in callers if func_to_layer.get(c, 10**9) < layer_idx]
+        if chisel_modules_only:
+            # Keep this structured name list consistent with the caller
+            # spec/expectation sections above: a name excluded there but
+            # still listed here would be a dangling reference.
+            earlier = [c for c in earlier if all_funcs.get(c, {}).get("is_module") is not False]
         module_file = Path(fn["file"])
         spec_file = module_file.with_name(module_file.stem + "_spec.md")
         info_file = module_file.with_name(module_file.stem + "_info.md")
@@ -523,6 +577,10 @@ def main() -> int:
     if start_layer < 0 or end_layer >= total_layers:
         raise ValueError(f"layer range {args.layers} out of bounds [0, {total_layers - 1}]")
 
+    if args.chisel_modules_only:
+        for layer in layers:
+            _require_module_classification_fields(layer.get("functions", []))
+
     output_dir = Path(args.output_dir) if args.output_dir else (
         work_dir / "spec_prompts" / f"batch_prompts_{project}_phase{args.phase:02d}"
     )
@@ -547,6 +605,8 @@ def main() -> int:
     for layer_idx in range(start_layer, end_layer + 1):
         layer = layers[layer_idx]
         layer_functions = layer.get("functions", [])
+        if args.chisel_modules_only:
+            layer_functions = [fn for fn in layer_functions if fn.get("is_module")]
         is_cycle = bool(layer.get("cycle_resolution", False))
         tag = "cycle" if is_cycle else "extracted"
         chunks = chunked(layer_functions, args.batch_size)
@@ -564,6 +624,7 @@ def main() -> int:
                 work_dir,
                 fm_agent_prefix,
                 ext_to_lang,
+                chisel_modules_only=args.chisel_modules_only,
             )
             out_path = output_dir / filename
             write_targets.append((out_path, content))

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -7,14 +7,14 @@ from collections import defaultdict
 
 try:
     from src.extract import EXT_TO_LANG, LANG_CONFIG, load_units_manifest
-    from src.chisel_support import chisel_declared_name, find_chisel_call_sites, strip_chisel_comments
+    from src.chisel_support import chisel_decl_info, chisel_declared_name, find_chisel_call_sites, strip_chisel_comments
     from src.verilog_support import find_verilog_call_sites, verilog_declared_name
 except ModuleNotFoundError:
     # Allow standalone execution as `python3 src/generate_topdown_layers.py`.
     import sys
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
     from src.extract import EXT_TO_LANG, LANG_CONFIG, load_units_manifest
-    from src.chisel_support import chisel_declared_name, find_chisel_call_sites, strip_chisel_comments
+    from src.chisel_support import chisel_decl_info, chisel_declared_name, find_chisel_call_sites, strip_chisel_comments
     from src.verilog_support import find_verilog_call_sites, verilog_declared_name
 
 
@@ -306,12 +306,6 @@ def _find_call_sites(text, lang_key, known_stems, keywords):
     return found
 
 
-_CHISEL_DECL_RE = re.compile(
-    r"^\s*(?:(?:(?:private|protected)(?:\[[\w.]+\])?|final|sealed|abstract|implicit|lazy|override|case)\s+)*"
-    r"(?P<kind>class|object|trait|def)\s+(?P<name>[A-Za-z_$][\w$]*)",
-    re.MULTILINE,
-)
-
 _CHISEL_REF_RE = re.compile(
     r"\b(?P<ctor>new)\s+(?P<ctor_name>[A-Za-z_$][\w$]*)"
     r"|\b(?P<inherit>extends|with)\s+(?P<inherit_name>[A-Za-z_$][\w$]*)"
@@ -325,15 +319,6 @@ def _read_file_text(filepath):
             return f.read()
     except OSError:
         return None
-
-
-def _chisel_decl_info(text):
-    """Return (kind, source_name) for an extracted Chisel declaration."""
-    cleaned = strip_chisel_comments(text)
-    m = _CHISEL_DECL_RE.search(cleaned)
-    if not m:
-        return None, None
-    return m.group("kind"), m.group("name")
 
 
 def _build_chisel_aliases(file_map):
@@ -354,12 +339,256 @@ def _build_chisel_aliases(file_map):
         text = _read_file_text(filepath)
         if text is None:
             continue
-        kind, source_name = _chisel_decl_info(text)
+        kind, source_name, _parent, _parent_prefix = chisel_decl_info(text)
         if not kind or not source_name:
             continue
         aliases[source_name][kind].add(fqn)
 
     return aliases
+
+
+# Root Chisel/Scala base classes that mark a declaration as elaboratable
+# hardware, and library base classes known to never be hardware (IO
+# Bundles, records, plain data payloads) -- both matched by bare name or by
+# the last segment of a package-qualified name.
+_MODULE_ROOT_NAMES = {"Module", "RawModule", "ExtModule", "BlackBox", "MultiIOModule"}
+_KNOWN_NON_MODULE_NAMES = {"Bundle", "Record", "Data"}
+
+
+def _build_chisel_decl_map(file_map):
+    """fqn -> (kind, name, parent, parent_qualified) for every Chisel unit.
+
+    Single-pass, project-wide input to the module-ness classifier -- built
+    once from the same ``chisel_decl_info`` used everywhere else, so the
+    classifier never re-derives declaration parsing on its own.
+    """
+    decl_map = {}
+    for fqn, filepath in file_map.items():
+        lang_key = _detect_lang_from_ext(filepath)
+        if LANG_CONFIG.get(lang_key, {}).get("body") != "chisel":
+            continue
+        text = _read_file_text(filepath)
+        if text is None:
+            continue
+        decl_map[fqn] = chisel_decl_info(text)
+    return decl_map
+
+
+def _classify_chisel_modules(decl_map):
+    """Compute ``(is_module, reason)`` for every FQN in ``decl_map``.
+
+    FQN-indexed, kind-aware, cycle-safe inheritance closure. For a given
+    unit's parent reference, resolves in this exact priority order:
+
+    1. A parent qualified with chisel3's own package (``chisel3.Module``,
+       ``_root_.chisel3.Module``, first-segment matched so
+       ``chisel3.util.*``/``chisel3.experimental.*`` qualify too) that
+       matches a root name -> ``extends_module_direct``, definitive.
+    2. Same, but matching a known-non-module name -> ``known_non_module_parent``,
+       definitive.
+    3. A project-local class/trait declaration matching the parent's bare
+       simple name -> resolved via THAT declaration's own (recursively
+       computed) classification. This applies to a genuinely bare
+       reference AND to a reference qualified with some OTHER (non-chisel3)
+       package -- e.g. a project's own ``mypkg.Data`` normalizes to the
+       same bare ``"Data"`` as chisel3.Data, but is NOT chisel3's Data, so
+       it must resolve via ITS real extends chain, never via the fixed
+       known-non-module/root sets below (steps 4-5). For the QUALIFIED
+       variant, a local result is trusted only when it is True: the
+       qualifying prefix cannot be verified against the local candidate's
+       package (extraction discards package declarations), and a
+       misdirected local False silently drops a real module, so False
+       falls back to ``unresolved_parent`` conservative-True instead.
+       Bare references trust False too -- that is what keeps local Bundle
+       chains filterable -- EXCEPT when the bare name is itself a root
+       name (``Module``/``RawModule``/``ExtModule``/``BlackBox``/
+       ``MultiIOModule``) and that local resolution is False: an
+       unrelated, non-hardware declaration sharing a root class's bare
+       name must never silently shadow a real ``extends Module``-style
+       reference into False
+       (``root_name_shadowed_conservative_true``). This asymmetry is safe
+       for the known-non-module set (Bundle/Record/Data) in either shadow
+       direction, but not for root names.
+    4. Only for a genuinely bare (unqualified) reference with no
+       project-local declaration match: bare root name.
+    5. Only for a genuinely bare (unqualified) reference with no
+       project-local declaration match: bare known-non-module name.
+    6. Otherwise: ``unresolved_parent``, conservative-True. A
+       non-chisel3-qualified reference with no project-local match lands
+       here directly too (steps 4-5 never apply to it -- see step 3).
+
+    KNOWN LIMITATION: step 3's project-local lookup has no package/import
+    scoping (extraction discards import info), so for a BARE reference an
+    unrelated, differently-scoped project-local declaration can still
+    coincidentally share a bare name with something the reference actually
+    meant to name externally (not just the 5 root names, which step 3
+    specifically guards against; qualified references no longer trust a
+    local False at all). Closing this fully would require a real Scala
+    import/package resolver, explicitly out of scope for this heuristic,
+    plain-text classifier -- see ``_resolve_local_candidates`` for the
+    full rationale.
+
+    Ambiguous same-``(kind, name)`` candidates that disagree, and cycles
+    detected during traversal, both classify conservative-True too --
+    false negatives (silently excluding a real module) are strictly worse
+    than false positives here.
+    """
+    local_index = defaultdict(set)
+    for fqn, (kind, name, _parent, _parent_prefix) in decl_map.items():
+        if kind in ("class", "trait") and name:
+            local_index[(kind, name)].add(fqn)
+
+    cache = {}
+    visiting = set()
+    for fqn in decl_map:
+        try:
+            _classify_one_chisel_module(fqn, decl_map, local_index, cache, visiting)
+        except RecursionError:
+            # An inheritance chain deep enough to exhaust Python's call
+            # stack (hundreds of levels -- unusual for real hardware
+            # designs, but not impossible). This runs unconditionally
+            # regardless of --chisel-modules-only, so a hard crash here
+            # would break the existing, always-on Chisel flow too. Every
+            # try/finally along the (now unwound) recursive chain already
+            # cleared its own entry from `visiting`; clearing it again here
+            # is just defensive. Conservative-True, same tier as the
+            # cycle/ambiguity guards -- never let "couldn't resolve
+            # cleanly" become "crashed" instead of "kept".
+            visiting.clear()
+            cache[fqn] = (True, "recursion_limit_conservative_true")
+    return cache
+
+
+def _classify_one_chisel_module(fqn, decl_map, local_index, cache, visiting):
+    if fqn in cache:
+        return cache[fqn]
+    if fqn in visiting:
+        # Mid-traversal cycle: this is a transient probe result for the
+        # frame that re-entered fqn, not fqn's own final answer -- the
+        # frame that owns fqn's computation (below) decides what goes in
+        # the cache.
+        return True, "cycle_detected_conservative_true"
+    visiting.add(fqn)
+    try:
+        result = _resolve_chisel_module_classification(fqn, decl_map, local_index, cache, visiting)
+    finally:
+        visiting.discard(fqn)
+    cache[fqn] = result
+    return result
+
+
+def _is_chisel3_prefix(prefix):
+    """True when a qualifying prefix is chisel3's own package, optionally
+    rooted via ``_root_.`` (e.g. ``"chisel3"``, ``"_root_.chisel3.experimental"``).
+
+    First-segment matching (not exact-string matching) so ``chisel3.util.*``/
+    ``chisel3.experimental.*`` qualify too, not just the bare ``chisel3.``
+    forms.
+    """
+    if prefix.startswith("_root_."):
+        prefix = prefix[len("_root_."):]
+    return prefix.split(".", 1)[0] == "chisel3"
+
+
+def _resolve_local_candidates(parent, decl_map, local_index, cache, visiting):
+    """Resolve a bare simple name against project-local class/trait
+    declarations sharing it, or None if there are no candidates.
+
+    Ambiguous (disagreeing) candidates and cycles both classify
+    conservative-True. A single candidate resolving False is trusted UNLESS
+    ``parent`` also happens to be a fixed Chisel root name -- an unrelated,
+    non-hardware project-local declaration coincidentally sharing a root
+    class's bare name must not silently shadow a real module (this is the
+    one direction where shadowing is actually dangerous; for the
+    known-non-module set either shadow outcome is safe by construction).
+
+    KNOWN LIMITATION: this has zero package/import scoping (extraction
+    discards import info entirely), so an unrelated project-local
+    declaration sharing ANY bare name -- not just a root name -- can still
+    misresolve a reference that was meant to name a different, externally
+    imported class of the same simple name. Fully closing this requires a
+    real Scala import/package resolver, explicitly out of scope for this
+    heuristic, plain-text classifier. The reason this isn't blanket-flipped
+    to conservative-True: a class extending a local non-hardware base, or
+    transitively through a local Bundle-rooted chain (e.g. ``class BarIO
+    extends FooIO`` where ``FooIO extends Bundle``), is a common and
+    legitimate pattern this classifier must keep recognizing as
+    non-hardware -- that's the real value step 3 provides, and a blanket
+    conservative-True override here would discard it entirely. Same tier as
+    the already-accepted import-alias limitation (a DIFFERENT limitation:
+    the with-mixin gap is about which clauses get scanned at all, not this
+    one, and isn't independent evidence for keeping this specific
+    trade-off).
+    """
+    candidates = set()
+    for local_kind in ("class", "trait"):
+        candidates |= local_index.get((local_kind, parent), set())
+    if not candidates:
+        return None
+
+    results = [
+        _classify_one_chisel_module(cand_fqn, decl_map, local_index, cache, visiting)
+        for cand_fqn in candidates
+    ]
+    if any(reason == "cycle_detected_conservative_true" for _, reason in results):
+        return True, "cycle_detected_conservative_true"
+    is_mods = {is_mod for is_mod, _reason in results}
+    if len(is_mods) > 1:
+        return True, "ambiguous_conservative_true"
+    is_mod = is_mods.pop()
+    if is_mod:
+        return True, "extends_module_transitive"
+    if parent in _MODULE_ROOT_NAMES:
+        return True, "root_name_shadowed_conservative_true"
+    return False, "non_module_parent"
+
+
+def _resolve_chisel_module_classification(fqn, decl_map, local_index, cache, visiting):
+    kind, _name, parent, parent_prefix = decl_map[fqn]
+
+    if kind in ("object", "def"):
+        return False, "non_module_decl_kind"
+    if parent is None:
+        return False, "no_extends_clause"
+
+    if parent_prefix is not None:
+        if _is_chisel3_prefix(parent_prefix):
+            # chisel3's own namespace -- definitive, no project-local
+            # declaration could ever be what this actually refers to.
+            if parent in _MODULE_ROOT_NAMES:
+                return True, "extends_module_direct"
+            if parent in _KNOWN_NON_MODULE_NAMES:
+                return False, "known_non_module_parent"
+            return True, "unresolved_parent"
+        # Qualified with some OTHER package -- e.g. a project's own
+        # `mypkg.Data` is NOT chisel3.Data, even though both normalize to
+        # the same bare "Data". Falling through to the bare-name fixed-set
+        # checks below would reintroduce exactly that bug via a different
+        # path, so resolve via project-local declarations only -- but trust
+        # a local result ONLY when it is True: extraction discards package
+        # declarations, so the qualifying prefix cannot be verified against
+        # the local candidate's own package. A local True is safe either
+        # way (keeps mypkg.Data's transitive precision; the ambiguity/cycle
+        # guards already return True). A local FALSE would silently drop a
+        # real module whenever the prefix actually names a different,
+        # external package (`vendor.hardware.ExternalBase` vs an unrelated
+        # local `ExternalBase extends Bundle`), so it falls back to
+        # unresolved_parent instead. Bare references (below) still trust
+        # False -- that is what keeps local Bundle chains filterable.
+        local_result = _resolve_local_candidates(parent, decl_map, local_index, cache, visiting)
+        if local_result is not None and local_result[0]:
+            return local_result
+        return True, "unresolved_parent"
+
+    local_result = _resolve_local_candidates(parent, decl_map, local_index, cache, visiting)
+    if local_result is not None:
+        return local_result
+
+    if parent in _MODULE_ROOT_NAMES:
+        return True, "extends_module_direct"
+    if parent in _KNOWN_NON_MODULE_NAMES:
+        return False, "known_non_module_parent"
+    return True, "unresolved_parent"
 
 
 def _resolve_chisel_refs(text, chisel_aliases, known_stems, keywords):
@@ -666,6 +895,9 @@ def generate_topdown_layers(proj_dir, phase_numbers=None):
             global_stem_to_fqns[stem].add(fqn)
             global_file_map[fqn] = filepath
 
+    global_chisel_decl_map = _build_chisel_decl_map(global_file_map)
+    global_module_classification = _classify_chisel_modules(global_chisel_decl_map)
+
     output_files = []
 
     for phase_info in phases_data["phases"]:
@@ -717,7 +949,7 @@ def generate_topdown_layers(proj_dir, phase_numbers=None):
                 phase_callees = sorted(callees_map.get(fqn, set()) & phase_fqns)
                 all_callees = sorted(all_callees_map.get(fqn, set()))
 
-                func_entries.append({
+                entry = {
                     "name": fqn,
                     "file": rel_path,
                     "unit": unit,
@@ -725,7 +957,12 @@ def generate_topdown_layers(proj_dir, phase_numbers=None):
                     phase_callers_key: phase_callers,
                     phase_callees_key: phase_callees,
                     "all_callees": all_callees,
-                })
+                }
+                if fqn in global_module_classification:
+                    is_module, reason = global_module_classification[fqn]
+                    entry["is_module"] = is_module
+                    entry["module_classification_reason"] = reason
+                func_entries.append(entry)
 
             layer_dict["functions"] = func_entries
             output_layers.append(layer_dict)


### PR DESCRIPTION
## Summary

Adds an opt-in, default-off CLI flag `--chisel-modules-only` that restricts Chisel hardware-spec generation to classes that transitively extend a Chisel hardware base class (`Module`, `RawModule`, `ExtModule`, `BlackBox`, `MultiIOModule`), plus a standalone extractor fix for curried parameter lists that benefits all Chisel runs regardless of the flag.

Two commits, independently reviewable:

1. **`Extract full Chisel declarations with curried parameter lists`** — `_unit_end` truncated the rocket-chip-ecosystem-standard shape `class Foo(a: A, ...)\n  (implicit p: Parameters) extends Module { ... }` after the first parameter list, silently feeding syntactically-broken source to spec generation (found on real Gemmini source: ~30 units affected). The signature walk now follows Scala 2's `ClassParamClause ::= [nl] '(' ...` grammar, operates on comment-masked text (nested comments, `//` inside block comments, `*/`-closing lines), and masks each file once (a per-declaration re-mask was O(n²): 2000 declarations took ~16s, now 0.06s). This fix affects the default Chisel flow and is cherry-pickable on its own.

2. **`Add opt-in --chisel-modules-only filter for Chisel spec generation`** — the feature itself.

## Motivation

Chisel extraction treats every top-level Scala declaration as spec-worthy. On riscv-mini, 32 of 49 extracted units are not hardware (IO Bundles, constant objects, Config classes, the `Main` entry point) — each gets a full LLM spec pass, making Chisel cost ~4x Verilog for the same design, and each shows up as a false positive in the undocumented-submodules advisory (23 entries, most of them noise nobody reads).

## Design

Classification is a text-only heuristic — no Scala import/package resolution — built on one hard rule: **silently dropping a real module is strictly worse than keeping noise.** Every unresolvable case classifies conservative-True (kept):

- unknown external bases (`unresolved_parent`)
- ambiguous same-name candidates (`ambiguous_conservative_true`)
- cyclic or stack-exhausting inheritance chains
- qualified references whose local resolution can't be verified (only a local **True** is trusted; a local False falls back to kept)
- bare root names can't be shadowed into False by unrelated local classes

Mechanics:

- `chisel_decl_info` in `chisel_support.py` is the single source of truthfor `(kind, name, parent, parent_prefix)`; the duplicate declaration regex in `generate_topdown_layers.py` is removed.
- An FQN-indexed, kind-aware, cycle-safe inheritance closure stamps `is_module`/`module_classification_reason` on every Chisel unit unconditionally (flag off = metadata only + a one-time "would exclude" listing).
- Batch generation filters `is_module=False` units; `all_funcs`/ `func_to_layer` stay unfiltered so caller lookups degrade gracefully. Field presence and types are validated loudly, never truthiness-guessed.
- A zero-post-filter-modules guard fails loudly (scoped to the topdown files actually written this run) instead of quietly emitting nothing.
- The flag survives `--resume` (subprocess argv + the recursive setup-rerun self-call).
- The shared undocumented-submodules advisory gains an explicit `filter_non_modules` parameter — Chisel call site only; the Verilog call site is byte-for-byte unaffected.
- Stale specs left by a prior unfiltered run are warned about, never deleted (matches the repo's existing no-cleanup convention).

## Validation

Real DeepSeek runs (same source, same backend, on/off):

| Run | Completion | Spec calls | Advisory |
|---|---|---|---|
| riscv-mini off | 49/49 units | 78 | 23 |
| riscv-mini **on** | **17/17 true modules** | **31 (−60%)** | **7 (−70%)** |
| gemmini systolic-array subset off | 10/10 units | 18 | 3 |
| gemmini subset **on** | **4/4 true modules** | **5 (−72%)** | **0** |

All 16 advisory entries eliminated on riscv-mini were known false positives; one surviving entry exposed a real caller-contract gap (a malformed `# Submodule:` heading breaking the caller-expectation handoff) that had been buried in prior runs' noise.

Non-regression: a real Verilog DeepSeek run (14/14 modules, call count on par with the pre-change baseline, zero advisory) and a deterministic software-pipeline smoke (no `is_module` leakage, embedded `[SPEC]` format intact). Developed test-first; the accompanying test suite can be contributed alongside if useful.

## Relationship to #104 (Support chisel with circt pass)

Complementary, not competing. Elaboration via CIRCT gives a compiler-grade module set and instance graph, but requires a buildable project (JDK/sbt/deps/a Top+Config) and only sees the design one configuration selects — riscv-mini's own CIRCT-generated Verilog contains 14 modules: the config-unselected implementations (`AluSimple`, `BrCondSimple`, `ImmGenMux`) don't exist in it, while 3 generated memory modules in it have no Scala source to attach a spec to. This text-only layer covers what elaboration structurally can't: repos that don't build, partial source trees, and all configuration variants, with zero toolchain requirements.

If #104 lands, its natural role in this flow is an **oracle**: cross-check `is_module` and provide precise instance edges (potentially hardening the Chisel advisory into a gate like Verilog's) when a build is available, reporting source declarations not covered by elaboration rather than silently skipping them. The classification metadata this PR stamps on every unit is the interface such an oracle would plug into.

## Known limitations (documented in README, pinned by regression tests)

- Bare `Bundle`/`Record`/`Data` are interpreted as chisel3's (imports are discarded at extraction); an import alias or an external class sharing one of the fixed bare names can be deterministically misclassified.
- `object`/`def` declarations are never eligible for module-ness (Scala singleton semantics: not instantiable via `Module(new ...)`, breaks re-elaboration).
- Scala 2 (2.12/2.13) syntax only; Scala 3 significant-indentation and the deprecated early-initializer syntax are unsupported input forms.
