### PR TITLE
fix issue#49 : propagate caller contracts across phases

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,8 +18,12 @@ from src.file_utils import (
 )
 from src.verification import streaming_reasoner
 from src.extract import run_extraction, EXT_TO_LANG
-from src.generate_topdown_layers import generate_topdown_layers
-from src.generate_batch_prompts import load_global_call_graph
+from src.generate_topdown_layers import generate_topdown_layers, _tarjan_scc
+from src.generate_batch_prompts import (
+    extract_info_block,
+    extract_spec_block,
+    load_global_call_graph,
+)
 from src.opencode_trace import (
     function_id_from_extracted_path,
     run_opencode_traced,
@@ -52,6 +56,9 @@ import logging
 import contextlib
 import concurrent.futures
 from pathlib import Path
+
+
+_CONTRACT_RECONCILIATION_MAX_ROUNDS = 3
 
 
 def _clean_previous_run(work_dir):
@@ -129,60 +136,175 @@ def _contract_reconciliation_targets(global_graph):
     return targets
 
 
-def _run_contract_reconciliation(proj_dir, work_dir, targets):
-    """Regenerate deferred specs after every caller contract is available."""
-    for (phase_num, layer_idx), function_fqns in sorted(targets.items()):
-        output_dir = os.path.join(
-            work_dir,
-            "spec_prompts",
-            f"reconciliation_phase{phase_num:02d}_layer{layer_idx}",
+def _contract_reconciliation_schedule(global_graph, targets):
+    """Return affected SCCs in caller-before-callee order."""
+    affected = {
+        fqn
+        for function_fqns in targets.values()
+        for fqn in function_fqns
+    }
+    pending = list(affected)
+    while pending:
+        caller_fqn = pending.pop()
+        for callee_fqn in global_graph["callees"][caller_fqn]:
+            if callee_fqn not in affected:
+                affected.add(callee_fqn)
+                pending.append(callee_fqn)
+
+    edges = {
+        fqn: set(global_graph["callees"][fqn]) & affected
+        for fqn in affected
+    }
+    components = _tarjan_scc(affected, edges)
+    component_by_fqn = {
+        fqn: idx
+        for idx, component in enumerate(components)
+        for fqn in component
+    }
+    successors = {idx: set() for idx in range(len(components))}
+    indegree = {idx: 0 for idx in range(len(components))}
+    for caller_fqn, callee_fqns in edges.items():
+        caller_idx = component_by_fqn[caller_fqn]
+        for callee_fqn in callee_fqns:
+            callee_idx = component_by_fqn[callee_fqn]
+            if caller_idx == callee_idx or callee_idx in successors[caller_idx]:
+                continue
+            successors[caller_idx].add(callee_idx)
+            indegree[callee_idx] += 1
+
+    component_key = lambda idx: tuple(sorted(components[idx]))
+    ready = sorted(
+        (idx for idx, degree in indegree.items() if degree == 0),
+        key=component_key,
+    )
+    schedule = []
+    while ready:
+        wave = ready
+        grouped = {}
+        wave_entries = []
+        for idx in wave:
+            component = tuple(sorted(components[idx]))
+            is_cycle = len(component) > 1 or any(
+                fqn in edges[fqn] for fqn in component
+            )
+            if is_cycle:
+                wave_entries.append((component, True))
+                continue
+            meta = global_graph["functions"][component[0]]
+            key = (meta["phase"], meta["layer"])
+            grouped.setdefault(key, []).extend(component)
+        wave_entries.extend(
+            (tuple(sorted(function_fqns)), False)
+            for function_fqns in grouped.values()
         )
-        command = [
-            "python3",
-            "fm_agent/spec_prompts/generate_batch_prompts.py",
-            "--phase", str(phase_num),
-            "--layers", str(layer_idx),
-            "--output-dir", output_dir,
-            "--require-all-callers",
-            "--functions", *sorted(function_fqns),
-        ]
-        subprocess.run(command, cwd=proj_dir, check=True)
+        schedule.extend(sorted(wave_entries, key=lambda item: item[0]))
 
-        manifest_path = os.path.join(output_dir, "manifest.json")
-        with open(manifest_path, "r") as f:
-            pending_batches = json.load(f).get("batches", [])
-        batch_rel_dir = os.path.relpath(output_dir, proj_dir)
+        ready = []
+        for idx in wave:
+            for successor in successors[idx]:
+                indegree[successor] -= 1
+                if indegree[successor] == 0:
+                    ready.append(successor)
+        ready.sort(key=component_key)
+    return schedule
 
-        for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
-            failed_batches = []
-            with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-                futures = {
-                    executor.submit(
-                        _run_spec_generation_batch,
-                        proj_dir,
-                        work_dir,
-                        attempt,
-                        phase_num,
-                        layer_idx,
-                        batch_rel_dir,
-                        batch_info,
-                        True,
-                    ): batch_info
-                    for batch_info in pending_batches
-                }
-                for future, batch_info in futures.items():
-                    try:
-                        if future.result() != 0:
-                            failed_batches.append(batch_info)
-                    except Exception as exc:
-                        logging.error(f"Contract reconciliation task failed: {exc}")
+
+def _run_contract_reconciliation_group(
+    proj_dir, work_dir, global_graph, function_fqns
+):
+    """Regenerate independent specs from one phase and layer."""
+    function_fqns = tuple(sorted(function_fqns))
+    meta = global_graph["functions"][function_fqns[0]]
+    phase_num = meta["phase"]
+    layer_idx = meta["layer"]
+    output_dir = os.path.join(
+        work_dir,
+        "spec_prompts",
+        f"reconciliation_phase{phase_num:02d}_layer{layer_idx}",
+    )
+    command = [
+        "python3",
+        "fm_agent/spec_prompts/generate_batch_prompts.py",
+        "--phase", str(phase_num),
+        "--layers", str(layer_idx),
+        "--output-dir", output_dir,
+        "--require-all-callers",
+        "--functions", *function_fqns,
+    ]
+    subprocess.run(command, cwd=proj_dir, check=True)
+
+    manifest_path = os.path.join(output_dir, "manifest.json")
+    with open(manifest_path, "r") as f:
+        pending_batches = json.load(f).get("batches", [])
+    batch_rel_dir = os.path.relpath(output_dir, proj_dir)
+
+    for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
+        failed_batches = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {
+                executor.submit(
+                    _run_spec_generation_batch,
+                    proj_dir,
+                    work_dir,
+                    attempt,
+                    phase_num,
+                    layer_idx,
+                    batch_rel_dir,
+                    batch_info,
+                    True,
+                ): batch_info
+                for batch_info in pending_batches
+            }
+            for future, batch_info in futures.items():
+                try:
+                    if future.result() != 0:
                         failed_batches.append(batch_info)
-            if not failed_batches:
+                except Exception as exc:
+                    logging.error(f"Contract reconciliation task failed: {exc}")
+                    failed_batches.append(batch_info)
+        if not failed_batches:
+            return
+        pending_batches = failed_batches
+    raise RuntimeError(
+        f"Contract reconciliation failed for phase {phase_num}, layer {layer_idx}"
+    )
+
+
+def _contract_snapshot(work_dir, global_graph, function_fqns):
+    snapshot = {}
+    for fqn in function_fqns:
+        path = Path(work_dir) / global_graph["functions"][fqn]["file"]
+        snapshot[fqn] = (
+            extract_spec_block(path),
+            extract_info_block(path),
+        )
+    return snapshot
+
+
+def _run_contract_reconciliation(proj_dir, work_dir, global_graph, schedule):
+    """Regenerate affected specs in caller-first order, converging cycles."""
+    for function_fqns, is_cycle in schedule:
+        rounds = _CONTRACT_RECONCILIATION_MAX_ROUNDS if is_cycle else 1
+        for _round in range(rounds):
+            before = _contract_snapshot(work_dir, global_graph, function_fqns)
+            if is_cycle:
+                for fqn in function_fqns:
+                    _run_contract_reconciliation_group(
+                        proj_dir, work_dir, global_graph, (fqn,)
+                    )
+            else:
+                _run_contract_reconciliation_group(
+                    proj_dir, work_dir, global_graph, function_fqns
+                )
+            if not is_cycle:
                 break
-            pending_batches = failed_batches
+            after = _contract_snapshot(work_dir, global_graph, function_fqns)
+            if after == before:
+                break
         else:
+            names = ", ".join(function_fqns)
             raise RuntimeError(
-                f"Contract reconciliation failed for phase {phase_num}, layer {layer_idx}"
+                f"Contract reconciliation did not converge for cycle: {names}"
             )
 
 
@@ -371,9 +493,12 @@ def run_pipeline(
     generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
     global_call_graph = load_global_call_graph(Path(work_dir))
     reconciliation_targets = _contract_reconciliation_targets(global_call_graph)
+    reconciliation_schedule = _contract_reconciliation_schedule(
+        global_call_graph, reconciliation_targets
+    )
     deferred_verification_files = {
         os.path.abspath(os.path.join(work_dir, global_call_graph["functions"][fqn]["file"]))
-        for function_fqns in reconciliation_targets.values()
+        for function_fqns, _is_cycle in reconciliation_schedule
         for fqn in function_fqns
     }
 
@@ -563,14 +688,14 @@ def run_pipeline(
         for rel in phase_files:
             all_processed.add(os.path.join(input_dir, rel))
 
-    if reconciliation_targets:
-        target_count = sum(len(fqns) for fqns in reconciliation_targets.values())
+    if reconciliation_schedule:
+        target_count = sum(len(fqns) for fqns, _is_cycle in reconciliation_schedule)
         print(
             f"[Pipeline] Reconciling {target_count} function spec(s) "
             "with deferred caller contracts..."
         )
         _run_contract_reconciliation(
-            proj_dir, work_dir, reconciliation_targets
+            proj_dir, work_dir, global_call_graph, reconciliation_schedule
         )
         deferred_rel_files = sorted(
             os.path.relpath(path, input_dir)

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from src.file_utils import (
 from src.verification import streaming_reasoner
 from src.extract import run_extraction, EXT_TO_LANG
 from src.generate_topdown_layers import generate_topdown_layers
+from src.generate_batch_prompts import load_global_call_graph
 from src.opencode_trace import (
     function_id_from_extracted_path,
     run_opencode_traced,
@@ -50,6 +51,7 @@ import subprocess
 import logging
 import contextlib
 import concurrent.futures
+from pathlib import Path
 
 
 def _clean_previous_run(work_dir):
@@ -107,6 +109,83 @@ def _normalize_submodules(proj_dir, submodules):
     return collapsed
 
 
+def _contract_reconciliation_targets(global_graph):
+    """Return callees whose callers are unavailable in the first scheduling pass."""
+    functions = global_graph["functions"]
+    targets = {}
+    for callee_fqn, caller_fqns in global_graph["callers"].items():
+        callee_meta = functions[callee_fqn]
+        for caller_fqn in caller_fqns:
+            caller_meta = functions[caller_fqn]
+            caller_runs_later = caller_meta["phase"] > callee_meta["phase"]
+            same_or_later_layer = (
+                caller_meta["phase"] == callee_meta["phase"]
+                and caller_meta["layer"] >= callee_meta["layer"]
+            )
+            if caller_runs_later or same_or_later_layer:
+                key = (callee_meta["phase"], callee_meta["layer"])
+                targets.setdefault(key, set()).add(callee_fqn)
+                break
+    return targets
+
+
+def _run_contract_reconciliation(proj_dir, work_dir, targets):
+    """Regenerate deferred specs after every caller contract is available."""
+    for (phase_num, layer_idx), function_fqns in sorted(targets.items()):
+        output_dir = os.path.join(
+            work_dir,
+            "spec_prompts",
+            f"reconciliation_phase{phase_num:02d}_layer{layer_idx}",
+        )
+        command = [
+            "python3",
+            "fm_agent/spec_prompts/generate_batch_prompts.py",
+            "--phase", str(phase_num),
+            "--layers", str(layer_idx),
+            "--output-dir", output_dir,
+            "--require-all-callers",
+            "--functions", *sorted(function_fqns),
+        ]
+        subprocess.run(command, cwd=proj_dir, check=True)
+
+        manifest_path = os.path.join(output_dir, "manifest.json")
+        with open(manifest_path, "r") as f:
+            pending_batches = json.load(f).get("batches", [])
+        batch_rel_dir = os.path.relpath(output_dir, proj_dir)
+
+        for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
+            failed_batches = []
+            with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = {
+                    executor.submit(
+                        _run_spec_generation_batch,
+                        proj_dir,
+                        work_dir,
+                        attempt,
+                        phase_num,
+                        layer_idx,
+                        batch_rel_dir,
+                        batch_info,
+                        True,
+                    ): batch_info
+                    for batch_info in pending_batches
+                }
+                for future, batch_info in futures.items():
+                    try:
+                        if future.result() != 0:
+                            failed_batches.append(batch_info)
+                    except Exception as exc:
+                        logging.error(f"Contract reconciliation task failed: {exc}")
+                        failed_batches.append(batch_info)
+            if not failed_batches:
+                break
+            pending_batches = failed_batches
+        else:
+            raise RuntimeError(
+                f"Contract reconciliation failed for phase {phase_num}, layer {layer_idx}"
+            )
+
+
 def _run_spec_generation_batch(
     proj_dir,
     work_dir,
@@ -115,6 +194,7 @@ def _run_spec_generation_batch(
     layer_idx,
     batch_rel_dir,
     batch_info,
+    reconcile=False,
 ):
     # Run one batch end-to-end so the executor can refill slots as soon as a
     # batch finishes, instead of waiting for a whole chunk barrier.
@@ -127,7 +207,14 @@ def _run_spec_generation_batch(
     ]
     fm_reminder = ("IMPORTANT: fm_agent/ is your output workspace, not project source. "
                     "Do NOT modify any existing project files.")
-    if attempt == 1:
+    if reconcile:
+        prompt = (
+            f"Reconcile the behavioral specs in the batch prompt file at {batch_prompt_rel}. "
+            f"Read it and fm_agent/spec_prompts/system_prompt.md, then regenerate every "
+            f"listed function using all available caller contracts and overwrite the complete "
+            f"specced files directly. {fm_reminder}"
+        )
+    elif attempt == 1:
         prompt = (
             f"Process the batch prompt file at {batch_prompt_rel}. "
             f"Read it and fm_agent/spec_prompts/system_prompt.md, "
@@ -285,6 +372,13 @@ def run_pipeline(
     # --- Stage 3: Generate topdown layers ---
     print("[Pipeline] Stage 3/4: Generating topdown layers...")
     generate_topdown_layers(work_dir)
+    global_call_graph = load_global_call_graph(Path(work_dir))
+    reconciliation_targets = _contract_reconciliation_targets(global_call_graph)
+    deferred_verification_files = {
+        os.path.abspath(os.path.join(work_dir, global_call_graph["functions"][fqn]["file"]))
+        for function_fqns in reconciliation_targets.values()
+        for fqn in function_fqns
+    }
 
     # --- Stage 4: Execute spec generation workflow (per phase, per layer) ---
     print("[Pipeline] Stage 4/4: Generating specs & verification...")
@@ -347,6 +441,9 @@ def run_pipeline(
             layer_files = []
             for batch_info in all_batches:
                 for func_rel in batch_info.get("functions", []):
+                    func_abs = os.path.abspath(os.path.join(proj_dir, func_rel))
+                    if func_abs in deferred_verification_files:
+                        continue
                     rel = os.path.relpath(os.path.join(proj_dir, func_rel), input_dir)
                     layer_files.append(rel)
 
@@ -427,7 +524,7 @@ def run_pipeline(
                     1 for rel in layer_files
                     if is_file_ready(os.path.join(input_dir, rel))
                 )
-                if specs_generated > 0 and not _get_pending_batches(all_batches, proj_dir):
+                if not _get_pending_batches(all_batches, proj_dir):
                     break
 
                 if specs_generated > 0:
@@ -462,6 +559,29 @@ def run_pipeline(
         # Mark all files from this phase as processed for subsequent phases
         for rel in phase_files:
             all_processed.add(os.path.join(input_dir, rel))
+
+    if reconciliation_targets:
+        target_count = sum(len(fqns) for fqns in reconciliation_targets.values())
+        print(
+            f"[Pipeline] Reconciling {target_count} function spec(s) "
+            "with deferred caller contracts..."
+        )
+        _run_contract_reconciliation(
+            proj_dir, work_dir, reconciliation_targets
+        )
+        deferred_rel_files = sorted(
+            os.path.relpath(path, input_dir)
+            for path in deferred_verification_files
+        )
+        streaming_reasoner(
+            input_dir,
+            output_dir,
+            file_list=deferred_rel_files,
+            proj_dir=proj_dir,
+            work_dir=work_dir,
+            already_processed=None,
+            resume=False,
+        )
 
     # Print confirmed bug count
     summary_path = os.path.join(work_dir, "bug_validation", "summary.json")

--- a/md/workflow_spec_step4_batch.md
+++ b/md/workflow_spec_step4_batch.md
@@ -11,7 +11,7 @@ You are given a single batch prompt file path in the prompt. Your ONLY job is to
 3. Read any domain context files mentioned in the batch prompt (e.g., `engine_overview.txt`, `phase_NN_types.txt`, and user-provided Markdown files under `user_knowledge/`)
 4. For EACH function listed in the batch prompt:
    a. Read the extracted function file
-   b. If layer > 0, read earlier-layer caller specs mentioned in the batch prompt
+   b. Read all available same-phase and cross-phase caller contracts mentioned in the batch prompt
    c. Generate a behavioral spec following the `[SPEC]` format
    d. Generate callee expectations in `[INFO]` format
    e. Write the COMPLETE file — prepend `[SPEC]` and `[INFO]` blocks, followed by the **UNCHANGED** original source code

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -123,7 +123,11 @@ def extract_info_block(filepath: Path) -> Optional[str]:
     return content[start + len(tag) + 1 : end].strip()
 
 
-def extract_callee_spec_from_info(info_block: str, callee_fqn: str) -> Optional[str]:
+def extract_callee_spec_from_info(
+    info_block: str,
+    callee_fqn: str,
+    candidate_callee_fqns=None,
+) -> Optional[str]:
     """Find the [SPLIT]-separated entry for callee_fqn in an info_block."""
     import re
 
@@ -156,8 +160,18 @@ def extract_callee_spec_from_info(info_block: str, callee_fqn: str) -> Optional[
         # Strip the comment prefix to get the actual content
         if prefix and first_line.startswith(prefix):
             first_line = first_line[len(prefix):].strip()
-        if callee_fqn in first_line or (callee_stem + "(") in first_line:
+        if callee_fqn in first_line:
             return entry
+        if (callee_stem + "(") not in first_line:
+            continue
+        if candidate_callee_fqns is not None:
+            same_stem = {
+                name for name in candidate_callee_fqns
+                if name.split("::")[-1] == callee_stem
+            }
+            if len(same_stem) != 1:
+                continue
+        return entry
     return None
 
 
@@ -168,6 +182,13 @@ def chunked(items: List[dict], size: int) -> List[List[dict]]:
 def read_json(path: Path) -> dict:
     if not path.exists():
         raise FileNotFoundError(f"missing required file: {path}")
+    return json.loads(path.read_text())
+
+
+def load_global_call_graph(work_dir: Path) -> dict:
+    path = work_dir / "spec_prompts" / "global_call_graph.json"
+    if not path.exists():
+        return {}
     return json.loads(path.read_text())
 
 
@@ -198,6 +219,7 @@ def build_prompt(
     work_dir: Path,
     fm_agent_prefix: str,
     ext_to_lang: Dict[str, str],
+    global_call_graph: Optional[dict] = None,
 ) -> str:
     lines: List[str] = []
     sample_lang = "unknown"
@@ -230,35 +252,72 @@ def build_prompt(
     lines.append("- Specs describe INTENDED CORRECT behavior per the domain (see domain files)")
     lines.append(f"- ALL files below exist in {fm_agent_prefix}extracted_functions/ - read and process each one")
 
-    caller_specs: List[Tuple[str, str]] = []
-    caller_expectations: Dict[str, List[Tuple[str, str]]] = {}
+    graph = global_call_graph or {}
+    global_funcs = graph.get("functions", {})
+    global_callers = graph.get("callers", {})
+    global_callees = graph.get("callees", {})
+    caller_specs = []
+    caller_expectations = {}
+    available_callers = {}
+    pending_callers = []
+    seen_specs = set()
+    seen_expectations = set()
     for fn in functions:
         fn_name = fn["name"]
         caller_key = phase_callers_key(fn, phase)
-        callers = fn.get(caller_key, [])
-        for caller_name in callers:
-            caller_layer = func_to_layer.get(caller_name)
-            if caller_layer is None or caller_layer >= layer_idx:
-                continue
-            caller_meta = all_funcs.get(caller_name)
+        callers = global_callers.get(fn_name, fn.get(caller_key, []))
+        for caller_name in sorted(set(callers)):
+            caller_meta = global_funcs.get(caller_name) or all_funcs.get(caller_name)
             if not caller_meta:
+                pending_callers.append((fn_name, caller_name, "function metadata not found"))
+                continue
+            caller_phase = caller_meta.get("phase", phase)
+            caller_layer = caller_meta.get("layer", func_to_layer.get(caller_name))
+            if caller_phase == phase and (
+                caller_layer is None or caller_layer >= layer_idx
+            ):
                 continue
             caller_file = work_dir / caller_meta["file"]
-            spec_block = extract_spec_block(caller_file)
-            if spec_block and (caller_name, spec_block) not in caller_specs:
-                caller_specs.append((caller_name, spec_block))
-            info_block = extract_info_block(caller_file)
-            if not info_block:
+            if not is_file_ready(caller_file):
+                pending_callers.append((fn_name, caller_name, "specification not generated yet"))
                 continue
-            entry = extract_callee_spec_from_info(info_block, fn_name)
+            spec_block = extract_spec_block(caller_file)
+            info_block = extract_info_block(caller_file)
+            if not spec_block or info_block is None:
+                pending_callers.append((fn_name, caller_name, "SPEC or INFO block is incomplete"))
+                continue
+            caller_kind = "same-phase" if caller_phase == phase else "cross-phase"
+            spec_key = (caller_name, spec_block)
+            if spec_key not in seen_specs:
+                seen_specs.add(spec_key)
+                caller_specs.append((caller_name, caller_phase, caller_kind, spec_block))
+            available_callers.setdefault(fn_name, []).append(caller_name)
+            entry = extract_callee_spec_from_info(
+                info_block,
+                fn_name,
+                global_callees.get(caller_name) if graph else None,
+            )
             if entry:
-                caller_expectations.setdefault(fn_name, []).append((caller_name, entry.strip()))
+                expectation_key = (fn_name, caller_name, entry.strip())
+                if expectation_key not in seen_expectations:
+                    seen_expectations.add(expectation_key)
+                    caller_expectations.setdefault(fn_name, []).append(
+                        (caller_name, caller_phase, caller_kind, entry.strip())
+                    )
+            elif global_callees.get(caller_name):
+                pending_callers.append((
+                    fn_name,
+                    caller_name,
+                    "matching INFO entry not found or callee name is ambiguous",
+                ))
 
     if caller_specs:
         lines.append("")
-        lines.append("## EARLIER-LAYER CALLER SPECS")
-        for caller_name, block in caller_specs:
-            lines.append(f"#### {caller_name}")
+        lines.append("## AVAILABLE CALLER CONTRACTS")
+        for caller_name, caller_phase, caller_kind, block in caller_specs:
+            lines.append(
+                f"#### {caller_name} ({caller_kind}, phase {caller_phase})"
+            )
             lines.append("")
             lines.append(block)
             lines.append("")
@@ -271,10 +330,22 @@ def build_prompt(
             if not entries:
                 continue
             lines.append(f"### What callers expect from {fn_name}:")
-            for caller_name, entry in entries:
-                lines.append(f"#### According to {caller_name}:")
+            for caller_name, caller_phase, caller_kind, entry in entries:
+                lines.append(
+                    f"#### According to {caller_name} ({caller_kind}, phase {caller_phase}):"
+                )
                 lines.append(entry)
             lines.append("")
+
+        lines.append("Treat caller expectations as contract evidence, not unquestionable truth.")
+        lines.append("Reconcile them with domain requirements and the callee's responsibility.")
+        lines.append("If callers conflict, do not silently choose one expectation.")
+
+    if pending_callers:
+        lines.append("")
+        lines.append("## PENDING CALLER CONTRACTS")
+        for fn_name, caller_name, reason in sorted(set(pending_callers)):
+            lines.append(f"- {caller_name} -> {fn_name}: {reason}")
 
     if is_cycle:
         lines.append("## CYCLE LAYER GUIDANCE")
@@ -292,14 +363,12 @@ def build_prompt(
     lines.append(f"## FUNCTIONS ({len(functions)} total - process ALL)")
     for idx, fn in enumerate(functions, start=1):
         fn_name = fn["name"]
-        caller_key = phase_callers_key(fn, phase)
-        callers = fn.get(caller_key, [])
-        earlier = [c for c in callers if func_to_layer.get(c, 10**9) < layer_idx]
         lines.append(f"### {idx}. {fm_agent_prefix}{fn['file']}")
-        if earlier:
-            lines.append("  Earlier-layer callers: " + ", ".join(earlier))
+        callers = sorted(set(available_callers.get(fn_name, [])))
+        if callers:
+            lines.append("  Available callers: " + ", ".join(callers))
         else:
-            lines.append("  Earlier-layer callers: (none)")
+            lines.append("  Available callers: (none)")
 
     lines.append("")
     lines.append("## SPEC FORMAT (prepend to file, preserving source code below)")
@@ -359,6 +428,7 @@ def main() -> int:
 
     topdown_path = work_dir / "spec_prompts" / f"phase_{args.phase:02d}_topdown_layers.json"
     topdown = read_json(topdown_path)
+    global_call_graph = load_global_call_graph(work_dir)
     layers = topdown.get("layers", [])
     total_layers = len(layers)
     start_layer, end_layer = parse_layers_spec(args.layers)
@@ -421,6 +491,7 @@ def main() -> int:
                     work_dir,
                     fm_agent_prefix,
                     ext_to_lang,
+                    global_call_graph,
                 )
                 write_targets.append((out_path, content))
             else:

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -162,7 +162,6 @@ def extract_callee_spec_from_info(
                 break
 
     split_tag = f"{prefix} [SPLIT]" if prefix else "[SPLIT]"
-    exact_names = {callee_fqn, *(aliases or ())}
     callee_stem = callee_fqn.split("::")[-1]
     for entry in info_block.split(split_tag):
         entry = entry.strip()
@@ -172,15 +171,16 @@ def extract_callee_spec_from_info(
         # Strip the comment prefix to get the actual content
         if prefix and first_line.startswith(prefix):
             first_line = first_line[len(prefix):].strip()
-        match = re.match(r"^(?P<label>[^\s(]+)\s*\(", first_line)
-        if not match:
-            continue
-        called_label = match.group("label")
-        if called_label in exact_names:
+        if _info_line_contains_call_name(first_line, callee_fqn):
             return entry
-        called_stem = re.split(r"::|->|\.", called_label)[-1]
-        if called_stem != callee_stem:
-            continue
+        if any(
+            _info_line_contains_call_name(
+                first_line, alias, allow_qualified_prefix=True
+            )
+            for alias in aliases or ()
+            if alias
+        ):
+            return entry
         if candidate_callee_fqns is not None:
             same_stem = {
                 name for name in candidate_callee_fqns
@@ -188,8 +188,31 @@ def extract_callee_spec_from_info(
             }
             if len(same_stem) != 1:
                 continue
-        return entry
+        if _info_line_contains_call_name(
+            first_line, callee_stem, allow_qualified_prefix=True
+        ):
+            return entry
     return None
+
+
+def _info_line_contains_call_name(
+    first_line: str,
+    name: str,
+    allow_qualified_prefix: bool = False,
+) -> bool:
+    if not name:
+        return False
+    left_boundary = (
+        r"(?<![A-Za-z0-9_])"
+        if allow_qualified_prefix
+        else r"(?<![A-Za-z0-9_:])"
+    )
+    return bool(
+        re.search(
+            rf"{left_boundary}{re.escape(name)}(?=\s*\()",
+            first_line,
+        )
+    )
 
 
 def chunked(items: List[dict], size: int) -> List[List[dict]]:

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -67,6 +67,17 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Skip functions already specced (file_utils.is_file_ready) when building batches",
     )
+    parser.add_argument(
+        "--functions",
+        nargs="+",
+        default=None,
+        help="Only generate prompts for these function FQNs",
+    )
+    parser.add_argument(
+        "--require-all-callers",
+        action="store_true",
+        help="Fail if any selected function has a caller contract that is not ready",
+    )
     return parser.parse_args()
 
 
@@ -160,9 +171,9 @@ def extract_callee_spec_from_info(
         # Strip the comment prefix to get the actual content
         if prefix and first_line.startswith(prefix):
             first_line = first_line[len(prefix):].strip()
-        if callee_fqn in first_line:
+        if re.match(rf"^{re.escape(callee_fqn)}\s*\(", first_line):
             return entry
-        if (callee_stem + "(") not in first_line:
+        if not re.match(rf"^{re.escape(callee_stem)}\s*\(", first_line):
             continue
         if candidate_callee_fqns is not None:
             same_stem = {
@@ -187,19 +198,51 @@ def read_json(path: Path) -> dict:
 
 def load_global_call_graph(work_dir: Path) -> dict:
     path = work_dir / "spec_prompts" / "global_call_graph.json"
-    if not path.exists():
-        return {}
-    return json.loads(path.read_text())
+    graph = read_json(path)
+    if not isinstance(graph, dict):
+        raise ValueError(f"invalid global call graph {path}: root must be an object")
+    if graph.get("schema_version") != 1:
+        raise ValueError(f"invalid global call graph {path}: unsupported schema_version")
 
+    required = {"functions", "callers", "callees"}
+    missing = required - set(graph)
+    if missing:
+        raise ValueError(
+            f"invalid global call graph {path}: missing {', '.join(sorted(missing))}"
+        )
+    for key in required:
+        if not isinstance(graph[key], dict):
+            raise ValueError(f"invalid global call graph {path}: {key} must be an object")
 
-def phase_callers_key(func: dict, phase: int) -> str:
-    target = f"phase{phase}_callers"
-    if target in func:
-        return target
-    for key in func.keys():
-        if key.endswith("_callers") and key.startswith("phase"):
-            return key
-    return target
+    function_names = set(graph["functions"])
+    if set(graph["callers"]) != function_names or set(graph["callees"]) != function_names:
+        raise ValueError(f"invalid global call graph {path}: function coverage is inconsistent")
+    for fqn, meta in graph["functions"].items():
+        if not isinstance(meta, dict) or not {"phase", "layer", "file"} <= set(meta):
+            raise ValueError(f"invalid global call graph {path}: incomplete metadata for {fqn}")
+        if (
+            not isinstance(meta["phase"], int)
+            or not isinstance(meta["layer"], int)
+            or not isinstance(meta["file"], str)
+        ):
+            raise ValueError(f"invalid global call graph {path}: invalid metadata for {fqn}")
+        for edge_key in ("callers", "callees"):
+            edges = graph[edge_key][fqn]
+            if (
+                not isinstance(edges, list)
+                or len(edges) != len(set(edges))
+                or any(edge not in function_names for edge in edges)
+            ):
+                raise ValueError(f"invalid global call graph {path}: invalid {edge_key} for {fqn}")
+    for caller_fqn, callee_fqns in graph["callees"].items():
+        for callee_fqn in callee_fqns:
+            if caller_fqn not in graph["callers"][callee_fqn]:
+                raise ValueError(f"invalid global call graph {path}: call edges are inconsistent")
+    for callee_fqn, caller_fqns in graph["callers"].items():
+        for caller_fqn in caller_fqns:
+            if callee_fqn not in graph["callees"][caller_fqn]:
+                raise ValueError(f"invalid global call graph {path}: call edges are inconsistent")
+    return graph
 
 
 def detect_lang_and_comment(file_rel: str, ext_to_lang: Dict[str, str]) -> Tuple[str, str]:
@@ -219,7 +262,8 @@ def build_prompt(
     work_dir: Path,
     fm_agent_prefix: str,
     ext_to_lang: Dict[str, str],
-    global_call_graph: Optional[dict] = None,
+    global_call_graph: dict,
+    require_all_callers: bool = False,
 ) -> str:
     lines: List[str] = []
     sample_lang = "unknown"
@@ -252,10 +296,10 @@ def build_prompt(
     lines.append("- Specs describe INTENDED CORRECT behavior per the domain (see domain files)")
     lines.append(f"- ALL files below exist in {fm_agent_prefix}extracted_functions/ - read and process each one")
 
-    graph = global_call_graph or {}
-    global_funcs = graph.get("functions", {})
-    global_callers = graph.get("callers", {})
-    global_callees = graph.get("callees", {})
+    graph = global_call_graph
+    global_funcs = graph["functions"]
+    global_callers = graph["callers"]
+    global_callees = graph["callees"]
     caller_specs = []
     caller_expectations = {}
     available_callers = {}
@@ -264,16 +308,16 @@ def build_prompt(
     seen_expectations = set()
     for fn in functions:
         fn_name = fn["name"]
-        caller_key = phase_callers_key(fn, phase)
-        callers = global_callers.get(fn_name, fn.get(caller_key, []))
+        if fn_name not in global_callers:
+            raise ValueError(f"function missing from global call graph: {fn_name}")
+        callers = global_callers[fn_name]
         for caller_name in sorted(set(callers)):
-            caller_meta = global_funcs.get(caller_name) or all_funcs.get(caller_name)
+            caller_meta = global_funcs.get(caller_name)
             if not caller_meta:
-                pending_callers.append((fn_name, caller_name, "function metadata not found"))
-                continue
-            caller_phase = caller_meta.get("phase", phase)
-            caller_layer = caller_meta.get("layer", func_to_layer.get(caller_name))
-            if caller_phase == phase and (
+                raise ValueError(f"caller missing from global call graph: {caller_name}")
+            caller_phase = caller_meta["phase"]
+            caller_layer = caller_meta["layer"]
+            if not require_all_callers and caller_phase == phase and (
                 caller_layer is None or caller_layer >= layer_idx
             ):
                 continue
@@ -295,7 +339,7 @@ def build_prompt(
             entry = extract_callee_spec_from_info(
                 info_block,
                 fn_name,
-                global_callees.get(caller_name) if graph else None,
+                global_callees[caller_name],
             )
             if entry:
                 expectation_key = (fn_name, caller_name, entry.strip())
@@ -310,6 +354,13 @@ def build_prompt(
                     caller_name,
                     "matching INFO entry not found or callee name is ambiguous",
                 ))
+
+    if require_all_callers and pending_callers:
+        details = "; ".join(
+            f"{caller_name} -> {fn_name}: {reason}"
+            for fn_name, caller_name, reason in sorted(set(pending_callers))
+        )
+        raise RuntimeError(f"caller contracts are not ready: {details}")
 
     if caller_specs:
         lines.append("")
@@ -344,6 +395,11 @@ def build_prompt(
     if pending_callers:
         lines.append("")
         lines.append("## PENDING CALLER CONTRACTS")
+        lines.append(
+            "The following callers exist, but their contracts are not available "
+            "in this generation pass."
+        )
+        lines.append("Do not assume that these callers have no requirements.")
         for fn_name, caller_name, reason in sorted(set(pending_callers)):
             lines.append(f"- {caller_name} -> {fn_name}: {reason}")
 
@@ -457,10 +513,17 @@ def main() -> int:
     batch_index = 0
     write_targets: List[Tuple[Path, str]] = []
     stale_targets: List[Path] = []
+    requested_functions = set(args.functions or [])
+    found_functions = set()
 
     for layer_idx in range(start_layer, end_layer + 1):
         layer = layers[layer_idx]
         layer_functions = layer.get("functions", [])
+        if requested_functions:
+            layer_functions = [
+                fn for fn in layer_functions if fn["name"] in requested_functions
+            ]
+            found_functions.update(fn["name"] for fn in layer_functions)
         is_cycle = bool(layer.get("cycle_resolution", False))
         tag = "cycle" if is_cycle else "extracted"
         chunks = chunked(layer_functions, args.batch_size)
@@ -492,6 +555,7 @@ def main() -> int:
                     fm_agent_prefix,
                     ext_to_lang,
                     global_call_graph,
+                    args.require_all_callers,
                 )
                 write_targets.append((out_path, content))
             else:
@@ -510,6 +574,13 @@ def main() -> int:
                 }
             )
             batch_index += 1
+
+    missing_functions = requested_functions - found_functions
+    if missing_functions:
+        raise ValueError(
+            "requested functions not found in selected layers: "
+            + ", ".join(sorted(missing_functions))
+        )
 
     manifest = {
         "phase": args.phase,

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -162,7 +162,7 @@ def extract_callee_spec_from_info(
                 break
 
     split_tag = f"{prefix} [SPLIT]" if prefix else "[SPLIT]"
-    exact_names = [callee_fqn, *(aliases or ())]
+    exact_names = {callee_fqn, *(aliases or ())}
     callee_stem = callee_fqn.split("::")[-1]
     for entry in info_block.split(split_tag):
         entry = entry.strip()
@@ -172,9 +172,14 @@ def extract_callee_spec_from_info(
         # Strip the comment prefix to get the actual content
         if prefix and first_line.startswith(prefix):
             first_line = first_line[len(prefix):].strip()
-        if any(_info_line_mentions_name(first_line, name) for name in exact_names):
+        match = re.match(r"^(?P<label>[^\s(]+)\s*\(", first_line)
+        if not match:
+            continue
+        called_label = match.group("label")
+        if called_label in exact_names:
             return entry
-        if not re.match(rf"^{re.escape(callee_stem)}\s*\(", first_line):
+        called_stem = re.split(r"::|->|\.", called_label)[-1]
+        if called_stem != callee_stem:
             continue
         if candidate_callee_fqns is not None:
             same_stem = {
@@ -185,17 +190,6 @@ def extract_callee_spec_from_info(
                 continue
         return entry
     return None
-
-
-def _info_line_mentions_name(first_line: str, name: str) -> bool:
-    if not name:
-        return False
-    return bool(
-        re.search(
-            rf"(?<![A-Za-z0-9_:]){re.escape(name)}\s*\(",
-            first_line,
-        )
-    )
 
 
 def chunked(items: List[dict], size: int) -> List[List[dict]]:

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -523,14 +523,11 @@ def generate_topdown_layers(proj_dir, phase_numbers=None):
             stem = fqn.split("::")[-1]
             global_stem_to_fqns[stem].add(fqn)
 
-    output_files = []
-
+    phase_results = []
+    global_callees_map = defaultdict(set)
     for phase_info in phases_data["phases"]:
         phase_num = phase_info["phase"]
         phase_name = phase_info["name"]
-
-        if phase_numbers and phase_num not in phase_numbers:
-            continue
 
         # 1.2 Collect files
         phase_files = _collect_phase_files(proj_dir, phase_info)
@@ -546,6 +543,70 @@ def generate_topdown_layers(proj_dir, phase_numbers=None):
 
         # 1.5 Compute topological layers
         layers = _compute_layers(phase_fqns, callees_map, callers_map)
+
+        for caller_fqn, callee_fqns in all_callees_map.items():
+            global_callees_map[caller_fqn].update(callee_fqns)
+
+        phase_results.append({
+            "phase": phase_num,
+            "phase_name": phase_name,
+            "callees_map": callees_map,
+            "callers_map": callers_map,
+            "file_map": file_map,
+            "module_map": module_map,
+            "phase_fqns": phase_fqns,
+            "layers": layers,
+        })
+
+    global_callers_map = defaultdict(set)
+    for caller_fqn, callee_fqns in global_callees_map.items():
+        for callee_fqn in callee_fqns:
+            global_callers_map[callee_fqn].add(caller_fqn)
+
+    global_functions = {}
+    for result in phase_results:
+        layer_by_fqn = {
+            fqn: layer_info["layer"]
+            for layer_info in result["layers"]
+            for fqn in layer_info["functions"]
+        }
+        for fqn in result["phase_fqns"]:
+            global_functions[fqn] = {
+                "phase": result["phase"],
+                "layer": layer_by_fqn[fqn],
+                "file": os.path.relpath(result["file_map"][fqn], proj_dir),
+                "unit": result["module_map"].get(fqn, ""),
+            }
+
+    global_graph = {
+        "schema_version": 1,
+        "functions": dict(sorted(global_functions.items())),
+        "callees": {
+            fqn: sorted(global_callees_map.get(fqn, set()))
+            for fqn in sorted(global_functions)
+        },
+        "callers": {
+            fqn: sorted(global_callers_map.get(fqn, set()))
+            for fqn in sorted(global_functions)
+        },
+    }
+    global_graph_path = os.path.join(output_dir, "global_call_graph.json")
+    with open(global_graph_path, "w") as f:
+        json.dump(global_graph, f, indent=2, ensure_ascii=False)
+
+    output_files = []
+    for result in phase_results:
+        phase_num = result["phase"]
+        phase_name = result["phase_name"]
+        if phase_numbers and phase_num not in phase_numbers:
+            continue
+
+        callees_map = result["callees_map"]
+        callers_map = result["callers_map"]
+        file_map = result["file_map"]
+        module_map = result["module_map"]
+        phase_fqns = result["phase_fqns"]
+        layers = result["layers"]
 
         # Build phase-specific key names
         phase_callers_key = f"phase{phase_num}_callers"
@@ -571,7 +632,8 @@ def generate_topdown_layers(proj_dir, phase_numbers=None):
 
                 phase_callers = sorted(callers_map.get(fqn, set()) & phase_fqns)
                 phase_callees = sorted(callees_map.get(fqn, set()) & phase_fqns)
-                all_callees = sorted(all_callees_map.get(fqn, set()))
+                all_callers = sorted(global_callers_map.get(fqn, set()))
+                all_callees = sorted(global_callees_map.get(fqn, set()))
 
                 func_entries.append({
                     "name": fqn,
@@ -579,6 +641,7 @@ def generate_topdown_layers(proj_dir, phase_numbers=None):
                     "unit": unit,
                     phase_callers_key: phase_callers,
                     phase_callees_key: phase_callees,
+                    "all_callers": all_callers,
                     "all_callees": all_callees,
                 })
 

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -1337,7 +1337,7 @@ def _llm_check_caller_info_update(proj_dir, work_dir, idx, caller_fqn, callee_na
     )
 
 
-def _collect_caller_context(fqn, callers_map, file_map):
+def _collect_caller_context(fqn, callers_map, callees_map, file_map):
     """
     Gather the context an existing caller provides about fqn, mirroring the caller context
     run_pipeline feeds into spec generation: each caller's own [SPEC] block and the entry in
@@ -1356,7 +1356,14 @@ def _collect_caller_context(fqn, callers_map, file_map):
         cpath_p = Path(cpath)
         caller_spec = extract_spec_block(cpath_p)
         info_block = extract_info_block(cpath_p)
-        expectation = extract_callee_spec_from_info(info_block, fqn) if info_block else None
+        expectation = (
+            extract_callee_spec_from_info(
+                info_block,
+                fqn,
+                callees_map.get(caller_fqn, ()),
+            )
+            if info_block else None
+        )
         if caller_spec or expectation:
             context.append((caller_fqn, caller_spec, expectation))
     return context
@@ -1558,7 +1565,9 @@ def _update_specs_for_intent(proj_dir, work_dir, developer_intent, changed_funct
             # one from scratch the way the full run does, rather than skipping the function.
             source = content
             old_spec, old_info = None, None
-            caller_context = _collect_caller_context(fqn, callers_map, file_map)
+            caller_context = _collect_caller_context(
+                fqn, callers_map, callees_map, file_map
+            )
             result = _opencode_generate_spec(
                 proj_dir, work_dir, idx, fqn, lang_key, comment_prefix,
                 developer_intent, callee_names, source, caller_context,


### PR DESCRIPTION
## Summary

- build a global bidirectional call graph across all phases
- add `all_callers` metadata and generate `global_call_graph.json`
- inject available cross-phase caller contracts into callee prompts
- preserve existing same-phase layer behavior
- report unavailable caller contracts as pending
- avoid ambiguous stem-only matching for same-named callees

## Problem

Cross-phase call edges were recorded only through `all_callees`. The corresponding reverse caller relationships were not persisted, and batch prompt generation only loaded callers from the current phase. As a result, callee specifications could miss requirements from callers in other phases.

## Validation

- Python syntax checks passed
- `git diff --check` passed
- isolated temporary-project tests passed
- CodeGraph behavior was mocked where appropriate
- no LLM or API calls were used during testing

Fixes fmagent-project/FM-Agent#49