### PR TITLE
Revert artifact contract regression from PR #142

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,6 @@ from src.file_utils import (
     _json_file_is_valid,
     _get_incomplete_verification_files,
     _is_under_submodules,
-    load_phases,
 )
 from src.verification import streaming_reasoner
 from src.extract import run_extraction, EXT_TO_LANG
@@ -281,7 +280,9 @@ def run_pipeline(
         os.path.join(spec_prompts_dir, "file_utils.py"),
     )
 
-    phases_data = load_phases(work_dir)
+    phases_path = os.path.join(work_dir, "phases.json")
+    with open(phases_path, "r") as f:
+        phases_data = json.load(f)
 
     print("[Pipeline] Stage 4/6: Collecting file list...")
     file_list_path = os.path.join(work_dir, "fm_agent_file_list.json")

--- a/src/extract.py
+++ b/src/extract.py
@@ -5,7 +5,7 @@ import sys
 import shutil
 import logging
 
-from src.file_utils import is_file_ready, _is_test_file, load_phases
+from src.file_utils import is_file_ready, _is_test_file
 from src.languages.codegraph import canonicalize
 from src.languages.registry import batch_extract_all, function_spans_for_file
 
@@ -687,7 +687,12 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     """
     if work_dir is None:
         work_dir = proj_dir
-    phases_data = load_phases(work_dir)
+    phases_path = os.path.join(work_dir, "phases.json")
+    if not os.path.exists(phases_path):
+        raise FileNotFoundError(f"phases.json not found at {phases_path}")
+
+    with open(phases_path, 'r') as f:
+        phases_data = json.load(f)
 
     registry_funcs, registry_langs = batch_extract_all(proj_dir)
     registry_funcs = {

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -118,23 +118,6 @@ def _json_file_is_valid(path):
         return False
 
 
-def load_phases(work_dir):
-    """Load and validate phases.json from work_dir.
-
-    Returns the parsed phases data dict.
-    Raises RuntimeError with a clear message when phases.json is missing or
-    invalid JSON, so every downstream stage gets a consistent failure.
-    """
-    phases_path = os.path.join(work_dir, "phases.json")
-    if not _json_file_is_valid(phases_path):
-        raise RuntimeError(
-            "fm_agent/phases.json is missing or invalid. "
-            "Please re-run the generate_phase_plan stage to produce a valid phases.json."
-        )
-    with open(phases_path, "r") as f:
-        return json.load(f)
-
-
 def _get_phase_files(phases_data, phase_num, input_dir):
     """Return relative paths of extracted function files for a given phase."""
     phase = next(p for p in phases_data["phases"] if p["phase"] == phase_num)

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 
 from src.extract import EXT_TO_LANG, LANG_CONFIG
 from src.languages.registry import call_edges_all
-from src.file_utils import load_phases
 
 
 # ---------------------------------------------------------------------------
@@ -16,11 +15,10 @@ from src.file_utils import load_phases
 # ---------------------------------------------------------------------------
 
 def _load_phases(proj_dir):
-    """Load phases.json from the project root.
-
-    Thin wrapper around file_utils.load_phases for backward compatibility.
-    """
-    return load_phases(proj_dir)
+    """Load phases.json from the project root."""
+    phases_path = os.path.join(proj_dir, "phases.json")
+    with open(phases_path, "r") as f:
+        return json.load(f)
 
 
 # ---------------------------------------------------------------------------

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -41,7 +41,6 @@ from .file_utils import (
     _is_under_submodules,
     _get_all_phase_files,
     _write_file_names,
-    load_phases,
 )
 from .generate_batch_prompts import (
     _detect_comment_prefix,
@@ -829,7 +828,8 @@ def run_incremental_pipeline(
     file_list_path = os.path.join(work_dir, "fm_agent_file_list.json")
     file_list = collect_file_names(input_dir, file_list_path)
     if submodules:
-        phases_data = load_phases(work_dir)
+        with open(os.path.join(work_dir, "phases.json"), "r") as f:
+            phases_data = json.load(f)
         file_list = _write_file_names(
             _get_all_phase_files(phases_data, input_dir), file_list_path
         )
@@ -837,7 +837,8 @@ def run_incremental_pipeline(
 
     # 7. Update top-down layers
     logging.info("[Stage 7/10] Generating topdown layers...")
-    phases_data = load_phases(work_dir)
+    with open(os.path.join(work_dir, "phases.json"), "r") as f:
+        phases_data = json.load(f)
     generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
     logging.info("  -> topdown layers generated for %d phase(s).", len(phases_data.get("phases", [])))
 

--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -266,6 +266,7 @@ def _deduplicate_phases(phases_dir):
     for phase in sorted(data["phases"], key=lambda p: p["phase"]):
         for module in phase["modules"]:
             original = module["source_files"]
+
             deduped = []
             for sf in original:
                 if sf not in seen:
@@ -620,10 +621,70 @@ def _update_module_description(proj_dir, work_dir, modified_modules):
     )
 
 
+def _phase_plan_schema_errors(phases_path):
+    """Return human-readable schema errors for phases.json."""
+    try:
+        with open(phases_path, "r") as f:
+            data = json.load(f)
+    except OSError as exc:
+        return [f"phases.json could not be read: {exc}"]
+    except json.JSONDecodeError as exc:
+        return [f"phases.json is not valid JSON: {exc}"]
+
+    if not isinstance(data, dict):
+        return ["the top-level value must be an object"]
+
+    phases = data.get("phases")
+    if not isinstance(phases, list):
+        return ['top-level field "phases" must be an array']
+
+    errors = []
+    for phase_index, phase in enumerate(phases):
+        phase_path = f"phases[{phase_index}]"
+        if not isinstance(phase, dict):
+            errors.append(f"{phase_path} must be an object")
+            continue
+
+        modules = phase.get("modules")
+        if not isinstance(modules, list):
+            errors.append(f"{phase_path}.modules must be an array")
+            continue
+
+        for module_index, module in enumerate(modules):
+            module_path = f"{phase_path}.modules[{module_index}]"
+            if not isinstance(module, dict):
+                errors.append(f"{module_path} must be an object")
+                continue
+
+            module_name = module.get("name", "")
+            context = (
+                f"{module_path} ({module_name!r})"
+                if module_name
+                else module_path
+            )
+
+            if "source_files" not in module:
+                errors.append(f"{context}.source_files is missing")
+                continue
+
+            source_files = module["source_files"]
+            if not isinstance(source_files, list):
+                errors.append(f"{context}.source_files must be an array")
+                continue
+
+            for source_index, source_file in enumerate(source_files):
+                if not isinstance(source_file, str):
+                    errors.append(
+                        f"{context}.source_files[{source_index}] must be a string"
+                    )
+
+    return errors
+
+
 def _phase_plan_complete(work_dir):
-    """Return True only if phases.json exists and is valid JSON."""
+    """Return True only if phases.json exists and matches the required schema."""
     phases_path = os.path.join(work_dir, "phases.json")
-    return _json_file_is_valid(phases_path)
+    return not _phase_plan_schema_errors(phases_path)
 
 
 def _domain_context_complete(work_dir):
@@ -843,182 +904,174 @@ def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
                          resume=False, submodules=None, plugin_stage=None,
                          plugin_root=None):
     """Stage 1: generate phase.json — input target code, output phases.json."""
-    phases_json = os.path.join(work_dir, "phases.json")
-    run_llm = True
-
     if plugin_stage is not None:
         if plugin_stage.type == "pass":
             print("[Pipeline] Stage 1/6: Plugin stage 'generate_phase_plan' type=pass, skipping.")
-            run_llm = False
-        elif plugin_stage.type == "replace":
+            return
+        if plugin_stage.type == "replace":
             print("[Pipeline] Stage 1/6: Plugin stage 'generate_phase_plan' type=replace, running plugin command.")
             from .plugin import run_plugin_command
             run_plugin_command(plugin_stage.replace_cmd, plugin_root, proj_dir, label="generate_phase_plan")
-            run_llm = False
+            return
 
-    if run_llm:
-        prev_mtime = os.path.getmtime(phases_json) if os.path.exists(phases_json) else None
+    phases_json = os.path.join(work_dir, "phases.json")
+    prev_mtime = os.path.getmtime(phases_json) if os.path.exists(phases_json) else None
+
+    phase_plan_errors = (
+        _phase_plan_schema_errors(phases_json)
+        if os.path.exists(phases_json)
+        else []
+    )
+    _resume_skip = resume and _phase_plan_complete(work_dir)
+    if _resume_skip:
+        print("[Pipeline] Stage 1/6: RESUME — phases.json found, skipping phase plan generation.")
+
+    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
+        workflow_src = str(plugin_root / plugin_stage.input_md)
+        workflow_dst = os.path.join(work_dir, "workflow_generate_phases.md")
+        shutil.copy2(workflow_src, workflow_dst)
+        user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
+        if user_knowledge_paths:
+            with open(workflow_dst, "a") as _f:
+                _f.write(
+                    "\n---\n\n"
+                    "## User-Provided Domain Knowledge\n\n"
+                    "The user supplied extra Markdown files with domain knowledge for this run. "
+                    "Read these files before writing `phases.json` and the generated domain "
+                    "context files. Use them only as contextual knowledge about intended "
+                    "behavior, terminology, business rules, data encodings, and invariants; "
+                    "do NOT include these Markdown files as project source files in "
+                    "`phases.json`, and do NOT edit or summarize them in place.\n\n"
+                    f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
+                )
+    else:
+        _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_phases.md")
+
+    fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
+                    "It is a workspace for storing your output files only. "
+                    "Do NOT include fm_agent/ paths in phases.json. "
+                    "Do NOT modify any existing project files.")
+    incremental_reminder = ("IMPORTANT: An existing fm_agent/phases.json from a previous run is already "
+                            "present. Do NOT regenerate it from scratch. Instead, inspect the current "
+                            "state of the source code and UPDATE the existing fm_agent/phases.json so it "
+                            "reflects the current version of the code: add modules and source files that "
+                            "are new, remove entries whose files no longer exist, and adjust phases as "
+                            "needed. Preserve entries that are still accurate.")
+    submodule_reminder = ""
+    if submodules:
+        allowed = ", ".join(f"`{submodule}/`" for submodule in submodules)
+        submodule_reminder = (
+            "IMPORTANT: Only process source files under these project-relative "
+            f"subdirectories: {allowed}. Do NOT include files outside these "
+            "subdirectories in phases.json."
+        )
+
+    for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
+        if _resume_skip:
+            break
+        if attempt == 1 and not resume:
+            prompt = f"Follow the instructions in the attached file. {fm_reminder} {submodule_reminder}"
+        else:
+            prompt = ("A previous attempt was interrupted and may have already produced some of the "
+                      "required output files. Follow the instructions in the attached file, but FIRST "
+                      "check the current progress in fm_agent/ (e.g. phases.json). Keep any existing valid "
+                      "output as-is and only generate the files that are missing or incomplete — do NOT "
+                      f"regenerate or overwrite work that is already done. {fm_reminder} {submodule_reminder}")
+        if is_incremental:
+            prompt = f"{prompt} {incremental_reminder}"
+        if phase_plan_errors:
+            formatted_errors = "\n".join(
+                f"- {error}" for error in phase_plan_errors
+            )
+            schema_repair_prompt = (
+                "IMPORTANT: The existing fm_agent/phases.json is valid JSON or "
+                "partially generated, but it does not match the required schema. "
+                "Read the project source files and repair these problems:\n"
+                f"{formatted_errors}\n"
+                "Do not use an empty source_files array merely to satisfy the schema. "
+                "Use an empty array only when the module genuinely owns no source files."
+            )
+            prompt = f"{prompt}\n\n{schema_repair_prompt}"
+        prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_phases.md")
+        command = build_llm_cli_command(
+            model=OPENCODE_SETUP_MODEL,
+            prompt=prompt,
+            cwd=proj_dir,
+            files=[prompt_file],
+        )
+        try:
+            run_opencode_traced(
+                proj_dir=proj_dir,
+                work_dir=work_dir,
+                command=command,
+                stage="generate_phases_json",
+                input_files=[
+                    "fm_agent/workflow_generate_phases.md",
+                    *list_staged_domain_knowledge_relpaths(work_dir),
+                ],
+                output_files=[
+                    "fm_agent/phases.json",
+                ],
+                summary=f"OpenCode generate phases.json attempt {attempt}",
+                metadata={"attempt": attempt},
+            )
+        except subprocess.CalledProcessError as e:
+            logging.warning(f"Stage 1 attempt {attempt}: opencode exited with code {e.returncode}")
 
         phase_plan_errors = (
             _phase_plan_schema_errors(phases_json)
             if os.path.exists(phases_json)
-            else []
+            else ["phases.json is missing"]
         )
-        _resume_skip = resume and _phase_plan_complete(work_dir)
-        if _resume_skip:
-            print("[Pipeline] Stage 1/6: RESUME — phases.json found, skipping phase plan generation.")
 
-        if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
-            workflow_src = str(plugin_root / plugin_stage.input_md)
-            workflow_dst = os.path.join(work_dir, "workflow_generate_phases.md")
-            shutil.copy2(workflow_src, workflow_dst)
-            user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
-            if user_knowledge_paths:
-                with open(workflow_dst, "a") as _f:
-                    _f.write(
-                        "\n---\n\n"
-                        "## User-Provided Domain Knowledge\n\n"
-                        "The user supplied extra Markdown files with domain knowledge for this run. "
-                        "Read these files before writing `phases.json` and the generated domain "
-                        "context files. Use them only as contextual knowledge about intended "
-                        "behavior, terminology, business rules, data encodings, and invariants; "
-                        "do NOT include these Markdown files as project source files in "
-                        "`phases.json`, and do NOT edit or summarize them in place.\n\n"
-                        f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
-                    )
+        phase_plan_ready = False
+        if not phase_plan_errors:
+            if submodules:
+                phase_plan_ready = _phases_cover_current_sources(
+                    phases_json, proj_dir, submodules
+                )
+            elif is_incremental:
+                phase_plan_ready = (
+                    os.path.getmtime(phases_json) != prev_mtime
+                    or _phases_cover_current_sources(phases_json, proj_dir)
+                )
+            else:
+                phase_plan_ready = True
+        if phase_plan_ready:
+            break
+
+        failure = "update phases.json" if is_incremental else "produce phases.json"
+        if phase_plan_errors:
+            missing = (
+                "phases.json schema validation failed: "
+                + "; ".join(phase_plan_errors)
+            )
         else:
-            _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_phases.md")
-
-        fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
-                        "It is a workspace for storing your output files only. "
-                        "Do NOT include fm_agent/ paths in phases.json. "
-                        "Do NOT modify any existing project files.")
-        incremental_reminder = ("IMPORTANT: An existing fm_agent/phases.json from a previous run is already "
-                                "present. Do NOT regenerate it from scratch. Instead, inspect the current "
-                                "state of the source code and UPDATE the existing fm_agent/phases.json so it "
-                                "reflects the current version of the code: add modules and source files that "
-                                "are new, remove entries whose files no longer exist, and adjust phases as "
-                                "needed. Preserve entries that are still accurate.")
-        submodule_reminder = ""
-        if submodules:
-            allowed = ", ".join(f"`{submodule}/`" for submodule in submodules)
-            submodule_reminder = (
-                "IMPORTANT: Only process source files under these project-relative "
-                f"subdirectories: {allowed}. Do NOT include files outside these "
-                "subdirectories in phases.json."
+            missing = (
+                "phases.json was not updated"
+                if is_incremental
+                else "phases.json missing or invalid"
             )
-
-        for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
-            if _resume_skip:
-                break
-            if attempt == 1 and not resume:
-                prompt = f"Follow the instructions in the attached file. {fm_reminder} {submodule_reminder}"
-            else:
-                prompt = ("A previous attempt was interrupted and may have already produced some of the "
-                          "required output files. Follow the instructions in the attached file, but FIRST "
-                          "check the current progress in fm_agent/ (e.g. phases.json). Keep any existing valid "
-                          "output as-is and only generate the files that are missing or incomplete — do NOT "
-                          f"regenerate or overwrite work that is already done. {fm_reminder} {submodule_reminder}")
-            if is_incremental:
-                prompt = f"{prompt} {incremental_reminder}"
-            if phase_plan_errors:
-                formatted_errors = "\n".join(
-                    f"- {error}" for error in phase_plan_errors
-                )
-                schema_repair_prompt = (
-                    "IMPORTANT: The existing fm_agent/phases.json is valid JSON or "
-                    "partially generated, but it does not match the required schema. "
-                    "Read the project source files and repair these problems:\n"
-                    f"{formatted_errors}\n"
-                    "Do not use an empty source_files array merely to satisfy the schema. "
-                    "Use an empty array only when the module genuinely owns no source files."
-                )
-                prompt = f"{prompt}\n\n{schema_repair_prompt}"
-            prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_phases.md")
-            command = build_llm_cli_command(
-                model=OPENCODE_SETUP_MODEL,
-                prompt=prompt,
-                cwd=proj_dir,
-                files=[prompt_file],
+        if attempt < OPENCODE_MAX_RETRIES:
+            delay = 10
+            print(
+                f"[Pipeline] Stage 1 failed to {failure} (attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
+                f"Retrying in {delay}s..."
             )
-            try:
-                run_opencode_traced(
-                    proj_dir=proj_dir,
-                    work_dir=work_dir,
-                    command=command,
-                    stage="generate_phases_json",
-                    input_files=[
-                        "fm_agent/workflow_generate_phases.md",
-                        *list_staged_domain_knowledge_relpaths(work_dir),
-                    ],
-                    output_files=[
-                        "fm_agent/phases.json",
-                    ],
-                    summary=f"OpenCode generate phases.json attempt {attempt}",
-                    metadata={"attempt": attempt},
-                )
-            except subprocess.CalledProcessError as e:
-                logging.warning(f"Stage 1 attempt {attempt}: opencode exited with code {e.returncode}")
-
-            phase_plan_errors = (
-                _phase_plan_schema_errors(phases_json)
-                if os.path.exists(phases_json)
-                else ["phases.json is missing"]
+            logging.warning(f"Stage 1 attempt {attempt} failed: {missing}. Retrying in {delay}s.")
+            time.sleep(delay)
+        else:
+            print(
+                f"[Pipeline] ERROR: Stage 1 failed after {OPENCODE_MAX_RETRIES} attempts. "
+                f"{missing}. "
+                f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
             )
+            sys.exit(1)
 
-            phase_plan_ready = False
-            if not phase_plan_errors:
-                if submodules:
-                    phase_plan_ready = _phases_cover_current_sources(
-                        phases_json, proj_dir, submodules
-                    )
-                elif is_incremental:
-                    phase_plan_ready = (
-                        os.path.getmtime(phases_json) != prev_mtime
-                        or _phases_cover_current_sources(phases_json, proj_dir)
-                    )
-                else:
-                    phase_plan_ready = True
-            if phase_plan_ready:
-                break
-
-            failure = "update phases.json" if is_incremental else "produce phases.json"
-            if phase_plan_errors:
-                missing = (
-                    "phases.json schema validation failed: "
-                    + "; ".join(phase_plan_errors)
-                )
-            else:
-                missing = (
-                    "phases.json was not updated"
-                    if is_incremental
-                    else "phases.json missing or invalid"
-                )
-            if attempt < OPENCODE_MAX_RETRIES:
-                delay = 10
-                print(
-                    f"[Pipeline] Stage 1 failed to {failure} (attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
-                    f"Retrying in {delay}s..."
-                )
-                logging.warning(f"Stage 1 attempt {attempt} failed: {missing}. Retrying in {delay}s.")
-                time.sleep(delay)
-            else:
-                raise RuntimeError(
-                    f"Stage generate_phase_plan failed after {OPENCODE_MAX_RETRIES} attempts. "
-                    f"{missing}. "
-                    f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
-                )
-
-        if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
-            print("[Pipeline] Stage 1/6: Running plugin post-process for generate_phase_plan...")
-            from .plugin import run_plugin_command
-            run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_phase_plan post-process")
-
-    if not _phase_plan_complete(work_dir):
-        raise RuntimeError(
-            "Stage generate_phase_plan failed: fm_agent/phases.json is missing or "
-            "invalid. Please re-run this stage to produce a valid phases.json."
-        )
+    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
+        print("[Pipeline] Stage 1/6: Running plugin post-process for generate_phase_plan...")
+        from .plugin import run_plugin_command
+        run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_phase_plan post-process")
 
 
 def _post_process_phases(proj_dir, work_dir, required_source_files=None,
@@ -1075,119 +1128,110 @@ def _run_generate_domain_context(proj_dir, work_dir, script_dir, resume=False,
     """Stage 2: generate domain context — input phases.json, output domain context
     files for each phase.
     """
-    run_llm = True
-
     if plugin_stage is not None:
         if plugin_stage.type == "pass":
             print("[Pipeline] Stage 2/6: Plugin stage 'generate_domain_context' type=pass, skipping.")
-            run_llm = False
-        elif plugin_stage.type == "replace":
+            return
+        if plugin_stage.type == "replace":
             print("[Pipeline] Stage 2/6: Plugin stage 'generate_domain_context' type=replace, running plugin command.")
             from .plugin import run_plugin_command
             run_plugin_command(plugin_stage.replace_cmd, plugin_root, proj_dir, label="generate_domain_context")
-            run_llm = False
+            return
 
-    if run_llm:
-        _resume_skip = resume and _domain_context_complete(work_dir)
+    _resume_skip = resume and _domain_context_complete(work_dir)
+    if _resume_skip:
+        print("[Pipeline] Stage 2/6: RESUME — domain context files found, skipping domain context generation.")
+
+    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
+        workflow_src = str(plugin_root / plugin_stage.input_md)
+        workflow_dst = os.path.join(work_dir, "workflow_generate_domain_context.md")
+        shutil.copy2(workflow_src, workflow_dst)
+        user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
+        if user_knowledge_paths:
+            with open(workflow_dst, "a") as _f:
+                _f.write(
+                    "\n---\n\n"
+                    "## User-Provided Domain Knowledge\n\n"
+                    "The user supplied extra Markdown files with domain knowledge for this run. "
+                    "Read these files before writing the domain context files. "
+                    "Use them only as contextual knowledge about intended "
+                    "behavior, terminology, business rules, data encodings, and invariants.\n\n"
+                    f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
+                )
+    else:
+        _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_domain_context.md")
+
+    fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
+                    "It is a workspace for storing your output files only. "
+                    "Do NOT modify any existing project files.")
+
+    for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
         if _resume_skip:
-            print("[Pipeline] Stage 2/6: RESUME — domain context files found, skipping domain context generation.")
-
-        if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
-            workflow_src = str(plugin_root / plugin_stage.input_md)
-            workflow_dst = os.path.join(work_dir, "workflow_generate_domain_context.md")
-            shutil.copy2(workflow_src, workflow_dst)
-            user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
-            if user_knowledge_paths:
-                with open(workflow_dst, "a") as _f:
-                    _f.write(
-                        "\n---\n\n"
-                        "## User-Provided Domain Knowledge\n\n"
-                        "The user supplied extra Markdown files with domain knowledge for this run. "
-                        "Read these files before writing the domain context files. "
-                        "Use them only as contextual knowledge about intended "
-                        "behavior, terminology, business rules, data encodings, and invariants.\n\n"
-                        f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
-                    )
-        else:
-            _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_domain_context.md")
-
-        fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
-                        "It is a workspace for storing your output files only. "
-                        "Do NOT modify any existing project files.")
-
-        for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
-            if _resume_skip:
-                break
-            if attempt == 1 and not resume:
-                prompt = (
-                    "Read fm_agent/phases.json first. "
-                    "Then follow the instructions in the attached file. "
-                    + fm_reminder
-                )
-            else:
-                prompt = ("A previous domain-context generation attempt was interrupted and may have already "
-                          "produced some of the required output files. Read fm_agent/phases.json first. "
-                          "Then follow the instructions in the attached file, but FIRST "
-                          "check the current progress in fm_agent/spec_prompts/domain_context/. "
-                          "Keep any existing valid output as-is and only generate the files that are missing or "
-                          f"incomplete — do NOT regenerate or overwrite work that is already done. {fm_reminder}")
-            prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_domain_context.md")
-            command = build_llm_cli_command(
-                model=OPENCODE_SETUP_MODEL,
-                prompt=prompt,
-                cwd=proj_dir,
-                files=[prompt_file],
+            break
+        if attempt == 1 and not resume:
+            prompt = (
+                "Read fm_agent/phases.json first. "
+                "Then follow the instructions in the attached file. "
+                + fm_reminder
             )
-            try:
-                run_opencode_traced(
-                    proj_dir=proj_dir,
-                    work_dir=work_dir,
-                    command=command,
-                    stage="generate_domain_context",
-                    input_files=[
-                        "fm_agent/workflow_generate_domain_context.md",
-                        "fm_agent/phases.json",
-                        *list_staged_domain_knowledge_relpaths(work_dir),
-                    ],
-                    output_files=[
-                        "fm_agent/spec_prompts/domain_context/engine_overview.txt",
-                    ],
-                    summary=f"OpenCode generate domain context attempt {attempt}",
-                    metadata={"attempt": attempt},
-                )
-            except subprocess.CalledProcessError as e:
-                logging.warning(f"Stage 2 attempt {attempt}: opencode exited with code {e.returncode}")
-
-            if _domain_context_complete(work_dir):
-                break
-
-            if attempt < OPENCODE_MAX_RETRIES:
-                delay = 10
-                print(
-                    f"[Pipeline] Stage 2 failed to produce domain context "
-                    f"(attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
-                    f"Retrying in {delay}s..."
-                )
-                logging.warning(f"Stage 2 attempt {attempt} failed: domain context outputs missing. Retrying in {delay}s.")
-                time.sleep(delay)
-            else:
-                raise RuntimeError(
-                    f"Stage generate_domain_context failed after {OPENCODE_MAX_RETRIES} attempts. "
-                    f"Domain context outputs missing. "
-                    f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
-                )
-
-        if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
-            print("[Pipeline] Stage 2/6: Running plugin post-process for generate_domain_context...")
-            from .plugin import run_plugin_command
-            run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_domain_context post-process")
-
-    if not _domain_context_complete(work_dir):
-        raise RuntimeError(
-            "Stage generate_domain_context failed: domain context output files "
-            "are missing or incomplete. Please re-run this stage to produce valid "
-            "domain context files."
+        else:
+            prompt = ("A previous domain-context generation attempt was interrupted and may have already "
+                      "produced some of the required output files. Read fm_agent/phases.json first. "
+                      "Then follow the instructions in the attached file, but FIRST "
+                      "check the current progress in fm_agent/spec_prompts/domain_context/. "
+                      "Keep any existing valid output as-is and only generate the files that are missing or "
+                      f"incomplete — do NOT regenerate or overwrite work that is already done. {fm_reminder}")
+        prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_domain_context.md")
+        command = build_llm_cli_command(
+            model=OPENCODE_SETUP_MODEL,
+            prompt=prompt,
+            cwd=proj_dir,
+            files=[prompt_file],
         )
+        try:
+            run_opencode_traced(
+                proj_dir=proj_dir,
+                work_dir=work_dir,
+                command=command,
+                stage="generate_domain_context",
+                input_files=[
+                    "fm_agent/workflow_generate_domain_context.md",
+                    "fm_agent/phases.json",
+                    *list_staged_domain_knowledge_relpaths(work_dir),
+                ],
+                output_files=[
+                    "fm_agent/spec_prompts/domain_context/engine_overview.txt",
+                ],
+                summary=f"OpenCode generate domain context attempt {attempt}",
+                metadata={"attempt": attempt},
+            )
+        except subprocess.CalledProcessError as e:
+            logging.warning(f"Stage 2 attempt {attempt}: opencode exited with code {e.returncode}")
+
+        if _domain_context_complete(work_dir):
+            break
+
+        if attempt < OPENCODE_MAX_RETRIES:
+            delay = 10
+            print(
+                f"[Pipeline] Stage 2 failed to produce domain context "
+                f"(attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
+                f"Retrying in {delay}s..."
+            )
+            logging.warning(f"Stage 2 attempt {attempt} failed: domain context outputs missing. Retrying in {delay}s.")
+            time.sleep(delay)
+        else:
+            print(
+                f"[Pipeline] ERROR: Stage 2 failed after {OPENCODE_MAX_RETRIES} attempts. "
+                f"Domain context outputs missing. "
+                f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
+            )
+            sys.exit(1)
+
+    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
+        print("[Pipeline] Stage 2/6: Running plugin post-process for generate_domain_context...")
+        from .plugin import run_plugin_command
+        run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_domain_context post-process")
 
 
 def _run_setup_extract(proj_dir, work_dir, script_dir, is_incremental=False,


### PR DESCRIPTION
## Summary

- revert `a6f06a9` (`Enforce artifact contract for plugin stage pass/replace paths`)
- preserve `2e42996` and its plugin interface for phase-plan and domain-context customization
- restore `_phase_plan_schema_errors` and the pre-follow-up setup behavior

## Reason

The follow-up commit removed `_phase_plan_schema_errors` while leaving live call sites in the normal and resume phase-plan paths. Those paths fail at runtime with `NameError`. Reverting only the second commit restores the validator without removing the plugin interface introduced by the first commit.

## Verification

- confirmed the resulting tree matches `2e42996`
- `python3 -m py_compile main.py src/plugin.py src/pipeline_setup.py src/file_utils.py src/extract.py src/generate_topdown_layers.py src/incremental_reasoner.py src/entry_reasoning_pipeline.py`
- `git diff --check public/main...HEAD`