### PR TITLE
chore(codegraph): bump pinned build to v1.5.0-fmagent.1

### DIFF
--- a/config.py
+++ b/config.py
@@ -157,7 +157,7 @@ class CodegraphCfg(_Section):
     repo: str = "fmagent-project/codegraph"
     # fm-agent.toml is the authoritative source; this default is only the fallback
     # when the toml is absent. Keep it in sync when bumping the pinned version.
-    version: str = "v1.3.0-fmagent.1"
+    version: str = "v1.5.0-fmagent.1"
     bin_dir: str = "~/.local/bin"  # launcher location; install and run must agree
 
 

--- a/fm-agent.toml
+++ b/fm-agent.toml
@@ -35,10 +35,10 @@ timeout_s = 180     # ELP_TIMEOUT_SECONDS
 # The pinned codegraph build. install.sh reads these to install it, and the
 # runtime invokes that pinned binary — so this is the single place that decides
 # "which codegraph": bump `version` (and `repo`), then re-run ./install.sh to
-# switch. The fork build fixes an upstream C extraction bug that otherwise drops
-# macro-decorated functions.
-# Do not run `codegraph upgrade` on this build — it pulls upstream's latest and
-# silently replaces the pinned binary (the runtime then only warns, not fails).
+# switch. This is a maintenance-fork release that re-hosts upstream v1.5.0, which
+# carries the C macro-attribute extraction fix natively. The fork build's updater
+# points back at the fork, so `codegraph upgrade` won't self-replace it with the
+# upstream build.
 repo    = "fmagent-project/codegraph"   # CODEGRAPH_REPO
-version = "v1.3.0-fmagent.1"            # CODEGRAPH_VERSION
+version = "v1.5.0-fmagent.1"            # CODEGRAPH_VERSION
 bin_dir = "~/.local/bin"                # CODEGRAPH_BIN_DIR — where the codegraph launcher is installed and invoked from


### PR DESCRIPTION
Bump the pinned codegraph build from `v1.3.0-fmagent.1` to `v1.5.0-fmagent.1`.

Upstream codegraph shipped the C macro-attribute extraction fix natively in v1.5.0 — a function of the form `MACRO Ret name(VOID)` is now indexed under its real name instead of its parameter list, which the maintenance fork previously carried as a local patch. The fork's new release re-hosts upstream v1.5.0 with no code patch on top; FM-Agent just re-points at it.

**Changes (two values + a comment):**
- `fm-agent.toml` `[codegraph].version` → `v1.5.0-fmagent.1`
- `config.py` `CodegraphCfg.version` default → same (the toml-absent fallback, kept in sync)
- Comment updated: the fork now re-hosts the fixed upstream and its own updater points back at the fork, so the earlier "don't run `codegraph upgrade`" caveat no longer applies.

**To apply:** re-run `./install.sh` — it reads `[codegraph]` and installs `v1.5.0-fmagent.1` into `~/.local/bin`.

The new fork release carries the native Rust extraction kernel; the built binary was verified to index the macro-attribute case under its real name.
