### PR TITLE
ci: scope private sync to public repository

### DIFF
--- a/.github/workflows/sync-private.yml
+++ b/.github/workflows/sync-private.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   sync:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'fmagent-project/FM-Agent' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- Restrict the public-to-private sync job to `fmagent-project/FM-Agent`.
- Prevent the copied workflow from running and failing in the private repository.
- Keep the existing `main` branch guard.

## Changes

- ci: scope private sync to public repository

## Diff Stats

```text
 .github/workflows/sync-private.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

---
Generated by an AI coding agent