### PR TITLE
Pin codegraph to the fmagent fork's fixed release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -145,12 +145,46 @@ else
     bunx oh-my-openagent install --no-tui --claude=no --gemini=no --copilot=no
 fi
 
-# ---------- codegraph ----------
-if command -v codegraph &>/dev/null; then
-    echo "[ok] codegraph found: $(codegraph --version 2>/dev/null || echo 'unknown version')"
+# ---------- codegraph (pinned to fmagent fork) ----------
+# Pin to our maintenance fork's fixed build: the latest upstream release still
+# has a C extraction bug (a macro attribute + typedef'd return type on a no-arg
+# function is indexed under its parameter list `(VOID)` instead of its name), so
+# tracking upstream `latest` silently drops functions. The fork ships a
+# self-contained prebuilt bundle (no Node/build). Change CODEGRAPH_VERSION to switch.
+CODEGRAPH_REPO="fmagent-project/codegraph"
+CODEGRAPH_VERSION="v1.3.0-fmagent.1"                 # <- switch: bump this one line
+codegraph_want="${CODEGRAPH_VERSION#v}"
+if codegraph --version 2>/dev/null | grep -qx "$codegraph_want"; then
+    echo "[ok] codegraph $codegraph_want already installed"
 else
-    echo "[..] installing codegraph"
-    bun install -g @colbymchenry/codegraph
+    echo "[..] installing codegraph $CODEGRAPH_VERSION from $CODEGRAPH_REPO"
+    curl -fsSL "https://raw.githubusercontent.com/$CODEGRAPH_REPO/main/install.sh" \
+      | CODEGRAPH_VERSION="$CODEGRAPH_VERSION" sh
+    command -v codegraph &>/dev/null || { echo "[!!] codegraph install failed"; exit 1; }
+    # If a different codegraph still wins on PATH, tell the user exactly how to
+    # remove it. We never uninstall global software ourselves.
+    if ! codegraph --version 2>/dev/null | grep -qx "$codegraph_want"; then
+        codegraph_now="$(command -v codegraph 2>/dev/null || true)"
+        codegraph_ver="$(codegraph --version 2>/dev/null || echo none)"
+        echo ""
+        echo "=================================================================="
+        echo "  [!!] ACTION REQUIRED - a different codegraph is shadowing ours"
+        echo ""
+        echo "    want : $codegraph_want  (fmagent fork, fixes C name loss)"
+        echo "    found: $codegraph_ver  ->  ${codegraph_now:-<not found>}"
+        echo ""
+        echo "    FM-Agent will silently lose functions until you remove it."
+        echo "    Run the matching command, then re-run ./install.sh :"
+        if command -v bun &>/dev/null && bun pm ls -g 2>/dev/null | grep -q '@colbymchenry/codegraph'; then
+            echo "      bun rm -g @colbymchenry/codegraph"
+        elif command -v npm &>/dev/null && npm ls -g @colbymchenry/codegraph >/dev/null 2>&1; then
+            echo "      npm rm -g @colbymchenry/codegraph"
+        elif [ -n "$codegraph_now" ]; then
+            echo "      rm -f \"$codegraph_now\"     # remove the shadowing launcher"
+        fi
+        echo "=================================================================="
+        echo ""
+    fi
 fi
 
 version_ge() {

--- a/install.sh
+++ b/install.sh
@@ -154,19 +154,17 @@ fi
 CODEGRAPH_REPO="fmagent-project/codegraph"
 CODEGRAPH_VERSION="v1.3.0-fmagent.1"                 # <- switch: bump this one line
 codegraph_want="${CODEGRAPH_VERSION#v}"
-if codegraph --version 2>/dev/null | grep -qx "$codegraph_want"; then
-    echo "[ok] codegraph $codegraph_want already installed"
+codegraph_bin_dir="${CODEGRAPH_BIN_DIR:-$HOME/.local/bin}"
+# Check/install against $codegraph_bin_dir specifically (not a bare `codegraph`
+# that might resolve to a different copy on PATH): FM-Agent invokes codegraph by
+# absolute path from this dir, so this is the location that must hold the pin.
+if [ "$("$codegraph_bin_dir/codegraph" --version 2>/dev/null)" = "$codegraph_want" ]; then
+    echo "[ok] codegraph $codegraph_want already installed in $codegraph_bin_dir"
 else
     echo "[..] installing codegraph $CODEGRAPH_VERSION from $CODEGRAPH_REPO"
-    codegraph_bin_dir="${CODEGRAPH_BIN_DIR:-$HOME/.local/bin}"
     curl -fsSL "https://raw.githubusercontent.com/$CODEGRAPH_REPO/main/install.sh" \
       | CODEGRAPH_VERSION="$CODEGRAPH_VERSION" CODEGRAPH_BIN_DIR="$codegraph_bin_dir" sh
-    # The installer writes $codegraph_bin_dir/codegraph but can't change this
-    # shell's PATH, so verify by the file (not `command -v`) and then put the dir
-    # on PATH for the rest of setup. If a different codegraph shadows this one, or
-    # the dir is not on your shell PATH, the installer prints how to fix it.
     [ -x "$codegraph_bin_dir/codegraph" ] || { echo "[!!] codegraph install failed"; exit 1; }
-    case ":$PATH:" in *":$codegraph_bin_dir:"*) ;; *) export PATH="$codegraph_bin_dir:$PATH" ;; esac
 fi
 
 version_ge() {

--- a/install.sh
+++ b/install.sh
@@ -158,33 +158,15 @@ if codegraph --version 2>/dev/null | grep -qx "$codegraph_want"; then
     echo "[ok] codegraph $codegraph_want already installed"
 else
     echo "[..] installing codegraph $CODEGRAPH_VERSION from $CODEGRAPH_REPO"
+    codegraph_bin_dir="${CODEGRAPH_BIN_DIR:-$HOME/.local/bin}"
     curl -fsSL "https://raw.githubusercontent.com/$CODEGRAPH_REPO/main/install.sh" \
-      | CODEGRAPH_VERSION="$CODEGRAPH_VERSION" sh
-    command -v codegraph &>/dev/null || { echo "[!!] codegraph install failed"; exit 1; }
-    # If a different codegraph still wins on PATH, tell the user exactly how to
-    # remove it. We never uninstall global software ourselves.
-    if ! codegraph --version 2>/dev/null | grep -qx "$codegraph_want"; then
-        codegraph_now="$(command -v codegraph 2>/dev/null || true)"
-        codegraph_ver="$(codegraph --version 2>/dev/null || echo none)"
-        echo ""
-        echo "=================================================================="
-        echo "  [!!] ACTION REQUIRED - a different codegraph is shadowing ours"
-        echo ""
-        echo "    want : $codegraph_want  (fmagent fork, fixes C name loss)"
-        echo "    found: $codegraph_ver  ->  ${codegraph_now:-<not found>}"
-        echo ""
-        echo "    FM-Agent will silently lose functions until you remove it."
-        echo "    Run the matching command, then re-run ./install.sh :"
-        if command -v bun &>/dev/null && bun pm ls -g 2>/dev/null | grep -q '@colbymchenry/codegraph'; then
-            echo "      bun rm -g @colbymchenry/codegraph"
-        elif command -v npm &>/dev/null && npm ls -g @colbymchenry/codegraph >/dev/null 2>&1; then
-            echo "      npm rm -g @colbymchenry/codegraph"
-        elif [ -n "$codegraph_now" ]; then
-            echo "      rm -f \"$codegraph_now\"     # remove the shadowing launcher"
-        fi
-        echo "=================================================================="
-        echo ""
-    fi
+      | CODEGRAPH_VERSION="$CODEGRAPH_VERSION" CODEGRAPH_BIN_DIR="$codegraph_bin_dir" sh
+    # The installer writes $codegraph_bin_dir/codegraph but can't change this
+    # shell's PATH, so verify by the file (not `command -v`) and then put the dir
+    # on PATH for the rest of setup. If a different codegraph shadows this one, or
+    # the dir is not on your shell PATH, the installer prints how to fix it.
+    [ -x "$codegraph_bin_dir/codegraph" ] || { echo "[!!] codegraph install failed"; exit 1; }
+    case ":$PATH:" in *":$codegraph_bin_dir:"*) ;; *) export PATH="$codegraph_bin_dir:$PATH" ;; esac
 fi
 
 version_ge() {

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -376,6 +376,27 @@ class CodeGraphExtractor:
         return dict(result)
 
 
+def _codegraph_env() -> dict:
+    """Return a copy of the environment whose PATH is prepended with the directory
+    FM-Agent installs the pinned codegraph into.
+
+    FM-Agent's install.sh installs the fork's fixed codegraph into
+    ``$CODEGRAPH_BIN_DIR`` (default ``~/.local/bin``). That directory is not on
+    the default PATH on macOS (and some Linux setups), and an older codegraph may
+    sit earlier on PATH, so invoking a bare ``codegraph`` could miss the pinned
+    build or a shadowing one could win. Prepending the install dir here — the same
+    approach ``npm run`` uses for ``node_modules/.bin`` — makes the subprocess use
+    the pinned build without touching the user's shell configuration. Operates on
+    a copy so the parent process's environment is never mutated.
+    """
+    env = os.environ.copy()
+    bin_dir = os.environ.get("CODEGRAPH_BIN_DIR") or os.path.join(
+        os.path.expanduser("~"), ".local", "bin"
+    )
+    env["PATH"] = bin_dir + os.pathsep + env.get("PATH", "")
+    return env
+
+
 def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
     """Build the codegraph index for proj_dir with `codegraph init`.
 
@@ -408,7 +429,8 @@ def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
         print("[Pipeline] Building codegraph index...")
     try:
         result = subprocess.run(
-            ["codegraph", "init"], cwd=proj_dir, capture_output=True, text=True
+            ["codegraph", "init"], cwd=proj_dir, capture_output=True, text=True,
+            env=_codegraph_env(),
         )
     except FileNotFoundError:
         return  # codegraph not installed

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -376,25 +376,24 @@ class CodeGraphExtractor:
         return dict(result)
 
 
-def _codegraph_env() -> dict:
-    """Return a copy of the environment whose PATH is prepended with the directory
-    FM-Agent installs the pinned codegraph into.
+def _codegraph_cmd() -> str:
+    """Return the codegraph executable to invoke.
 
-    FM-Agent's install.sh installs the fork's fixed codegraph into
-    ``$CODEGRAPH_BIN_DIR`` (default ``~/.local/bin``). That directory is not on
-    the default PATH on macOS (and some Linux setups), and an older codegraph may
-    sit earlier on PATH, so invoking a bare ``codegraph`` could miss the pinned
-    build or a shadowing one could win. Prepending the install dir here — the same
-    approach ``npm run`` uses for ``node_modules/.bin`` — makes the subprocess use
-    the pinned build without touching the user's shell configuration. Operates on
-    a copy so the parent process's environment is never mutated.
+    FM-Agent's install.sh installs the pinned fork build into ``$CODEGRAPH_BIN_DIR``
+    (default ``~/.local/bin``) and keeps that path pointing at the pinned version.
+    Invoking it by absolute path — rather than a bare ``codegraph`` resolved against
+    the user's PATH — means the pinned build is used even when that directory is not
+    on PATH (the macOS default) and a different/older codegraph earlier on PATH
+    cannot shadow it (the pipx/Playwright pattern of running a managed binary from
+    its known location instead of by name). Falls back to a bare ``codegraph`` when
+    the pinned build is absent, so an externally provided codegraph still works; the
+    caller turns a missing binary into the regex-extractor fallback.
     """
-    env = os.environ.copy()
     bin_dir = os.environ.get("CODEGRAPH_BIN_DIR") or os.path.join(
         os.path.expanduser("~"), ".local", "bin"
     )
-    env["PATH"] = bin_dir + os.pathsep + env.get("PATH", "")
-    return env
+    local = os.path.join(bin_dir, "codegraph")
+    return local if os.access(local, os.X_OK) else "codegraph"
 
 
 def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
@@ -429,8 +428,7 @@ def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
         print("[Pipeline] Building codegraph index...")
     try:
         result = subprocess.run(
-            ["codegraph", "init"], cwd=proj_dir, capture_output=True, text=True,
-            env=_codegraph_env(),
+            [_codegraph_cmd(), "init"], cwd=proj_dir, capture_output=True, text=True
         )
     except FileNotFoundError:
         return  # codegraph not installed


### PR DESCRIPTION
Closes #119.

## Summary

Makes FM-Agent reliably use our maintenance fork's fixed codegraph, both at install time and at run time.

**`install.sh` — pin the install:**
- **Pin + switch** — installs `fmagent-project/codegraph` `v1.3.0-fmagent.1` (upstream v1.3.0 + the C macro-attribute name-loss fix). Bump the one `CODEGRAPH_VERSION` line to switch versions.
- **Self-contained bundle** — installed via the fork's `install.sh` (a prebuilt per-OS bundle; no Node or build tools needed).
- **Checks/installs against `$CODEGRAPH_BIN_DIR`** (default `~/.local/bin`) specifically, and verifies the launcher by file — so a bin dir that is not on the caller's PATH does not abort setup, and that dir always holds the pinned version.

**`src/languages/codegraph.py` — resolve it at run time:**
- The pinned build lands in `$CODEGRAPH_BIN_DIR/codegraph`. FM-Agent now invokes it by **absolute path** rather than a bare `codegraph` resolved against PATH — so the pinned build is used even when that dir is not on PATH (the macOS default), and an older codegraph earlier on PATH cannot shadow it (the pipx/Playwright pattern of running a managed binary from its known location). Falls back to a bare `codegraph`, then the regex extractor, when the pinned build is absent.

## Why

Tracking upstream `latest` silently pulls in a C extraction bug: a function shaped `MACRO_ATTR TYPEDEF_RET name(VOID)` is indexed under its parameter list `(VOID)` instead of its name, so such functions drop out of the call graph. Details in #119.