### PR TITLE
Add plugin support for phase planning and domain context generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,6 +188,7 @@ def run_pipeline(
     one_phase=False,
     extra_call_edges_path=None,
     only_spec=False,
+    plugin_config=None,
 ):
     if not os.path.isdir(proj_dir):
         print(f"[Pipeline] ERROR: proj_dir does not exist or is not a directory: {proj_dir}")
@@ -227,10 +228,15 @@ def run_pipeline(
 
     # Stage 1: generate phase.json (input: target code → phases.json)
     # Stage 2: generate domain context (input: phases.json → domain context files)
+    phase_stage = plugin_config.get_stage("generate_phase_plan") if plugin_config else None
+    context_stage = plugin_config.get_stage("generate_domain_context") if plugin_config else None
+    plugin_root = plugin_config.root if plugin_config else None
+
     print("[Pipeline] Stage 1/6: Generating phase plan...")
     _run_generate_phases(
         proj_dir, work_dir, script_dir, resume=resume,
         submodules=submodules,
+        plugin_stage=phase_stage, plugin_root=plugin_root,
     )
 
     phases_modified = _post_process_phases(
@@ -241,7 +247,8 @@ def run_pipeline(
     )
 
     print("[Pipeline] Stage 2/6: Generating domain context...")
-    _run_generate_domain_context(proj_dir, work_dir, script_dir, resume=resume and not phases_modified)
+    _run_generate_domain_context(proj_dir, work_dir, script_dir, resume=resume and not phases_modified,
+                                 plugin_stage=context_stage, plugin_root=plugin_root)
 
     # Build (or rebuild) the codegraph index if codegraph is installed. Both
     # run_extraction (Stage 3) and generate_topdown_layers (Stage 5) read from it.
@@ -497,10 +504,11 @@ if __name__ == "__main__":
         usage="python3 main.py <proj_dir> [--resume] [--incremental INTENT_FILE] "
               "[--domain-knowledge FILE ...] [--one-phase] [--isolate] "
               "[--submodule PATH [PATH ...]] [--entry-func PATH] "
-              "[--end-func PATH ...] [--extra-edge FILE] [--only-spec]",
+              "[--end-func PATH ...] [--extra-edge FILE] [--only-spec] "
+              "[--list-plugin] [--plugin NAME]",
         description="Run the FM agent pipeline on a project directory.",
     )
-    parser.add_argument("proj_dir", help="path to the project directory")
+    parser.add_argument("proj_dir", nargs="?", help="path to the project directory")
     parser.add_argument(
         "--resume",
         action="store_true",
@@ -572,10 +580,53 @@ if __name__ == "__main__":
         help="optional JSON file, or directory of JSON files, containing "
         "supplemental caller->callee edges.",
     )
+    parser.add_argument(
+        "--list-plugin",
+        action="store_true",
+        help="list all valid plugins found under the plugins/ directory and exit.",
+    )
+    parser.add_argument(
+        "--plugin",
+        metavar="NAME",
+        default=None,
+        help="load and activate the named plugin from the plugins/ directory.",
+    )
     args = parser.parse_args()
 
-    resume = args.resume or os.environ.get("FM_AGENT_RESUME") == "1"
+    if args.list_plugin:
+        from pathlib import Path
+        from src.plugin import load_plugins
+        plugins_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "plugins")
+        plugins = load_plugins(Path(plugins_dir))
+        if not plugins:
+            print("No valid plugins found.")
+        else:
+            print(f"{'Plugin':<30} {'Version':<12} Stages")
+            print("-" * 65)
+            for name, plugin in plugins.items():
+                stage_names = ", ".join(plugin.stages.keys()) if plugin.stages else "(none)"
+                print(f"{name:<30} {plugin.version:<12} {stage_names}")
+        sys.exit(0)
+
+    plugin_config = None
+    if args.plugin:
+        if not args.proj_dir:
+            parser.error("the following arguments are required when --plugin is used: proj_dir")
+        from pathlib import Path
+        from src.plugin import load_plugins
+        plugins_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "plugins")
+        plugins = load_plugins(Path(plugins_dir))
+        if args.plugin not in plugins:
+            print(f"[Pipeline] ERROR: Plugin '{args.plugin}' not found or invalid.")
+            sys.exit(1)
+        plugin_config = plugins[args.plugin]
+        print(f"[Pipeline] Loaded plugin '{plugin_config.name}' v{plugin_config.version}")
+
+    if not args.proj_dir:
+        parser.error("the following arguments are required: proj_dir")
     proj_dir = os.path.abspath(args.proj_dir)
+
+    resume = args.resume or os.environ.get("FM_AGENT_RESUME") == "1"
     extra_call_edges_path = args.extra_edge
     if extra_call_edges_path:
         extra_call_edges_path = os.path.abspath(extra_call_edges_path)
@@ -623,6 +674,7 @@ if __name__ == "__main__":
             one_phase=args.one_phase,
             extra_call_edges_path=extra_call_edges_path,
             only_spec=args.only_spec,
+            plugin_config=plugin_config,
         )
         end_time = time.time()
         logging.info(f"Total time: {end_time - start_time:.2f} seconds")
@@ -681,6 +733,7 @@ if __name__ == "__main__":
                     submodules=submodules,
                     one_phase=args.one_phase,
                     extra_call_edges_path=extra_call_edges_path,
+                    plugin_config=plugin_config,
                 )
             else:
                 run_pipeline(
@@ -691,6 +744,7 @@ if __name__ == "__main__":
                     one_phase=args.one_phase,
                     extra_call_edges_path=extra_call_edges_path,
                     only_spec=args.only_spec,
+                    plugin_config=plugin_config,
                 )
             # Record the commit that was processed. Written after the pipeline since
             # it recreates fm_agent/; with --isolate it lives in the snapshot and is

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from src.file_utils import (
     _json_file_is_valid,
     _get_incomplete_verification_files,
     _is_under_submodules,
+    load_phases,
 )
 from src.verification import streaming_reasoner
 from src.extract import run_extraction, EXT_TO_LANG
@@ -280,9 +281,7 @@ def run_pipeline(
         os.path.join(spec_prompts_dir, "file_utils.py"),
     )
 
-    phases_path = os.path.join(work_dir, "phases.json")
-    with open(phases_path, "r") as f:
-        phases_data = json.load(f)
+    phases_data = load_phases(work_dir)
 
     print("[Pipeline] Stage 4/6: Collecting file list...")
     file_list_path = os.path.join(work_dir, "fm_agent_file_list.json")

--- a/src/entry_reasoning_pipeline.py
+++ b/src/entry_reasoning_pipeline.py
@@ -223,6 +223,7 @@ def run_entry_pipeline(
     one_phase=False,
     extra_call_edges_path=None,
     only_spec=False,
+    plugin_config=None,
 ):
     """Run the entry-point-scoped reasoning pipeline.
 
@@ -283,6 +284,7 @@ def run_entry_pipeline(
             one_phase=one_phase,
             extra_call_edges_path=extra_call_edges_path,
             only_spec=only_spec,
+            plugin_config=plugin_config,
         )
     finally:
         clear_test_file_exemptions()
@@ -431,6 +433,7 @@ def _run_entry_pipeline_inner(
     one_phase=False,
     extra_call_edges_path=None,
     only_spec=False,
+    plugin_config=None,
 ):
     """Body of run_entry_pipeline; runs with the entry source file exempted."""
     # 1. Selection: extract fresh into a temp workspace and build the call graph.
@@ -478,6 +481,7 @@ def _run_entry_pipeline_inner(
             one_phase=one_phase,
             extra_call_edges_path=extra_call_edges_path,
             only_spec=only_spec,
+            plugin_config=plugin_config,
         )
     finally:
         # 4. Copy the generated fm_agent/ back into proj_dir, then discard the

--- a/src/extract.py
+++ b/src/extract.py
@@ -5,7 +5,7 @@ import sys
 import shutil
 import logging
 
-from src.file_utils import is_file_ready, _is_test_file
+from src.file_utils import is_file_ready, _is_test_file, load_phases
 from src.languages.codegraph import canonicalize
 from src.languages.registry import batch_extract_all, function_spans_for_file
 
@@ -687,12 +687,7 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     """
     if work_dir is None:
         work_dir = proj_dir
-    phases_path = os.path.join(work_dir, "phases.json")
-    if not os.path.exists(phases_path):
-        raise FileNotFoundError(f"phases.json not found at {phases_path}")
-
-    with open(phases_path, 'r') as f:
-        phases_data = json.load(f)
+    phases_data = load_phases(work_dir)
 
     registry_funcs, registry_langs = batch_extract_all(proj_dir)
     registry_funcs = {

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -118,6 +118,23 @@ def _json_file_is_valid(path):
         return False
 
 
+def load_phases(work_dir):
+    """Load and validate phases.json from work_dir.
+
+    Returns the parsed phases data dict.
+    Raises RuntimeError with a clear message when phases.json is missing or
+    invalid JSON, so every downstream stage gets a consistent failure.
+    """
+    phases_path = os.path.join(work_dir, "phases.json")
+    if not _json_file_is_valid(phases_path):
+        raise RuntimeError(
+            "fm_agent/phases.json is missing or invalid. "
+            "Please re-run the generate_phase_plan stage to produce a valid phases.json."
+        )
+    with open(phases_path, "r") as f:
+        return json.load(f)
+
+
 def _get_phase_files(phases_data, phase_num, input_dir):
     """Return relative paths of extracted function files for a given phase."""
     phase = next(p for p in phases_data["phases"] if p["phase"] == phase_num)

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 from src.extract import EXT_TO_LANG, LANG_CONFIG
 from src.languages.registry import call_edges_all
+from src.file_utils import load_phases
 
 
 # ---------------------------------------------------------------------------
@@ -15,10 +16,11 @@ from src.languages.registry import call_edges_all
 # ---------------------------------------------------------------------------
 
 def _load_phases(proj_dir):
-    """Load phases.json from the project root."""
-    phases_path = os.path.join(proj_dir, "phases.json")
-    with open(phases_path, "r") as f:
-        return json.load(f)
+    """Load phases.json from the project root.
+
+    Thin wrapper around file_utils.load_phases for backward compatibility.
+    """
+    return load_phases(proj_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -38,6 +38,7 @@ from .file_utils import (
     _is_under_submodules,
     _get_all_phase_files,
     _write_file_names,
+    load_phases,
 )
 from .generate_batch_prompts import (
     _detect_comment_prefix,
@@ -734,8 +735,7 @@ def run_incremental_pipeline(
     file_list_path = os.path.join(work_dir, "fm_agent_file_list.json")
     file_list = collect_file_names(input_dir, file_list_path)
     if submodules:
-        with open(os.path.join(work_dir, "phases.json"), "r") as f:
-            phases_data = json.load(f)
+        phases_data = load_phases(work_dir)
         file_list = _write_file_names(
             _get_all_phase_files(phases_data, input_dir), file_list_path
         )
@@ -743,8 +743,7 @@ def run_incremental_pipeline(
 
     # 7. Update top-down layers
     logging.info("[Stage 7/10] Generating topdown layers...")
-    with open(os.path.join(work_dir, "phases.json"), "r") as f:
-        phases_data = json.load(f)
+    phases_data = load_phases(work_dir)
     generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
     logging.info("  -> topdown layers generated for %d phase(s).", len(phases_data.get("phases", [])))
 

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -578,6 +578,7 @@ def run_incremental_pipeline(
     submodules=None,
     one_phase=False,
     extra_call_edges_path=None,
+    plugin_config=None,
 ):
     """
     Run the pipeline in incremental mode, intent_file_path is a file (absolute path) defining the goal of modification.
@@ -630,6 +631,7 @@ def run_incremental_pipeline(
             submodules=submodules,
             one_phase=one_phase,
             extra_call_edges_path=extra_call_edges_path,
+            plugin_config=plugin_config,
         )
         return
     logging.info("  -> previous full run found; proceeding with incremental analysis.")
@@ -685,6 +687,7 @@ def run_incremental_pipeline(
         proj_dir, work_dir, script_dir,
         is_incremental=True, submodules=submodules,
         one_phase=one_phase,
+        plugin_config=plugin_config,
     )
     logging.info("  -> phases.json regenerated.")
 

--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -843,143 +843,151 @@ def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
                          resume=False, submodules=None, plugin_stage=None,
                          plugin_root=None):
     """Stage 1: generate phase.json — input target code, output phases.json."""
+    phases_json = os.path.join(work_dir, "phases.json")
+    run_llm = True
+
     if plugin_stage is not None:
         if plugin_stage.type == "pass":
             print("[Pipeline] Stage 1/6: Plugin stage 'generate_phase_plan' type=pass, skipping.")
-            return
-        if plugin_stage.type == "replace":
+            run_llm = False
+        elif plugin_stage.type == "replace":
             print("[Pipeline] Stage 1/6: Plugin stage 'generate_phase_plan' type=replace, running plugin command.")
             from .plugin import run_plugin_command
             run_plugin_command(plugin_stage.replace_cmd, plugin_root, proj_dir, label="generate_phase_plan")
-            return
+            run_llm = False
 
-    phases_json = os.path.join(work_dir, "phases.json")
-    prev_mtime = os.path.getmtime(phases_json) if os.path.exists(phases_json) else None
+    if run_llm:
+        prev_mtime = os.path.getmtime(phases_json) if os.path.exists(phases_json) else None
 
-    _resume_skip = resume and _phase_plan_complete(work_dir)
-    if _resume_skip:
-        print("[Pipeline] Stage 1/6: RESUME — phases.json found, skipping phase plan generation.")
-
-    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
-        workflow_src = str(plugin_root / plugin_stage.input_md)
-        workflow_dst = os.path.join(work_dir, "workflow_generate_phases.md")
-        shutil.copy2(workflow_src, workflow_dst)
-        user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
-        if user_knowledge_paths:
-            with open(workflow_dst, "a") as _f:
-                _f.write(
-                    "\n---\n\n"
-                    "## User-Provided Domain Knowledge\n\n"
-                    "The user supplied extra Markdown files with domain knowledge for this run. "
-                    "Read these files before writing `phases.json` and the generated domain "
-                    "context files. Use them only as contextual knowledge about intended "
-                    "behavior, terminology, business rules, data encodings, and invariants; "
-                    "do NOT include these Markdown files as project source files in "
-                    "`phases.json`, and do NOT edit or summarize them in place.\n\n"
-                    f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
-                )
-    else:
-        _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_phases.md")
-
-    fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
-                    "It is a workspace for storing your output files only. "
-                    "Do NOT include fm_agent/ paths in phases.json. "
-                    "Do NOT modify any existing project files.")
-    incremental_reminder = ("IMPORTANT: An existing fm_agent/phases.json from a previous run is already "
-                            "present. Do NOT regenerate it from scratch. Instead, inspect the current "
-                            "state of the source code and UPDATE the existing fm_agent/phases.json so it "
-                            "reflects the current version of the code: add modules and source files that "
-                            "are new, remove entries whose files no longer exist, and adjust phases as "
-                            "needed. Preserve entries that are still accurate.")
-    submodule_reminder = ""
-    if submodules:
-        allowed = ", ".join(f"`{submodule}/`" for submodule in submodules)
-        submodule_reminder = (
-            "IMPORTANT: Only process source files under these project-relative "
-            f"subdirectories: {allowed}. Do NOT include files outside these "
-            "subdirectories in phases.json."
-        )
-
-    for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
+        _resume_skip = resume and _phase_plan_complete(work_dir)
         if _resume_skip:
-            break
-        if attempt == 1 and not resume:
-            prompt = f"Follow the instructions in the attached file. {fm_reminder} {submodule_reminder}"
-        else:
-            prompt = ("A previous attempt was interrupted and may have already produced some of the "
-                      "required output files. Follow the instructions in the attached file, but FIRST "
-                      "check the current progress in fm_agent/ (e.g. phases.json). Keep any existing valid "
-                      "output as-is and only generate the files that are missing or incomplete — do NOT "
-                      f"regenerate or overwrite work that is already done. {fm_reminder} {submodule_reminder}")
-        if is_incremental:
-            prompt = f"{prompt} {incremental_reminder}"
-        prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_phases.md")
-        command = build_llm_cli_command(
-            model=OPENCODE_SETUP_MODEL,
-            prompt=prompt,
-            cwd=proj_dir,
-            files=[prompt_file],
-        )
-        try:
-            run_opencode_traced(
-                proj_dir=proj_dir,
-                work_dir=work_dir,
-                command=command,
-                stage="generate_phases_json",
-                input_files=[
-                    "fm_agent/workflow_generate_phases.md",
-                    *list_staged_domain_knowledge_relpaths(work_dir),
-                ],
-                output_files=[
-                    "fm_agent/phases.json",
-                ],
-                summary=f"OpenCode generate phases.json attempt {attempt}",
-                metadata={"attempt": attempt},
-            )
-        except subprocess.CalledProcessError as e:
-            logging.warning(f"Stage 1 attempt {attempt}: opencode exited with code {e.returncode}")
+            print("[Pipeline] Stage 1/6: RESUME — phases.json found, skipping phase plan generation.")
 
-        if os.path.exists(phases_json):
-            if submodules:
-                phase_plan_ready = _phases_cover_current_sources(
-                    phases_json, proj_dir, submodules
-                )
-            elif is_incremental:
-                phase_plan_ready = (
-                    os.path.getmtime(phases_json) != prev_mtime
-                    or _phases_cover_current_sources(phases_json, proj_dir)
-                )
-            else:
-                phase_plan_ready = _json_file_is_valid(phases_json)
-            if phase_plan_ready:
+        if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
+            workflow_src = str(plugin_root / plugin_stage.input_md)
+            workflow_dst = os.path.join(work_dir, "workflow_generate_phases.md")
+            shutil.copy2(workflow_src, workflow_dst)
+            user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
+            if user_knowledge_paths:
+                with open(workflow_dst, "a") as _f:
+                    _f.write(
+                        "\n---\n\n"
+                        "## User-Provided Domain Knowledge\n\n"
+                        "The user supplied extra Markdown files with domain knowledge for this run. "
+                        "Read these files before writing `phases.json` and the generated domain "
+                        "context files. Use them only as contextual knowledge about intended "
+                        "behavior, terminology, business rules, data encodings, and invariants; "
+                        "do NOT include these Markdown files as project source files in "
+                        "`phases.json`, and do NOT edit or summarize them in place.\n\n"
+                        f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
+                    )
+        else:
+            _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_phases.md")
+
+        fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
+                        "It is a workspace for storing your output files only. "
+                        "Do NOT include fm_agent/ paths in phases.json. "
+                        "Do NOT modify any existing project files.")
+        incremental_reminder = ("IMPORTANT: An existing fm_agent/phases.json from a previous run is already "
+                                "present. Do NOT regenerate it from scratch. Instead, inspect the current "
+                                "state of the source code and UPDATE the existing fm_agent/phases.json so it "
+                                "reflects the current version of the code: add modules and source files that "
+                                "are new, remove entries whose files no longer exist, and adjust phases as "
+                                "needed. Preserve entries that are still accurate.")
+        submodule_reminder = ""
+        if submodules:
+            allowed = ", ".join(f"`{submodule}/`" for submodule in submodules)
+            submodule_reminder = (
+                "IMPORTANT: Only process source files under these project-relative "
+                f"subdirectories: {allowed}. Do NOT include files outside these "
+                "subdirectories in phases.json."
+            )
+
+        for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
+            if _resume_skip:
                 break
+            if attempt == 1 and not resume:
+                prompt = f"Follow the instructions in the attached file. {fm_reminder} {submodule_reminder}"
+            else:
+                prompt = ("A previous attempt was interrupted and may have already produced some of the "
+                          "required output files. Follow the instructions in the attached file, but FIRST "
+                          "check the current progress in fm_agent/ (e.g. phases.json). Keep any existing valid "
+                          "output as-is and only generate the files that are missing or incomplete — do NOT "
+                          f"regenerate or overwrite work that is already done. {fm_reminder} {submodule_reminder}")
+            if is_incremental:
+                prompt = f"{prompt} {incremental_reminder}"
+            prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_phases.md")
+            command = build_llm_cli_command(
+                model=OPENCODE_SETUP_MODEL,
+                prompt=prompt,
+                cwd=proj_dir,
+                files=[prompt_file],
+            )
+            try:
+                run_opencode_traced(
+                    proj_dir=proj_dir,
+                    work_dir=work_dir,
+                    command=command,
+                    stage="generate_phases_json",
+                    input_files=[
+                        "fm_agent/workflow_generate_phases.md",
+                        *list_staged_domain_knowledge_relpaths(work_dir),
+                    ],
+                    output_files=[
+                        "fm_agent/phases.json",
+                    ],
+                    summary=f"OpenCode generate phases.json attempt {attempt}",
+                    metadata={"attempt": attempt},
+                )
+            except subprocess.CalledProcessError as e:
+                logging.warning(f"Stage 1 attempt {attempt}: opencode exited with code {e.returncode}")
 
-        failure = "update phases.json" if is_incremental else "produce phases.json"
-        missing = (
-            "phases.json was not updated"
-            if is_incremental
-            else "phases.json missing or invalid"
+            if os.path.exists(phases_json):
+                if submodules:
+                    phase_plan_ready = _phases_cover_current_sources(
+                        phases_json, proj_dir, submodules
+                    )
+                elif is_incremental:
+                    phase_plan_ready = (
+                        os.path.getmtime(phases_json) != prev_mtime
+                        or _phases_cover_current_sources(phases_json, proj_dir)
+                    )
+                else:
+                    phase_plan_ready = _json_file_is_valid(phases_json)
+                if phase_plan_ready:
+                    break
+
+            failure = "update phases.json" if is_incremental else "produce phases.json"
+            missing = (
+                "phases.json was not updated"
+                if is_incremental
+                else "phases.json missing or invalid"
+            )
+            if attempt < OPENCODE_MAX_RETRIES:
+                delay = 10
+                print(
+                    f"[Pipeline] Stage 1 failed to {failure} (attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
+                    f"Retrying in {delay}s..."
+                )
+                logging.warning(f"Stage 1 attempt {attempt} failed: {missing}. Retrying in {delay}s.")
+                time.sleep(delay)
+            else:
+                raise RuntimeError(
+                    f"Stage generate_phase_plan failed after {OPENCODE_MAX_RETRIES} attempts. "
+                    f"{missing}. "
+                    f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
+                )
+
+        if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
+            print("[Pipeline] Stage 1/6: Running plugin post-process for generate_phase_plan...")
+            from .plugin import run_plugin_command
+            run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_phase_plan post-process")
+
+    if not _phase_plan_complete(work_dir):
+        raise RuntimeError(
+            "Stage generate_phase_plan failed: fm_agent/phases.json is missing or "
+            "invalid. Please re-run this stage to produce a valid phases.json."
         )
-        if attempt < OPENCODE_MAX_RETRIES:
-            delay = 10
-            print(
-                f"[Pipeline] Stage 1 failed to {failure} (attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
-                f"Retrying in {delay}s..."
-            )
-            logging.warning(f"Stage 1 attempt {attempt} failed: {missing}. Retrying in {delay}s.")
-            time.sleep(delay)
-        else:
-            print(
-                f"[Pipeline] ERROR: Stage 1 failed after {OPENCODE_MAX_RETRIES} attempts. "
-                f"{missing}. "
-                f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
-            )
-            sys.exit(1)
-
-    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
-        print("[Pipeline] Stage 1/6: Running plugin post-process for generate_phase_plan...")
-        from .plugin import run_plugin_command
-        run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_phase_plan post-process")
 
 
 def _post_process_phases(proj_dir, work_dir, required_source_files=None,
@@ -1036,110 +1044,119 @@ def _run_generate_domain_context(proj_dir, work_dir, script_dir, resume=False,
     """Stage 2: generate domain context — input phases.json, output domain context
     files for each phase.
     """
+    run_llm = True
+
     if plugin_stage is not None:
         if plugin_stage.type == "pass":
             print("[Pipeline] Stage 2/6: Plugin stage 'generate_domain_context' type=pass, skipping.")
-            return
-        if plugin_stage.type == "replace":
+            run_llm = False
+        elif plugin_stage.type == "replace":
             print("[Pipeline] Stage 2/6: Plugin stage 'generate_domain_context' type=replace, running plugin command.")
             from .plugin import run_plugin_command
             run_plugin_command(plugin_stage.replace_cmd, plugin_root, proj_dir, label="generate_domain_context")
-            return
+            run_llm = False
 
-    _resume_skip = resume and _domain_context_complete(work_dir)
-    if _resume_skip:
-        print("[Pipeline] Stage 2/6: RESUME — domain context files found, skipping domain context generation.")
-
-    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
-        workflow_src = str(plugin_root / plugin_stage.input_md)
-        workflow_dst = os.path.join(work_dir, "workflow_generate_domain_context.md")
-        shutil.copy2(workflow_src, workflow_dst)
-        user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
-        if user_knowledge_paths:
-            with open(workflow_dst, "a") as _f:
-                _f.write(
-                    "\n---\n\n"
-                    "## User-Provided Domain Knowledge\n\n"
-                    "The user supplied extra Markdown files with domain knowledge for this run. "
-                    "Read these files before writing the domain context files. "
-                    "Use them only as contextual knowledge about intended "
-                    "behavior, terminology, business rules, data encodings, and invariants.\n\n"
-                    f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
-                )
-    else:
-        _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_domain_context.md")
-
-    fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
-                    "It is a workspace for storing your output files only. "
-                    "Do NOT modify any existing project files.")
-
-    for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
+    if run_llm:
+        _resume_skip = resume and _domain_context_complete(work_dir)
         if _resume_skip:
-            break
-        if attempt == 1 and not resume:
-            prompt = (
-                "Read fm_agent/phases.json first. "
-                "Then follow the instructions in the attached file. "
-                + fm_reminder
-            )
+            print("[Pipeline] Stage 2/6: RESUME — domain context files found, skipping domain context generation.")
+
+        if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
+            workflow_src = str(plugin_root / plugin_stage.input_md)
+            workflow_dst = os.path.join(work_dir, "workflow_generate_domain_context.md")
+            shutil.copy2(workflow_src, workflow_dst)
+            user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
+            if user_knowledge_paths:
+                with open(workflow_dst, "a") as _f:
+                    _f.write(
+                        "\n---\n\n"
+                        "## User-Provided Domain Knowledge\n\n"
+                        "The user supplied extra Markdown files with domain knowledge for this run. "
+                        "Read these files before writing the domain context files. "
+                        "Use them only as contextual knowledge about intended "
+                        "behavior, terminology, business rules, data encodings, and invariants.\n\n"
+                        f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
+                    )
         else:
-            prompt = ("A previous domain-context generation attempt was interrupted and may have already "
-                      "produced some of the required output files. Read fm_agent/phases.json first. "
-                      "Then follow the instructions in the attached file, but FIRST "
-                      "check the current progress in fm_agent/spec_prompts/domain_context/. "
-                      "Keep any existing valid output as-is and only generate the files that are missing or "
-                      f"incomplete — do NOT regenerate or overwrite work that is already done. {fm_reminder}")
-        prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_domain_context.md")
-        command = build_llm_cli_command(
-            model=OPENCODE_SETUP_MODEL,
-            prompt=prompt,
-            cwd=proj_dir,
-            files=[prompt_file],
+            _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_domain_context.md")
+
+        fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
+                        "It is a workspace for storing your output files only. "
+                        "Do NOT modify any existing project files.")
+
+        for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
+            if _resume_skip:
+                break
+            if attempt == 1 and not resume:
+                prompt = (
+                    "Read fm_agent/phases.json first. "
+                    "Then follow the instructions in the attached file. "
+                    + fm_reminder
+                )
+            else:
+                prompt = ("A previous domain-context generation attempt was interrupted and may have already "
+                          "produced some of the required output files. Read fm_agent/phases.json first. "
+                          "Then follow the instructions in the attached file, but FIRST "
+                          "check the current progress in fm_agent/spec_prompts/domain_context/. "
+                          "Keep any existing valid output as-is and only generate the files that are missing or "
+                          f"incomplete — do NOT regenerate or overwrite work that is already done. {fm_reminder}")
+            prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_domain_context.md")
+            command = build_llm_cli_command(
+                model=OPENCODE_SETUP_MODEL,
+                prompt=prompt,
+                cwd=proj_dir,
+                files=[prompt_file],
+            )
+            try:
+                run_opencode_traced(
+                    proj_dir=proj_dir,
+                    work_dir=work_dir,
+                    command=command,
+                    stage="generate_domain_context",
+                    input_files=[
+                        "fm_agent/workflow_generate_domain_context.md",
+                        "fm_agent/phases.json",
+                        *list_staged_domain_knowledge_relpaths(work_dir),
+                    ],
+                    output_files=[
+                        "fm_agent/spec_prompts/domain_context/engine_overview.txt",
+                    ],
+                    summary=f"OpenCode generate domain context attempt {attempt}",
+                    metadata={"attempt": attempt},
+                )
+            except subprocess.CalledProcessError as e:
+                logging.warning(f"Stage 2 attempt {attempt}: opencode exited with code {e.returncode}")
+
+            if _domain_context_complete(work_dir):
+                break
+
+            if attempt < OPENCODE_MAX_RETRIES:
+                delay = 10
+                print(
+                    f"[Pipeline] Stage 2 failed to produce domain context "
+                    f"(attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
+                    f"Retrying in {delay}s..."
+                )
+                logging.warning(f"Stage 2 attempt {attempt} failed: domain context outputs missing. Retrying in {delay}s.")
+                time.sleep(delay)
+            else:
+                raise RuntimeError(
+                    f"Stage generate_domain_context failed after {OPENCODE_MAX_RETRIES} attempts. "
+                    f"Domain context outputs missing. "
+                    f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
+                )
+
+        if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
+            print("[Pipeline] Stage 2/6: Running plugin post-process for generate_domain_context...")
+            from .plugin import run_plugin_command
+            run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_domain_context post-process")
+
+    if not _domain_context_complete(work_dir):
+        raise RuntimeError(
+            "Stage generate_domain_context failed: domain context output files "
+            "are missing or incomplete. Please re-run this stage to produce valid "
+            "domain context files."
         )
-        try:
-            run_opencode_traced(
-                proj_dir=proj_dir,
-                work_dir=work_dir,
-                command=command,
-                stage="generate_domain_context",
-                input_files=[
-                    "fm_agent/workflow_generate_domain_context.md",
-                    "fm_agent/phases.json",
-                    *list_staged_domain_knowledge_relpaths(work_dir),
-                ],
-                output_files=[
-                    "fm_agent/spec_prompts/domain_context/engine_overview.txt",
-                ],
-                summary=f"OpenCode generate domain context attempt {attempt}",
-                metadata={"attempt": attempt},
-            )
-        except subprocess.CalledProcessError as e:
-            logging.warning(f"Stage 2 attempt {attempt}: opencode exited with code {e.returncode}")
-
-        if _domain_context_complete(work_dir):
-            break
-
-        if attempt < OPENCODE_MAX_RETRIES:
-            delay = 10
-            print(
-                f"[Pipeline] Stage 2 failed to produce domain context "
-                f"(attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
-                f"Retrying in {delay}s..."
-            )
-            logging.warning(f"Stage 2 attempt {attempt} failed: domain context outputs missing. Retrying in {delay}s.")
-            time.sleep(delay)
-        else:
-            print(
-                f"[Pipeline] ERROR: Stage 2 failed after {OPENCODE_MAX_RETRIES} attempts. "
-                f"Domain context outputs missing. "
-                f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
-            )
-            sys.exit(1)
-
-    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
-        print("[Pipeline] Stage 2/6: Running plugin post-process for generate_domain_context...")
-        from .plugin import run_plugin_command
-        run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_domain_context post-process")
 
 
 def _run_setup_extract(proj_dir, work_dir, script_dir, is_incremental=False,

--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -840,8 +840,19 @@ def _prepare_workflow_file(proj_dir, work_dir, script_dir, workflow_filename):
 
 
 def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
-                         resume=False, submodules=None):
+                         resume=False, submodules=None, plugin_stage=None,
+                         plugin_root=None):
     """Stage 1: generate phase.json — input target code, output phases.json."""
+    if plugin_stage is not None:
+        if plugin_stage.type == "pass":
+            print("[Pipeline] Stage 1/6: Plugin stage 'generate_phase_plan' type=pass, skipping.")
+            return
+        if plugin_stage.type == "replace":
+            print("[Pipeline] Stage 1/6: Plugin stage 'generate_phase_plan' type=replace, running plugin command.")
+            from .plugin import run_plugin_command
+            run_plugin_command(plugin_stage.replace_cmd, plugin_root, proj_dir, label="generate_phase_plan")
+            return
+
     phases_json = os.path.join(work_dir, "phases.json")
     prev_mtime = os.path.getmtime(phases_json) if os.path.exists(phases_json) else None
 
@@ -849,7 +860,26 @@ def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
     if _resume_skip:
         print("[Pipeline] Stage 1/6: RESUME — phases.json found, skipping phase plan generation.")
 
-    _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_phases.md")
+    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
+        workflow_src = str(plugin_root / plugin_stage.input_md)
+        workflow_dst = os.path.join(work_dir, "workflow_generate_phases.md")
+        shutil.copy2(workflow_src, workflow_dst)
+        user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
+        if user_knowledge_paths:
+            with open(workflow_dst, "a") as _f:
+                _f.write(
+                    "\n---\n\n"
+                    "## User-Provided Domain Knowledge\n\n"
+                    "The user supplied extra Markdown files with domain knowledge for this run. "
+                    "Read these files before writing `phases.json` and the generated domain "
+                    "context files. Use them only as contextual knowledge about intended "
+                    "behavior, terminology, business rules, data encodings, and invariants; "
+                    "do NOT include these Markdown files as project source files in "
+                    "`phases.json`, and do NOT edit or summarize them in place.\n\n"
+                    f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
+                )
+    else:
+        _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_phases.md")
 
     fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
                     "It is a workspace for storing your output files only. "
@@ -946,6 +976,11 @@ def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
             )
             sys.exit(1)
 
+    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
+        print("[Pipeline] Stage 1/6: Running plugin post-process for generate_phase_plan...")
+        from .plugin import run_plugin_command
+        run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_phase_plan post-process")
+
 
 def _post_process_phases(proj_dir, work_dir, required_source_files=None,
                           submodules=None, one_phase=False):
@@ -996,15 +1031,43 @@ def _post_process_phases(proj_dir, work_dir, required_source_files=None,
     return phases_modified
 
 
-def _run_generate_domain_context(proj_dir, work_dir, script_dir, resume=False):
+def _run_generate_domain_context(proj_dir, work_dir, script_dir, resume=False,
+                                 plugin_stage=None, plugin_root=None):
     """Stage 2: generate domain context — input phases.json, output domain context
     files for each phase.
     """
+    if plugin_stage is not None:
+        if plugin_stage.type == "pass":
+            print("[Pipeline] Stage 2/6: Plugin stage 'generate_domain_context' type=pass, skipping.")
+            return
+        if plugin_stage.type == "replace":
+            print("[Pipeline] Stage 2/6: Plugin stage 'generate_domain_context' type=replace, running plugin command.")
+            from .plugin import run_plugin_command
+            run_plugin_command(plugin_stage.replace_cmd, plugin_root, proj_dir, label="generate_domain_context")
+            return
+
     _resume_skip = resume and _domain_context_complete(work_dir)
     if _resume_skip:
         print("[Pipeline] Stage 2/6: RESUME — domain context files found, skipping domain context generation.")
 
-    _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_domain_context.md")
+    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
+        workflow_src = str(plugin_root / plugin_stage.input_md)
+        workflow_dst = os.path.join(work_dir, "workflow_generate_domain_context.md")
+        shutil.copy2(workflow_src, workflow_dst)
+        user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
+        if user_knowledge_paths:
+            with open(workflow_dst, "a") as _f:
+                _f.write(
+                    "\n---\n\n"
+                    "## User-Provided Domain Knowledge\n\n"
+                    "The user supplied extra Markdown files with domain knowledge for this run. "
+                    "Read these files before writing the domain context files. "
+                    "Use them only as contextual knowledge about intended "
+                    "behavior, terminology, business rules, data encodings, and invariants.\n\n"
+                    f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
+                )
+    else:
+        _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_domain_context.md")
 
     fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
                     "It is a workspace for storing your output files only. "
@@ -1073,17 +1136,29 @@ def _run_generate_domain_context(proj_dir, work_dir, script_dir, resume=False):
             )
             sys.exit(1)
 
+    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
+        print("[Pipeline] Stage 2/6: Running plugin post-process for generate_domain_context...")
+        from .plugin import run_plugin_command
+        run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_domain_context post-process")
+
 
 def _run_setup_extract(proj_dir, work_dir, script_dir, is_incremental=False,
                        resume=False, required_source_files=None,
-                       submodules=None, one_phase=False):
+                       submodules=None, one_phase=False,
+                       plugin_config=None):
     """Run generate-phases, post-process, and generate-domain-context stages.
 
     Backward-compatible wrapper that calls the three sub-stages in sequence.
     """
-    _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental, resume, submodules)
+    phase_stage = plugin_config.get_stage("generate_phase_plan") if plugin_config else None
+    context_stage = plugin_config.get_stage("generate_domain_context") if plugin_config else None
+    plugin_root = plugin_config.root if plugin_config else None
+
+    _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental, resume, submodules,
+                         plugin_stage=phase_stage, plugin_root=plugin_root)
     phases_modified = _post_process_phases(proj_dir, work_dir, required_source_files, submodules, one_phase=one_phase)
-    _run_generate_domain_context(proj_dir, work_dir, script_dir, resume and not phases_modified)
+    _run_generate_domain_context(proj_dir, work_dir, script_dir, resume and not phases_modified,
+                                 plugin_stage=context_stage, plugin_root=plugin_root)
 
     if not _setup_outputs_complete(work_dir):
         print(

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -1,0 +1,216 @@
+"""FM-Agent plugin loading, validation, and execution."""
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class PluginStageConfig:
+    """Configuration for a single pipeline stage modification."""
+
+    type: str = ""  # "pass", "replace", or "modify"
+    replace_cmd: Optional[str] = None
+    input_md: Optional[str] = None  # relative to plugin root
+    output_process: Optional[str] = None
+
+    @staticmethod
+    def from_dict(data: dict) -> "PluginStageConfig":
+        return PluginStageConfig(
+            type=data.get("type", ""),
+            replace_cmd=data.get("replace_cmd"),
+            input_md=data.get("input_md"),
+            output_process=data.get("output_process"),
+        )
+
+    def validated(self) -> List[str]:
+        """Return a list of validation error strings (empty = valid)."""
+        errors = []
+        if self.type not in ("pass", "replace", "modify"):
+            errors.append(
+                "stage type must be 'pass', 'replace', or 'modify', "
+                f"got '{self.type}'"
+            )
+        if self.type == "replace" and not self.replace_cmd:
+            errors.append("type=replace requires 'replace_cmd'")
+        if (
+            self.type == "modify"
+            and not self.input_md
+            and not self.output_process
+        ):
+            errors.append(
+                "type=modify requires at least one of 'input_md' or 'output_process'"
+            )
+        return errors
+
+
+@dataclass
+class PluginConfig:
+    """Parsed plugin.json with resolved plugin root path."""
+
+    name: str
+    version: str
+    root: Path
+    stages: Dict[str, PluginStageConfig] = field(default_factory=dict)
+
+    def get_stage(self, stage_name: str) -> Optional[PluginStageConfig]:
+        """Return the stage config for *stage_name*, or None if not configured."""
+        return self.stages.get(stage_name)
+
+
+def _resolve_command(cmd: str, plugin_root: Path) -> str:
+    """Rewrite relative file paths in *cmd* to absolute paths under *plugin_root*.
+
+    Each whitespace-delimited token in *cmd* is checked: if ``plugin_root / token``
+    points to an existing file, the token is replaced with its absolute path.
+    Tokens starting with ``/``, ``$``, or ``-`` are left unchanged.
+    """
+    tokens = cmd.split()
+    resolved = []
+    for token in tokens:
+        if token.startswith("/") or token.startswith("$"):
+            resolved.append(token)
+            continue
+        candidate = plugin_root / token
+        if candidate.is_file():
+            resolved.append(str(candidate))
+        else:
+            resolved.append(token)
+    return " ".join(resolved)
+
+
+def run_plugin_command(
+    cmd: str, plugin_root: Path, proj_dir: str, label: str = ""
+) -> None:
+    """Execute a plugin bash command with ``check=True`` so failure stops the pipeline.
+
+    Relative file paths in *cmd* are resolved under *plugin_root*. The command runs
+    in *proj_dir* with ``FM_AGENT_PLUGIN_ROOT`` set to the plugin root.
+    """
+    resolved = _resolve_command(cmd, plugin_root)
+    env = dict(os.environ, FM_AGENT_PLUGIN_ROOT=str(plugin_root))
+    try:
+        subprocess.run(resolved, shell=True, check=True, cwd=proj_dir, env=env)
+    except subprocess.CalledProcessError as e:
+        label_prefix = f"Plugin {label}: " if label else ""
+        print(
+            f"[Pipeline] ERROR: {label_prefix}command exited with code {e.returncode}: "
+            f"{resolved}"
+        )
+        raise
+
+
+def _validate_plugin_json_content(
+    plugin_dir: Path, name: str, data: dict
+) -> Optional[PluginConfig]:
+    """Validate the content of a parsed plugin.json; returns PluginConfig or None."""
+    plugin_name = data.get("name", "")
+    if plugin_name != name:
+        print(
+            f"Invalid plugin '{name}': plugin name mismatch "
+            f"(expected '{name}', got '{plugin_name}')"
+        )
+        return None
+
+    if not data.get("version"):
+        print(f"Invalid plugin '{name}': 'version' field is missing or empty")
+        return None
+
+    stages = {}
+    stages_data = data.get("stages", {})
+    if not isinstance(stages_data, dict):
+        print(f"Invalid plugin '{name}': 'stages' must be a JSON object")
+        return None
+
+    for stage_name, stage_data in stages_data.items():
+        if not isinstance(stage_data, dict):
+            print(
+                f"Invalid plugin '{name}': stage '{stage_name}' "
+                "must be a JSON object"
+            )
+            return None
+        stage = PluginStageConfig.from_dict(stage_data)
+        errors = stage.validated()
+        if errors:
+            for err in errors:
+                print(
+                    f"Invalid plugin '{name}': stage '{stage_name}' — {err}"
+                )
+            return None
+        if stage.type == "modify" and stage.input_md:
+            input_path = plugin_dir / stage.input_md
+            if not input_path.is_file():
+                print(
+                    f"Invalid plugin '{name}': stage '{stage_name}' — "
+                    f"input_md '{stage.input_md}' not found in plugin directory"
+                )
+                return None
+        stages[stage_name] = stage
+
+    return PluginConfig(
+        name=plugin_name,
+        version=data["version"],
+        root=plugin_dir,
+        stages=stages,
+    )
+
+
+def validate_plugin(plugin_dir: Path) -> Optional[PluginConfig]:
+    """Validate a single plugin directory.
+
+    Returns a ``PluginConfig`` if the plugin is valid, otherwise ``None``
+    (after printing validation errors to stdout).
+    """
+    name = plugin_dir.name
+    plugin_json = plugin_dir / "plugin.json"
+    plugin_config_json = plugin_dir / "plugin.config.json"
+
+    if not plugin_json.is_file():
+        if plugin_config_json.is_file():
+            print(
+                f"Invalid plugin '{name}': found plugin.config.json "
+                "but expected plugin.json"
+            )
+        else:
+            print(f"Invalid plugin '{name}': plugin.json not found")
+        return None
+
+    try:
+        with open(plugin_json, "r") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(
+            f"Invalid plugin '{name}': failed to parse plugin.json — {exc}"
+        )
+        return None
+
+    if not isinstance(data, dict):
+        print(
+            f"Invalid plugin '{name}': plugin.json must be a JSON object"
+        )
+        return None
+
+    return _validate_plugin_json_content(plugin_dir, name, data)
+
+
+def load_plugins(plugins_dir: Path) -> Dict[str, PluginConfig]:
+    """Scan *plugins_dir* for subdirectories, validate each, return valid plugins.
+
+    Invalid plugins are printed with their error reason and skipped.
+    """
+    if not plugins_dir.is_dir():
+        return {}
+
+    plugins = {}
+    for entry in sorted(plugins_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith(".") or entry.name == "__pycache__":
+            continue
+        config = validate_plugin(entry)
+        if config is not None:
+            plugins[config.name] = config
+    return plugins


### PR DESCRIPTION
closes #131
- Add src/plugin.py for plugin loading, validation, and execution
- Add plugins/ directory for external plugins
- Support --list-plugin and --plugin CLI arguments
- Support three stage behaviors: pass, replace, and modify
- Enable plugins in full, incremental, and entry-func pipelines