### PR TITLE
fix(setup): normalize missing module source files

### DIFF
--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -911,7 +911,7 @@ def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
         if os.path.exists(phases_json)
         else []
     )
-    _resume_skip = resume and not phase_plan_errors
+    _resume_skip = resume and _phase_plan_complete(work_dir)
     if _resume_skip:
         print("[Pipeline] Stage 1/6: RESUME — phases.json found, skipping phase plan generation.")
 

--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -265,32 +265,7 @@ def _deduplicate_phases(phases_dir):
     changed_modules = []
     for phase in sorted(data["phases"], key=lambda p: p["phase"]):
         for module in phase["modules"]:
-            source_files = module.get("source_files")
-
-            if source_files is None:
-                logging.warning(
-                    "Phase %s module '%s' has missing or null source_files; "
-                    "normalizing it to an empty list",
-                    phase.get("phase"),
-                    module.get("name", ""),
-                )
-                original = []
-            elif not isinstance(source_files, list):
-                raise ValueError(
-                    "Phase "
-                    f"{phase.get('phase')} module "
-                    f"{module.get('name', '')!r} field source_files "
-                    "must be an array or null"
-                )
-            elif not all(isinstance(source_file, str) for source_file in source_files):
-                raise ValueError(
-                    "Phase "
-                    f"{phase.get('phase')} module "
-                    f"{module.get('name', '')!r} field source_files "
-                    "must contain only strings"
-                )
-            else:
-                original = list(source_files)
+            original = module["source_files"]
 
             deduped = []
             for sf in original:
@@ -646,10 +621,70 @@ def _update_module_description(proj_dir, work_dir, modified_modules):
     )
 
 
+def _phase_plan_schema_errors(phases_path):
+    """Return human-readable schema errors for phases.json."""
+    try:
+        with open(phases_path, "r") as f:
+            data = json.load(f)
+    except OSError as exc:
+        return [f"phases.json could not be read: {exc}"]
+    except json.JSONDecodeError as exc:
+        return [f"phases.json is not valid JSON: {exc}"]
+
+    if not isinstance(data, dict):
+        return ["the top-level value must be an object"]
+
+    phases = data.get("phases")
+    if not isinstance(phases, list):
+        return ['top-level field "phases" must be an array']
+
+    errors = []
+    for phase_index, phase in enumerate(phases):
+        phase_path = f"phases[{phase_index}]"
+        if not isinstance(phase, dict):
+            errors.append(f"{phase_path} must be an object")
+            continue
+
+        modules = phase.get("modules")
+        if not isinstance(modules, list):
+            errors.append(f"{phase_path}.modules must be an array")
+            continue
+
+        for module_index, module in enumerate(modules):
+            module_path = f"{phase_path}.modules[{module_index}]"
+            if not isinstance(module, dict):
+                errors.append(f"{module_path} must be an object")
+                continue
+
+            module_name = module.get("name", "")
+            context = (
+                f"{module_path} ({module_name!r})"
+                if module_name
+                else module_path
+            )
+
+            if "source_files" not in module:
+                errors.append(f"{context}.source_files is missing")
+                continue
+
+            source_files = module["source_files"]
+            if not isinstance(source_files, list):
+                errors.append(f"{context}.source_files must be an array")
+                continue
+
+            for source_index, source_file in enumerate(source_files):
+                if not isinstance(source_file, str):
+                    errors.append(
+                        f"{context}.source_files[{source_index}] must be a string"
+                    )
+
+    return errors
+
+
 def _phase_plan_complete(work_dir):
-    """Return True only if phases.json exists and is valid JSON."""
+    """Return True only if phases.json exists and matches the required schema."""
     phases_path = os.path.join(work_dir, "phases.json")
-    return _json_file_is_valid(phases_path)
+    return not _phase_plan_schema_errors(phases_path)
 
 
 def _domain_context_complete(work_dir):
@@ -871,7 +906,12 @@ def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
     phases_json = os.path.join(work_dir, "phases.json")
     prev_mtime = os.path.getmtime(phases_json) if os.path.exists(phases_json) else None
 
-    _resume_skip = resume and _phase_plan_complete(work_dir)
+    phase_plan_errors = (
+        _phase_plan_schema_errors(phases_json)
+        if os.path.exists(phases_json)
+        else []
+    )
+    _resume_skip = resume and not phase_plan_errors
     if _resume_skip:
         print("[Pipeline] Stage 1/6: RESUME — phases.json found, skipping phase plan generation.")
 
@@ -909,6 +949,19 @@ def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
                       f"regenerate or overwrite work that is already done. {fm_reminder} {submodule_reminder}")
         if is_incremental:
             prompt = f"{prompt} {incremental_reminder}"
+        if phase_plan_errors:
+            formatted_errors = "\n".join(
+                f"- {error}" for error in phase_plan_errors
+            )
+            schema_repair_prompt = (
+                "IMPORTANT: The existing fm_agent/phases.json is valid JSON or "
+                "partially generated, but it does not match the required schema. "
+                "Read the project source files and repair these problems:\n"
+                f"{formatted_errors}\n"
+                "Do not use an empty source_files array merely to satisfy the schema. "
+                "Use an empty array only when the module genuinely owns no source files."
+            )
+            prompt = f"{prompt}\n\n{schema_repair_prompt}"
         prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_phases.md")
         command = build_llm_cli_command(
             model=OPENCODE_SETUP_MODEL,
@@ -935,7 +988,14 @@ def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
         except subprocess.CalledProcessError as e:
             logging.warning(f"Stage 1 attempt {attempt}: opencode exited with code {e.returncode}")
 
-        if os.path.exists(phases_json):
+        phase_plan_errors = (
+            _phase_plan_schema_errors(phases_json)
+            if os.path.exists(phases_json)
+            else ["phases.json is missing"]
+        )
+
+        phase_plan_ready = False
+        if not phase_plan_errors:
             if submodules:
                 phase_plan_ready = _phases_cover_current_sources(
                     phases_json, proj_dir, submodules
@@ -946,16 +1006,22 @@ def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
                     or _phases_cover_current_sources(phases_json, proj_dir)
                 )
             else:
-                phase_plan_ready = _json_file_is_valid(phases_json)
-            if phase_plan_ready:
-                break
+                phase_plan_ready = True
+        if phase_plan_ready:
+            break
 
         failure = "update phases.json" if is_incremental else "produce phases.json"
-        missing = (
-            "phases.json was not updated"
-            if is_incremental
-            else "phases.json missing or invalid"
-        )
+        if phase_plan_errors:
+            missing = (
+                "phases.json schema validation failed: "
+                + "; ".join(phase_plan_errors)
+            )
+        else:
+            missing = (
+                "phases.json was not updated"
+                if is_incremental
+                else "phases.json missing or invalid"
+            )
         if attempt < OPENCODE_MAX_RETRIES:
             delay = 10
             print(

--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -265,7 +265,33 @@ def _deduplicate_phases(phases_dir):
     changed_modules = []
     for phase in sorted(data["phases"], key=lambda p: p["phase"]):
         for module in phase["modules"]:
-            original = module["source_files"]
+            source_files = module.get("source_files")
+
+            if source_files is None:
+                logging.warning(
+                    "Phase %s module '%s' has missing or null source_files; "
+                    "normalizing it to an empty list",
+                    phase.get("phase"),
+                    module.get("name", ""),
+                )
+                original = []
+            elif not isinstance(source_files, list):
+                raise ValueError(
+                    "Phase "
+                    f"{phase.get('phase')} module "
+                    f"{module.get('name', '')!r} field source_files "
+                    "must be an array or null"
+                )
+            elif not all(isinstance(source_file, str) for source_file in source_files):
+                raise ValueError(
+                    "Phase "
+                    f"{phase.get('phase')} module "
+                    f"{module.get('name', '')!r} field source_files "
+                    "must contain only strings"
+                )
+            else:
+                original = list(source_files)
+
             deduped = []
             for sf in original:
                 if sf not in seen:


### PR DESCRIPTION

## Summary

Prevent Stage 1 from crashing when an LLM-generated `phases.json` contains malformed or missing `source_files` fields.

Instead of normalizing malformed data or raising an immediate `ValueError`, the pipeline now reports the schema problems to the setup agent and asks it to repair `phases.json`.

Closes #109.

## Root cause

Stage 1 previously considered `phases.json` complete when it existed and contained syntactically valid JSON. It did not validate the nested module schema.

As a result, output such as:

```json
{
  "name": "example",
  "description": "..."
}
```

could pass Stage 1 despite missing `source_files`. The malformed data would only be discovered later by `_deduplicate_phases()`, causing an unhandled `KeyError` or another post-processing failure.

## Changes

- Check the nested `phases.json` schema before accepting the Stage 1 output.
- Detect:
  - missing `source_files`;
  - non-array `source_files` values;
  - non-string entries inside `source_files`;
  - malformed top-level phase and module containers.
- Include actionable schema errors in the next setup-agent prompt.
- Ask the agent to inspect the project and repair the existing `phases.json`.
- Retry repairs using the existing `OPENCODE_MAX_RETRIES` limit.
- Prevent `--resume` from skipping a syntactically valid but schema-invalid phase plan.
- Only enter phase post-processing after the required schema checks pass.
- Keep `_deduplicate_phases()` focused on source-file deduplication rather than schema recovery.

## Behavior

A valid `phases.json` continues through the existing pipeline without behavioral changes.

When the generated phase plan has malformed `source_files` metadata, the pipeline now:

1. identifies the exact invalid module and field;
2. sends those errors back to the setup agent;
3. asks the agent to repair the existing phase plan;
4. checks the repaired output again before continuing.

If the agent cannot produce a valid phase plan within the configured retry limit, Stage 1 exits through its existing controlled failure path instead of producing an unhandled Python traceback.
```