### PR TITLE
Feat: add new argument --only-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ uv run python main.py <proj_dir> [--resume] [--domain-knowledge FILE ...] [--sub
 | `--isolate`                 | Run against an isolated git worktree snapshot of the project instead of the project directory itself. |
 | `--submodule PATH [PATH ...]` | Only process source code under one or more subdirectories of `proj_dir`. |
 | `--extra-edge FILE`         | Add supplemental caller-to-callee edges to the static call graph from a JSON file or directory. |
+| `--only-spec`               | Only generate behavioral specs; skip the reasoning and bug validation stages. Cannot be combined with `--incremental`. |
 
 `proj_dir` must be a git repository.
 
@@ -217,6 +218,12 @@ uv run python main.py <proj_dir> --incremental intent.md --submodule src/core sr
 `--submodule` paths must point to directories inside `proj_dir`. The option can be combined with `--resume`, `--isolate`, and `--incremental`, but not with `--entry-func`.
 
 By default, every invocation wipes the existing `fm_agent/` directory and restarts from scratch, so an interrupted run loses all prior progress. Pass `--resume` (or set the environment variable `FM_AGENT_RESUME=1`) to continue where the previous run left off. In resume mode FM-Agent keeps the existing `fm_agent/` directory and only does the remaining work.
+
+Use `--only-spec` to stop after generating behavioral specs, skipping the reasoning and bug validation stages. This produces the `[SPEC]` blocks for each function without spending time on verification, which is useful when you only want the specs or want to review them before running the full analysis. It cannot be combined with `--incremental`, which is inherently a reasoning/bug-validation flow.
+
+```bash
+uv run python main.py <proj_dir> --only-spec
+```
 
 Use `--extra-edge FILE` when the static parser cannot see an important call relationship, such as indirect syscall dispatch. Supplemental edges are applied to full, entry-point-scoped, and incremental runs. The JSON shape is:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -175,6 +175,7 @@ uv run python main.py <proj_dir> [--resume] [--domain-knowledge FILE ...] [--sub
 | `--isolate` | 针对项目的隔离 git worktree 快照运行，而非直接在项目目录上运行。 |
 | `--submodule PATH [PATH ...]` | 只处理 `proj_dir` 中一个或多个子目录下的源代码。 |
 | `--extra-edge FILE` | 从 JSON 文件或目录向静态调用图补充 caller 到 callee 的边。 |
+| `--only-spec` | 只生成行为规约，跳过推理与 Bug 验证阶段。不能与 `--incremental` 一起使用。 |
 
 `proj_dir` 必须是一个 git 仓库。
 
@@ -196,6 +197,12 @@ uv run python main.py <proj_dir> --incremental intent.md --submodule src/core sr
 `--submodule` 路径必须是 `proj_dir` 内部目录。该参数可与 `--resume`、`--isolate` 和 `--incremental` 一起使用，但不能与 `--entry-func` 一起使用。
 
 默认情况下，每次运行都会清空已有的 `fm_agent/` 目录并从头开始，因此一旦运行中断，之前的所有进度都会丢失。可通过 `--resume` 参数（或设置环境变量 `FM_AGENT_RESUME=1`）从上一次中断处继续。在续跑模式下，FM-Agent 会保留已有的 `fm_agent/` 目录，只执行剩余的工作。
+
+使用 `--only-spec` 可以在生成行为规约后即停止，跳过推理与 Bug 验证阶段。它会为每个函数生成 `[SPEC]` 块，而不在验证上花费时间，适用于只需要规约、或希望先审阅规约再运行完整分析的场景。该参数不能与 `--incremental` 一起使用，因为增量模式本质上是一个推理/Bug 验证流程。
+
+```bash
+uv run python main.py <proj_dir> --only-spec
+```
 
 当静态解析无法看到关键调用关系时（例如间接 syscall 分发），可使用 `--extra-edge FILE`。补充边会同时作用于完整运行、入口函数范围运行和增量运行。JSON 格式如下：
 

--- a/main.py
+++ b/main.py
@@ -184,6 +184,7 @@ def run_pipeline(
     submodules=None,
     one_phase=False,
     extra_call_edges_path=None,
+    only_spec=False,
 ):
     if not os.path.isdir(proj_dir):
         print(f"[Pipeline] ERROR: proj_dir does not exist or is not a directory: {proj_dir}")
@@ -283,7 +284,10 @@ def run_pipeline(
     generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
 
     # --- Stage 4: Execute spec generation workflow (per phase, per layer) ---
-    print("[Pipeline] Stage 4/4: Generating specs & verification...")
+    if only_spec:
+        print("[Pipeline] Stage 4/4: Generating specs (reasoning & bug validation disabled)...")
+    else:
+        print("[Pipeline] Stage 4/4: Generating specs & verification...")
     batch_md_src = os.path.join(script_dir, "md", "workflow_spec_step4_batch.md")
     batch_md_dst = os.path.join(work_dir, "workflow_spec_step4_batch.md")
     shutil.copy2(batch_md_src, batch_md_dst)
@@ -352,22 +356,25 @@ def run_pipeline(
                 # Find batches with unspecced functions
                 pending_batches = _get_pending_batches(all_batches, proj_dir)
                 if not pending_batches:
-                    incomplete_verification = _get_incomplete_verification_files(
-                        layer_files, input_dir, output_dir, work_dir
-                    )
-                    if incomplete_verification:
-                        logging.info(
-                            f"Phase {phase_num} Layer {layer_idx}: "
-                            f"{len(incomplete_verification)} ready file(s) still need verification or validation"
+                    # All functions in this layer are specced. In only-spec mode
+                    # we stop here without running the reasoner/bug validation.
+                    if not only_spec:
+                        incomplete_verification = _get_incomplete_verification_files(
+                            layer_files, input_dir, output_dir, work_dir
                         )
-                        newly_processed = streaming_reasoner(
-                            input_dir, output_dir, file_list=layer_files,
-                            proj_dir=proj_dir, work_dir=work_dir,
-                            spec_procs=None,
-                            already_processed=all_processed | layer_processed,
-                            resume=resume,
-                        )
-                        layer_processed.update(newly_processed)
+                        if incomplete_verification:
+                            logging.info(
+                                f"Phase {phase_num} Layer {layer_idx}: "
+                                f"{len(incomplete_verification)} ready file(s) still need verification or validation"
+                            )
+                            newly_processed = streaming_reasoner(
+                                input_dir, output_dir, file_list=layer_files,
+                                proj_dir=proj_dir, work_dir=work_dir,
+                                spec_procs=None,
+                                already_processed=all_processed | layer_processed,
+                                resume=resume,
+                            )
+                            layer_processed.update(newly_processed)
                     break
 
                 # Submit all pending spec batches through a bounded executor so
@@ -402,7 +409,7 @@ def run_pipeline(
                         f"submitted {len(spec_futures)} spec-generation batch tasks "
                         f"(max_workers={MAX_WORKERS}, total_pending_batches={len(pending_batches)})"
                     )
-                    if spec_futures:
+                    if spec_futures and not only_spec:
                         newly_processed = streaming_reasoner(
                             input_dir, output_dir, file_list=layer_files,
                             proj_dir=proj_dir, work_dir=work_dir,
@@ -459,15 +466,20 @@ def run_pipeline(
         for rel in phase_files:
             all_processed.add(os.path.join(input_dir, rel))
 
-    # Print confirmed bug count
-    summary_path = os.path.join(work_dir, "bug_validation", "summary.json")
-    if os.path.exists(summary_path):
-        with open(summary_path, "r") as f:
-            summary = json.load(f)
-        confirmed = summary.get("total_confirmed", 0)
-        print(f"[Pipeline] Confirmed bugs: {confirmed}")
+    # Print confirmed bug count (skipped in only-spec mode, which runs no
+    # reasoning or bug validation).
+    if not only_spec:
+        summary_path = os.path.join(work_dir, "bug_validation", "summary.json")
+        if os.path.exists(summary_path):
+            with open(summary_path, "r") as f:
+                summary = json.load(f)
+            confirmed = summary.get("total_confirmed", 0)
+            print(f"[Pipeline] Confirmed bugs: {confirmed}")
 
-    print("[Pipeline] Done.")
+    if only_spec:
+        print("[Pipeline] Done (specs only; reasoning & bug validation skipped).")
+    else:
+        print("[Pipeline] Done.")
 
 
 if __name__ == "__main__":
@@ -475,7 +487,7 @@ if __name__ == "__main__":
         usage="python3 main.py <proj_dir> [--resume] [--incremental INTENT_FILE] "
               "[--domain-knowledge FILE ...] [--one-phase] [--isolate] "
               "[--submodule PATH [PATH ...]] [--entry-func PATH] "
-              "[--end-func PATH ...] [--extra-edge FILE]",
+              "[--end-func PATH ...] [--extra-edge FILE] [--only-spec]",
         description="Run the FM agent pipeline on a project directory.",
     )
     parser.add_argument("proj_dir", help="path to the project directory")
@@ -502,6 +514,12 @@ if __name__ == "__main__":
         "--one-phase",
         action="store_true",
         help="Put all planned source files into a single analysis phase.",
+    )
+    parser.add_argument(
+        "--only-spec",
+        action="store_true",
+        help="Only generate behavioral specs; skip the reasoning and bug "
+        "validation stages.",
     )
     parser.add_argument(
         "--domain-knowledge",
@@ -568,6 +586,12 @@ if __name__ == "__main__":
     if submodules and args.entry_func is not None:
         parser.error("--submodule cannot be combined with --entry-func.")
 
+    if args.only_spec and args.incremental:
+        parser.error(
+            "--only-spec cannot be combined with --incremental "
+            "(incremental mode is inherently a reasoning/bug-validation flow)."
+        )
+
     # ---- pre-flight environment check (shared by all pipeline modes) ----
     import config
     from src.env_check import run as env_check_run
@@ -588,6 +612,7 @@ if __name__ == "__main__":
             domain_knowledge_files=domain_knowledge_files,
             one_phase=args.one_phase,
             extra_call_edges_path=extra_call_edges_path,
+            only_spec=args.only_spec,
         )
         end_time = time.time()
         logging.info(f"Total time: {end_time - start_time:.2f} seconds")
@@ -655,6 +680,7 @@ if __name__ == "__main__":
                     submodules=submodules,
                     one_phase=args.one_phase,
                     extra_call_edges_path=extra_call_edges_path,
+                    only_spec=args.only_spec,
                 )
             # Record the commit that was processed. Written after the pipeline since
             # it recreates fm_agent/; with --isolate it lives in the snapshot and is

--- a/src/entry_reasoning_pipeline.py
+++ b/src/entry_reasoning_pipeline.py
@@ -222,6 +222,7 @@ def run_entry_pipeline(
     domain_knowledge_files=None,
     one_phase=False,
     extra_call_edges_path=None,
+    only_spec=False,
 ):
     """Run the entry-point-scoped reasoning pipeline.
 
@@ -281,6 +282,7 @@ def run_entry_pipeline(
             domain_knowledge_files=domain_knowledge_files,
             one_phase=one_phase,
             extra_call_edges_path=extra_call_edges_path,
+            only_spec=only_spec,
         )
     finally:
         clear_test_file_exemptions()
@@ -428,6 +430,7 @@ def _run_entry_pipeline_inner(
     domain_knowledge_files=None,
     one_phase=False,
     extra_call_edges_path=None,
+    only_spec=False,
 ):
     """Body of run_entry_pipeline; runs with the entry source file exempted."""
     # 1. Selection: extract fresh into a temp workspace and build the call graph.
@@ -474,6 +477,7 @@ def _run_entry_pipeline_inner(
             domain_knowledge_files=domain_knowledge_files,
             one_phase=one_phase,
             extra_call_edges_path=extra_call_edges_path,
+            only_spec=only_spec,
         )
     finally:
         # 4. Copy the generated fm_agent/ back into proj_dir, then discard the


### PR DESCRIPTION
## Add `--only-spec` flag to stop after spec generation

Fixes issue #117 

### Summary
Adds a new `--only-spec` CLI flag that runs the pipeline through behavioral
spec generation and then stops, skipping the reasoning and bug-validation
stages. This is useful when you only want the `[SPEC]` blocks for each
function, or want to review generated specs before committing time to the
full verification analysis.

### Changes
- **`main.py`**
  - New `--only-spec` argument (`action="store_true"`).
  - `run_pipeline()` gains an `only_spec` parameter. When set:
    - Stage 4 no longer invokes `streaming_reasoner` (both the per-attempt
      spec+reason path and the post-spec verification catch-up path are
      skipped).
    - The confirmed-bug summary print is skipped.
    - A clearer completion message is printed:
      `Done (specs only; reasoning & bug validation skipped).`
  - Stage 4 header message reflects the mode.
  - Guardrail: `--only-spec` cannot be combined with `--incremental`
    (incremental mode is inherently a reasoning/bug-validation flow) —
    rejected with a `parser.error`.
  - Threaded `only_spec` through to the entry-point pipeline call.
- **`src/entry_reasoning_pipeline.py`**
  - Propagate `only_spec` through `run_entry_pipeline` →
    `_run_entry_pipeline_inner` → `run_pipeline`, so entry-func runs honor
    the flag.
- **`README.md` / `README_zh.md`**
  - Documented the new flag in the argument table and added a usage section.

### Usage
```bash
uv run python main.py <proj_dir> --only-spec
