### PR TITLE
Add --one-phase mode for single-phase analysis

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,6 +190,7 @@ def run_pipeline(
     required_source_files=None,
     domain_knowledge_files=None,
     submodules=None,
+    one_phase=False,
 ):
     if not os.path.isdir(proj_dir):
         print(f"[Pipeline] ERROR: proj_dir does not exist or is not a directory: {proj_dir}")
@@ -234,6 +235,7 @@ def run_pipeline(
         proj_dir, work_dir, script_dir, resume=resume,
         required_source_files=required_source_files,
         submodules=submodules,
+        one_phase=one_phase,
     )
 
     # Build (or rebuild) the codegraph index if codegraph is installed. Both
@@ -477,7 +479,7 @@ def run_pipeline(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         usage="python3 main.py <proj_dir> [--resume] [--incremental INTENT_FILE] "
-              "[--domain-knowledge FILE ...] [--isolate] "
+              "[--domain-knowledge FILE ...] [--one-phase] [--isolate] "
               "[--submodule PATH [PATH ...]] [--entry-func PATH] "
               "[--end-func PATH ...]",
         description="Run the FM agent pipeline on a project directory.",
@@ -501,6 +503,11 @@ if __name__ == "__main__":
         action="store_true",
         help="Run the pipeline against an isolated git worktree snapshot of "
         "the project instead of the project directory itself.",
+    )
+    parser.add_argument(
+        "--one-phase",
+        action="store_true",
+        help="Put all planned source files into a single analysis phase.",
     )
     parser.add_argument(
         "--domain-knowledge",
@@ -574,6 +581,7 @@ if __name__ == "__main__":
             end_funcs=args.end_func,
             resume=resume,
             domain_knowledge_files=domain_knowledge_files,
+            one_phase=args.one_phase,
         )
         end_time = time.time()
         logging.info(f"Total time: {end_time - start_time:.2f} seconds")
@@ -630,6 +638,7 @@ if __name__ == "__main__":
                     old_commit,
                     domain_knowledge_files=domain_knowledge_files,
                     submodules=submodules,
+                    one_phase=args.one_phase,
                 )
             else:
                 run_pipeline(
@@ -637,6 +646,7 @@ if __name__ == "__main__":
                     resume=resume,
                     domain_knowledge_files=domain_knowledge_files,
                     submodules=submodules,
+                    one_phase=args.one_phase,
                 )
             # Record the commit that was processed. Written after the pipeline since
             # it recreates fm_agent/; with --isolate it lives in the snapshot and is

--- a/src/entry_reasoning_pipeline.py
+++ b/src/entry_reasoning_pipeline.py
@@ -219,6 +219,7 @@ def run_entry_pipeline(
     end_funcs=None,
     resume=False,
     domain_knowledge_files=None,
+    one_phase=False,
 ):
     """Run the entry-point-scoped reasoning pipeline.
 
@@ -251,6 +252,7 @@ def run_entry_pipeline(
             restriction is applied and the whole call graph reachable from
             ``entry_func`` is selected.
         resume: forwarded directly to the standard pipeline.
+        one_phase: forwarded directly to the standard pipeline.
     """
     if entry_func is None:
         raise ValueError("entry_func is required to run the entry pipeline")
@@ -273,6 +275,7 @@ def run_entry_pipeline(
             end_funcs,
             resume,
             domain_knowledge_files=domain_knowledge_files,
+            one_phase=one_phase,
         )
     finally:
         clear_test_file_exemptions()
@@ -409,6 +412,7 @@ def _run_entry_pipeline_inner(
     end_funcs,
     resume,
     domain_knowledge_files=None,
+    one_phase=False,
 ):
     """Body of run_entry_pipeline; runs with the entry source file exempted."""
     # 1. Selection: extract fresh into a temp workspace and build the call graph.
@@ -449,6 +453,7 @@ def _run_entry_pipeline_inner(
             resume=resume,
             required_source_files=[_entry_func_source_rel(entry_func)],
             domain_knowledge_files=domain_knowledge_files,
+            one_phase=one_phase,
         )
     finally:
         # 4. Copy the generated fm_agent/ back into proj_dir, then discard the

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -578,6 +578,7 @@ def run_incremental_pipeline(
     old_commit_id,
     domain_knowledge_files=None,
     submodules=None,
+    one_phase=False,
 ):
     """
     Run the pipeline in incremental mode, intent_file_path is a file (absolute path) defining the goal of modification.
@@ -627,6 +628,7 @@ def run_incremental_pipeline(
             proj_dir,
             domain_knowledge_files=domain_knowledge_files,
             submodules=submodules,
+            one_phase=one_phase,
         )
         return
     logging.info("  -> previous full run found; proceeding with incremental analysis.")
@@ -681,6 +683,7 @@ def run_incremental_pipeline(
     _run_setup_extract(
         proj_dir, work_dir, script_dir,
         is_incremental=True, submodules=submodules,
+        one_phase=one_phase,
     )
     logging.info("  -> phases.json regenerated.")
 

--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -7,6 +7,7 @@ It is imported by `main.py` (the full pipeline) and by `src/incremental_reasoner
 """
 
 import os
+import glob
 import sys
 import json
 import time
@@ -420,10 +421,17 @@ def _collapse_phases_to_one(work_dir):
     with open(phases_path) as f:
         data = json.load(f)
     phases = sorted(data.get("phases", []), key=lambda phase: phase.get("phase", 0))
-    if len(phases) <= 1:
+    if not phases:
         return
 
+    merged_description = "\n\n".join(
+        f"Phase {phase['phase']} ({phase['name']}): {phase_description}"
+        for phase in phases
+        if (phase_description := (phase.get("description") or "").strip())
+    )
     first = phases[0]
+    first["name"] = "Unified Analysis Phase"
+    first["description"] = merged_description
     first["modules"] = [
         module
         for phase in phases
@@ -435,6 +443,7 @@ def _collapse_phases_to_one(work_dir):
         json.dump(data, f, indent=2)
 
     domain_dir = os.path.join(work_dir, "spec_prompts", "domain_context")
+    merged_types_path = os.path.join(domain_dir, "phase_01_types.txt")
     type_context = []
     for phase in phases:
         types_path = os.path.join(domain_dir, f"phase_{phase['phase']:02d}_types.txt")
@@ -442,8 +451,11 @@ def _collapse_phases_to_one(work_dir):
             with open(types_path) as f:
                 type_context.append(f.read().strip())
     if type_context:
-        with open(os.path.join(domain_dir, "phase_01_types.txt"), "w") as f:
+        with open(merged_types_path, "w") as f:
             f.write("\n\n".join(type_context) + "\n")
+        for types_path in glob.glob(os.path.join(domain_dir, "phase_*_types.txt")):
+            if types_path != merged_types_path:
+                os.remove(types_path)
 
 
 def _collect_changed_modules(ensure_changes, *change_sets):

--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -414,6 +414,38 @@ def _clean_domain_context_files(work_dir, removed_phase_nums, renumbered):
         logging.info("Renamed domain-context file to %s", os.path.basename(final_path))
 
 
+def _collapse_phases_to_one(work_dir):
+    """Merge every planned module and its type context into phase 1."""
+    phases_path = os.path.join(work_dir, "phases.json")
+    with open(phases_path) as f:
+        data = json.load(f)
+    phases = sorted(data.get("phases", []), key=lambda phase: phase.get("phase", 0))
+    if len(phases) <= 1:
+        return
+
+    first = phases[0]
+    first["modules"] = [
+        module
+        for phase in phases
+        for module in phase.get("modules", [])
+    ]
+    first["depends_on_phases"] = []
+    data["phases"] = [first]
+    with open(phases_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+    domain_dir = os.path.join(work_dir, "spec_prompts", "domain_context")
+    type_context = []
+    for phase in phases:
+        types_path = os.path.join(domain_dir, f"phase_{phase['phase']:02d}_types.txt")
+        if os.path.isfile(types_path):
+            with open(types_path) as f:
+                type_context.append(f.read().strip())
+    if type_context:
+        with open(os.path.join(domain_dir, "phase_01_types.txt"), "w") as f:
+            f.write("\n\n".join(type_context) + "\n")
+
+
 def _collect_changed_modules(ensure_changes, *change_sets):
     """Collect the modules whose source-file list changed during post-processing.
 
@@ -810,7 +842,7 @@ def _prepare_setup_workflow_file(proj_dir, work_dir, script_dir):
 
 def _run_setup_extract(proj_dir, work_dir, script_dir, is_incremental=False,
                        resume=False, required_source_files=None,
-                       submodules=None):
+                       submodules=None, one_phase=False):
     """Stage 1: prepare the setup workflow file and run opencode (with retries) to produce phases.json.
 
     ``required_source_files`` are paths the caller must have processed regardless
@@ -818,6 +850,7 @@ def _run_setup_extract(proj_dir, work_dir, script_dir, is_incremental=False,
     once the plan is otherwise finalized (see ``_ensure_source_files_in_phases``).
     ``submodules`` optionally limits the full pipeline to selected project-relative
     subdirectories.
+    ``one_phase`` merges the finalized plan before downstream stages consume it.
     """
     # On resume, reuse the existing phase plan instead of paying for the
     # setup_context LLM call again.
@@ -1001,3 +1034,6 @@ def _run_setup_extract(proj_dir, work_dir, script_dir, is_incremental=False,
             "phase_NN_types.txt per phase."
         )
         sys.exit(1)
+
+    if one_phase:
+        _collapse_phases_to_one(work_dir)


### PR DESCRIPTION
## Summary

- Add an opt-in `--one-phase` CLI flag.
- Collapse the finalized `phases.json` into one `Unified Analysis Phase`, combining the original phase descriptions with their phase labels.
- Preserve all modules and source files, merge per-phase type context into `phase_01_types.txt`, and remove superseded type files.
- Support the option across full, resume, isolate, submodule, entry, and incremental modes through the shared setup path.

Validated with full entry-mode runs.

Closes #103
