### PR TITLE
Refactor plugin execution to use Python function interfaces

### DIFF
--- a/main.py
+++ b/main.py
@@ -165,6 +165,7 @@ def run_pipeline(
         submodules=submodules,
         plugin_stage=phase_stage,
         plugin_root=plugin_root,
+        plugin_config=plugin_config,
     )
 
     phases_modified = _post_process_phases(
@@ -182,6 +183,7 @@ def run_pipeline(
         resume=resume and not phases_modified,
         plugin_stage=context_stage,
         plugin_root=plugin_root,
+        plugin_config=plugin_config,
     )
 
     # Build (or rebuild) the codegraph index if codegraph is installed. Both

--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -266,7 +266,6 @@ def _deduplicate_phases(phases_dir):
     for phase in sorted(data["phases"], key=lambda p: p["phase"]):
         for module in phase["modules"]:
             original = module["source_files"]
-
             deduped = []
             for sf in original:
                 if sf not in seen:
@@ -902,176 +901,195 @@ def _prepare_workflow_file(proj_dir, work_dir, script_dir, workflow_filename):
 
 def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
                          resume=False, submodules=None, plugin_stage=None,
-                         plugin_root=None):
+                         plugin_root=None, plugin_config=None):
     """Stage 1: generate phase.json — input target code, output phases.json."""
+    phases_json = os.path.join(work_dir, "phases.json")
+    run_llm = True
+
     if plugin_stage is not None:
         if plugin_stage.type == "pass":
             print("[Pipeline] Stage 1/6: Plugin stage 'generate_phase_plan' type=pass, skipping.")
-            return
-        if plugin_stage.type == "replace":
-            print("[Pipeline] Stage 1/6: Plugin stage 'generate_phase_plan' type=replace, running plugin command.")
-            from .plugin import run_plugin_command
-            run_plugin_command(plugin_stage.replace_cmd, plugin_root, proj_dir, label="generate_phase_plan")
-            return
-
-    phases_json = os.path.join(work_dir, "phases.json")
-    prev_mtime = os.path.getmtime(phases_json) if os.path.exists(phases_json) else None
-
-    phase_plan_errors = (
-        _phase_plan_schema_errors(phases_json)
-        if os.path.exists(phases_json)
-        else []
-    )
-    _resume_skip = resume and _phase_plan_complete(work_dir)
-    if _resume_skip:
-        print("[Pipeline] Stage 1/6: RESUME — phases.json found, skipping phase plan generation.")
-
-    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
-        workflow_src = str(plugin_root / plugin_stage.input_md)
-        workflow_dst = os.path.join(work_dir, "workflow_generate_phases.md")
-        shutil.copy2(workflow_src, workflow_dst)
-        user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
-        if user_knowledge_paths:
-            with open(workflow_dst, "a") as _f:
-                _f.write(
-                    "\n---\n\n"
-                    "## User-Provided Domain Knowledge\n\n"
-                    "The user supplied extra Markdown files with domain knowledge for this run. "
-                    "Read these files before writing `phases.json` and the generated domain "
-                    "context files. Use them only as contextual knowledge about intended "
-                    "behavior, terminology, business rules, data encodings, and invariants; "
-                    "do NOT include these Markdown files as project source files in "
-                    "`phases.json`, and do NOT edit or summarize them in place.\n\n"
-                    f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
-                )
-    else:
-        _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_phases.md")
-
-    fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
-                    "It is a workspace for storing your output files only. "
-                    "Do NOT include fm_agent/ paths in phases.json. "
-                    "Do NOT modify any existing project files.")
-    incremental_reminder = ("IMPORTANT: An existing fm_agent/phases.json from a previous run is already "
-                            "present. Do NOT regenerate it from scratch. Instead, inspect the current "
-                            "state of the source code and UPDATE the existing fm_agent/phases.json so it "
-                            "reflects the current version of the code: add modules and source files that "
-                            "are new, remove entries whose files no longer exist, and adjust phases as "
-                            "needed. Preserve entries that are still accurate.")
-    submodule_reminder = ""
-    if submodules:
-        allowed = ", ".join(f"`{submodule}/`" for submodule in submodules)
-        submodule_reminder = (
-            "IMPORTANT: Only process source files under these project-relative "
-            f"subdirectories: {allowed}. Do NOT include files outside these "
-            "subdirectories in phases.json."
-        )
-
-    for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
-        if _resume_skip:
-            break
-        if attempt == 1 and not resume:
-            prompt = f"Follow the instructions in the attached file. {fm_reminder} {submodule_reminder}"
-        else:
-            prompt = ("A previous attempt was interrupted and may have already produced some of the "
-                      "required output files. Follow the instructions in the attached file, but FIRST "
-                      "check the current progress in fm_agent/ (e.g. phases.json). Keep any existing valid "
-                      "output as-is and only generate the files that are missing or incomplete — do NOT "
-                      f"regenerate or overwrite work that is already done. {fm_reminder} {submodule_reminder}")
-        if is_incremental:
-            prompt = f"{prompt} {incremental_reminder}"
-        if phase_plan_errors:
-            formatted_errors = "\n".join(
-                f"- {error}" for error in phase_plan_errors
+            run_llm = False
+        elif plugin_stage.type == "replace":
+            print("[Pipeline] Stage 1/6: Plugin stage 'generate_phase_plan' type=replace, calling plugin.replacer().")
+            knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
+            input_files = [os.path.join(work_dir, "workflow_generate_phases.md")]
+            if knowledge_paths:
+                input_files += [os.path.join(work_dir, p) for p in knowledge_paths]
+            context = {"project_dir": proj_dir, "work_dir": work_dir}
+            _outputs = plugin_config.invoke_replace(
+                "generate_phase_plan",
+                input_files=input_files,
+                context=context,
             )
-            schema_repair_prompt = (
-                "IMPORTANT: The existing fm_agent/phases.json is valid JSON or "
-                "partially generated, but it does not match the required schema. "
-                "Read the project source files and repair these problems:\n"
-                f"{formatted_errors}\n"
-                "Do not use an empty source_files array merely to satisfy the schema. "
-                "Use an empty array only when the module genuinely owns no source files."
-            )
-            prompt = f"{prompt}\n\n{schema_repair_prompt}"
-        prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_phases.md")
-        command = build_llm_cli_command(
-            model=OPENCODE_SETUP_MODEL,
-            prompt=prompt,
-            cwd=proj_dir,
-            files=[prompt_file],
-        )
-        try:
-            run_opencode_traced(
-                proj_dir=proj_dir,
-                work_dir=work_dir,
-                command=command,
-                stage="generate_phases_json",
-                input_files=[
-                    "fm_agent/workflow_generate_phases.md",
-                    *list_staged_domain_knowledge_relpaths(work_dir),
-                ],
-                output_files=[
-                    "fm_agent/phases.json",
-                ],
-                summary=f"OpenCode generate phases.json attempt {attempt}",
-                metadata={"attempt": attempt},
-            )
-        except subprocess.CalledProcessError as e:
-            logging.warning(f"Stage 1 attempt {attempt}: opencode exited with code {e.returncode}")
+            run_llm = False
+
+    if run_llm:
+        prev_mtime = os.path.getmtime(phases_json) if os.path.exists(phases_json) else None
 
         phase_plan_errors = (
             _phase_plan_schema_errors(phases_json)
             if os.path.exists(phases_json)
-            else ["phases.json is missing"]
+            else []
         )
+        _resume_skip = resume and _phase_plan_complete(work_dir)
+        if _resume_skip:
+            print("[Pipeline] Stage 1/6: RESUME — phases.json found, skipping phase plan generation.")
 
-        phase_plan_ready = False
-        if not phase_plan_errors:
-            if submodules:
-                phase_plan_ready = _phases_cover_current_sources(
-                    phases_json, proj_dir, submodules
+        if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
+            workflow_src = str(plugin_root / plugin_stage.input_md)
+            workflow_dst = os.path.join(work_dir, "workflow_generate_phases.md")
+            shutil.copy2(workflow_src, workflow_dst)
+            user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
+            if user_knowledge_paths:
+                with open(workflow_dst, "a") as _f:
+                    _f.write(
+                        "\n---\n\n"
+                        "## User-Provided Domain Knowledge\n\n"
+                        "The user supplied extra Markdown files with domain knowledge for this run. "
+                        "Read these files before writing `phases.json` and the generated domain "
+                        "context files. Use them only as contextual knowledge about intended "
+                        "behavior, terminology, business rules, data encodings, and invariants; "
+                        "do NOT include these Markdown files as project source files in "
+                        "`phases.json`, and do NOT edit or summarize them in place.\n\n"
+                        f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
+                    )
+        else:
+            _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_phases.md")
+
+        fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
+                        "It is a workspace for storing your output files only. "
+                        "Do NOT include fm_agent/ paths in phases.json. "
+                        "Do NOT modify any existing project files.")
+        incremental_reminder = ("IMPORTANT: An existing fm_agent/phases.json from a previous run is already "
+                                "present. Do NOT regenerate it from scratch. Instead, inspect the current "
+                                "state of the source code and UPDATE the existing fm_agent/phases.json so it "
+                                "reflects the current version of the code: add modules and source files that "
+                                "are new, remove entries whose files no longer exist, and adjust phases as "
+                                "needed. Preserve entries that are still accurate.")
+        submodule_reminder = ""
+        if submodules:
+            allowed = ", ".join(f"`{submodule}/`" for submodule in submodules)
+            submodule_reminder = (
+                "IMPORTANT: Only process source files under these project-relative "
+                f"subdirectories: {allowed}. Do NOT include files outside these "
+                "subdirectories in phases.json."
+            )
+
+        for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
+            if _resume_skip:
+                break
+            if attempt == 1 and not resume:
+                prompt = f"Follow the instructions in the attached file. {fm_reminder} {submodule_reminder}"
+            else:
+                prompt = ("A previous attempt was interrupted and may have already produced some of the "
+                          "required output files. Follow the instructions in the attached file, but FIRST "
+                          "check the current progress in fm_agent/ (e.g. phases.json). Keep any existing valid "
+                          "output as-is and only generate the files that are missing or incomplete — do NOT "
+                          f"regenerate or overwrite work that is already done. {fm_reminder} {submodule_reminder}")
+            if is_incremental:
+                prompt = f"{prompt} {incremental_reminder}"
+            if phase_plan_errors:
+                formatted_errors = "\n".join(
+                    f"- {error}" for error in phase_plan_errors
                 )
-            elif is_incremental:
-                phase_plan_ready = (
-                    os.path.getmtime(phases_json) != prev_mtime
-                    or _phases_cover_current_sources(phases_json, proj_dir)
+                schema_repair_prompt = (
+                    "IMPORTANT: The existing fm_agent/phases.json is valid JSON or "
+                    "partially generated, but it does not match the required schema. "
+                    "Read the project source files and repair these problems:\n"
+                    f"{formatted_errors}\n"
+                    "Do not use an empty source_files array merely to satisfy the schema. "
+                    "Use an empty array only when the module genuinely owns no source files."
+                )
+                prompt = f"{prompt}\n\n{schema_repair_prompt}"
+            prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_phases.md")
+            command = build_llm_cli_command(
+                model=OPENCODE_SETUP_MODEL,
+                prompt=prompt,
+                cwd=proj_dir,
+                files=[prompt_file],
+            )
+            try:
+                run_opencode_traced(
+                    proj_dir=proj_dir,
+                    work_dir=work_dir,
+                    command=command,
+                    stage="generate_phases_json",
+                    input_files=[
+                        "fm_agent/workflow_generate_phases.md",
+                        *list_staged_domain_knowledge_relpaths(work_dir),
+                    ],
+                    output_files=[
+                        "fm_agent/phases.json",
+                    ],
+                    summary=f"OpenCode generate phases.json attempt {attempt}",
+                    metadata={"attempt": attempt},
+                )
+            except subprocess.CalledProcessError as e:
+                logging.warning(f"Stage 1 attempt {attempt}: opencode exited with code {e.returncode}")
+
+            phase_plan_errors = (
+                _phase_plan_schema_errors(phases_json)
+                if os.path.exists(phases_json)
+                else ["phases.json is missing"]
+            )
+
+            phase_plan_ready = False
+            if not phase_plan_errors:
+                if submodules:
+                    phase_plan_ready = _phases_cover_current_sources(
+                        phases_json, proj_dir, submodules
+                    )
+                elif is_incremental:
+                    phase_plan_ready = (
+                        os.path.getmtime(phases_json) != prev_mtime
+                        or _phases_cover_current_sources(phases_json, proj_dir)
+                    )
+                else:
+                    phase_plan_ready = True
+            if phase_plan_ready:
+                break
+
+            failure = "update phases.json" if is_incremental else "produce phases.json"
+            if phase_plan_errors:
+                missing = (
+                    "phases.json schema validation failed: "
+                    + "; ".join(phase_plan_errors)
                 )
             else:
-                phase_plan_ready = True
-        if phase_plan_ready:
-            break
+                missing = (
+                    "phases.json was not updated"
+                    if is_incremental
+                    else "phases.json missing or invalid"
+                )
+            if attempt < OPENCODE_MAX_RETRIES:
+                delay = 10
+                print(
+                    f"[Pipeline] Stage 1 failed to {failure} (attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
+                    f"Retrying in {delay}s..."
+                )
+                logging.warning(f"Stage 1 attempt {attempt} failed: {missing}. Retrying in {delay}s.")
+                time.sleep(delay)
+            else:
+                raise RuntimeError(
+                    f"Stage generate_phase_plan failed after {OPENCODE_MAX_RETRIES} attempts. "
+                    f"{missing}. "
+                    f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
+                )
 
-        failure = "update phases.json" if is_incremental else "produce phases.json"
-        if phase_plan_errors:
-            missing = (
-                "phases.json schema validation failed: "
-                + "; ".join(phase_plan_errors)
+        if plugin_stage is not None and plugin_stage.type == "modify":
+            print("[Pipeline] Stage 1/6: Running plugin post-process for generate_phase_plan...")
+            output_files = [os.path.join(work_dir, "phases.json")]
+            plugin_config.invoke_modify_output(
+                "generate_phase_plan",
+                output_files=output_files,
             )
-        else:
-            missing = (
-                "phases.json was not updated"
-                if is_incremental
-                else "phases.json missing or invalid"
-            )
-        if attempt < OPENCODE_MAX_RETRIES:
-            delay = 10
-            print(
-                f"[Pipeline] Stage 1 failed to {failure} (attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
-                f"Retrying in {delay}s..."
-            )
-            logging.warning(f"Stage 1 attempt {attempt} failed: {missing}. Retrying in {delay}s.")
-            time.sleep(delay)
-        else:
-            print(
-                f"[Pipeline] ERROR: Stage 1 failed after {OPENCODE_MAX_RETRIES} attempts. "
-                f"{missing}. "
-                f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
-            )
-            sys.exit(1)
 
-    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
-        print("[Pipeline] Stage 1/6: Running plugin post-process for generate_phase_plan...")
-        from .plugin import run_plugin_command
-        run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_phase_plan post-process")
+    if not _phase_plan_complete(work_dir):
+        raise RuntimeError(
+            "Stage generate_phase_plan failed: fm_agent/phases.json is missing or "
+            "invalid. Please re-run this stage to produce a valid phases.json."
+        )
 
 
 def _post_process_phases(proj_dir, work_dir, required_source_files=None,
@@ -1124,114 +1142,147 @@ def _post_process_phases(proj_dir, work_dir, required_source_files=None,
 
 
 def _run_generate_domain_context(proj_dir, work_dir, script_dir, resume=False,
-                                 plugin_stage=None, plugin_root=None):
+                                 plugin_stage=None, plugin_root=None,
+                                 plugin_config=None):
     """Stage 2: generate domain context — input phases.json, output domain context
     files for each phase.
     """
+    run_llm = True
+
     if plugin_stage is not None:
         if plugin_stage.type == "pass":
             print("[Pipeline] Stage 2/6: Plugin stage 'generate_domain_context' type=pass, skipping.")
-            return
-        if plugin_stage.type == "replace":
-            print("[Pipeline] Stage 2/6: Plugin stage 'generate_domain_context' type=replace, running plugin command.")
-            from .plugin import run_plugin_command
-            run_plugin_command(plugin_stage.replace_cmd, plugin_root, proj_dir, label="generate_domain_context")
-            return
+            run_llm = False
+        elif plugin_stage.type == "replace":
+            print("[Pipeline] Stage 2/6: Plugin stage 'generate_domain_context' type=replace, calling plugin.replacer().")
+            knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
+            input_files = [
+                os.path.join(work_dir, "workflow_generate_domain_context.md"),
+                os.path.join(work_dir, "phases.json"),
+            ]
+            if knowledge_paths:
+                input_files += [os.path.join(work_dir, p) for p in knowledge_paths]
+            context = {"project_dir": proj_dir, "work_dir": work_dir}
+            _outputs = plugin_config.invoke_replace(
+                "generate_domain_context",
+                input_files=input_files,
+                context=context,
+            )
+            run_llm = False
 
-    _resume_skip = resume and _domain_context_complete(work_dir)
-    if _resume_skip:
-        print("[Pipeline] Stage 2/6: RESUME — domain context files found, skipping domain context generation.")
-
-    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
-        workflow_src = str(plugin_root / plugin_stage.input_md)
-        workflow_dst = os.path.join(work_dir, "workflow_generate_domain_context.md")
-        shutil.copy2(workflow_src, workflow_dst)
-        user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
-        if user_knowledge_paths:
-            with open(workflow_dst, "a") as _f:
-                _f.write(
-                    "\n---\n\n"
-                    "## User-Provided Domain Knowledge\n\n"
-                    "The user supplied extra Markdown files with domain knowledge for this run. "
-                    "Read these files before writing the domain context files. "
-                    "Use them only as contextual knowledge about intended "
-                    "behavior, terminology, business rules, data encodings, and invariants.\n\n"
-                    f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
-                )
-    else:
-        _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_domain_context.md")
-
-    fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
-                    "It is a workspace for storing your output files only. "
-                    "Do NOT modify any existing project files.")
-
-    for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
+    if run_llm:
+        _resume_skip = resume and _domain_context_complete(work_dir)
         if _resume_skip:
-            break
-        if attempt == 1 and not resume:
-            prompt = (
-                "Read fm_agent/phases.json first. "
-                "Then follow the instructions in the attached file. "
-                + fm_reminder
-            )
+            print("[Pipeline] Stage 2/6: RESUME — domain context files found, skipping domain context generation.")
+
+        if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.input_md:
+            workflow_src = str(plugin_root / plugin_stage.input_md)
+            workflow_dst = os.path.join(work_dir, "workflow_generate_domain_context.md")
+            shutil.copy2(workflow_src, workflow_dst)
+            user_knowledge_paths = list_staged_domain_knowledge_relpaths(work_dir)
+            if user_knowledge_paths:
+                with open(workflow_dst, "a") as _f:
+                    _f.write(
+                        "\n---\n\n"
+                        "## User-Provided Domain Knowledge\n\n"
+                        "The user supplied extra Markdown files with domain knowledge for this run. "
+                        "Read these files before writing the domain context files. "
+                        "Use them only as contextual knowledge about intended "
+                        "behavior, terminology, business rules, data encodings, and invariants.\n\n"
+                        f"{format_domain_knowledge_bullets(user_knowledge_paths)}\n"
+                    )
         else:
-            prompt = ("A previous domain-context generation attempt was interrupted and may have already "
-                      "produced some of the required output files. Read fm_agent/phases.json first. "
-                      "Then follow the instructions in the attached file, but FIRST "
-                      "check the current progress in fm_agent/spec_prompts/domain_context/. "
-                      "Keep any existing valid output as-is and only generate the files that are missing or "
-                      f"incomplete — do NOT regenerate or overwrite work that is already done. {fm_reminder}")
-        prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_domain_context.md")
-        command = build_llm_cli_command(
-            model=OPENCODE_SETUP_MODEL,
-            prompt=prompt,
-            cwd=proj_dir,
-            files=[prompt_file],
+            _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_domain_context.md")
+
+        fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
+                        "It is a workspace for storing your output files only. "
+                        "Do NOT modify any existing project files.")
+
+        for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
+            if _resume_skip:
+                break
+            if attempt == 1 and not resume:
+                prompt = (
+                    "Read fm_agent/phases.json first. "
+                    "Then follow the instructions in the attached file. "
+                    + fm_reminder
+                )
+            else:
+                prompt = ("A previous domain-context generation attempt was interrupted and may have already "
+                          "produced some of the required output files. Read fm_agent/phases.json first. "
+                          "Then follow the instructions in the attached file, but FIRST "
+                          "check the current progress in fm_agent/spec_prompts/domain_context/. "
+                          "Keep any existing valid output as-is and only generate the files that are missing or "
+                          f"incomplete — do NOT regenerate or overwrite work that is already done. {fm_reminder}")
+            prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_generate_domain_context.md")
+            command = build_llm_cli_command(
+                model=OPENCODE_SETUP_MODEL,
+                prompt=prompt,
+                cwd=proj_dir,
+                files=[prompt_file],
+            )
+            try:
+                run_opencode_traced(
+                    proj_dir=proj_dir,
+                    work_dir=work_dir,
+                    command=command,
+                    stage="generate_domain_context",
+                    input_files=[
+                        "fm_agent/workflow_generate_domain_context.md",
+                        "fm_agent/phases.json",
+                        *list_staged_domain_knowledge_relpaths(work_dir),
+                    ],
+                    output_files=[
+                        "fm_agent/spec_prompts/domain_context/engine_overview.txt",
+                    ],
+                    summary=f"OpenCode generate domain context attempt {attempt}",
+                    metadata={"attempt": attempt},
+                )
+            except subprocess.CalledProcessError as e:
+                logging.warning(f"Stage 2 attempt {attempt}: opencode exited with code {e.returncode}")
+
+            if _domain_context_complete(work_dir):
+                break
+
+            if attempt < OPENCODE_MAX_RETRIES:
+                delay = 10
+                print(
+                    f"[Pipeline] Stage 2 failed to produce domain context "
+                    f"(attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
+                    f"Retrying in {delay}s..."
+                )
+                logging.warning(f"Stage 2 attempt {attempt} failed: domain context outputs missing. Retrying in {delay}s.")
+                time.sleep(delay)
+            else:
+                raise RuntimeError(
+                    f"Stage generate_domain_context failed after {OPENCODE_MAX_RETRIES} attempts. "
+                    f"Domain context outputs missing. "
+                    f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
+                )
+
+        if plugin_stage is not None and plugin_stage.type == "modify":
+            print("[Pipeline] Stage 2/6: Running plugin post-process for generate_domain_context...")
+            from .file_utils import load_phases
+            phases_data = load_phases(work_dir)
+            domain_dir = os.path.join(work_dir, "spec_prompts", "domain_context")
+            output_files = [os.path.join(domain_dir, "engine_overview.txt")]
+            for phase in phases_data.get("phases", []):
+                phase_num = phase.get("phase")
+                if phase_num is not None:
+                    output_files.append(
+                        os.path.join(domain_dir, f"phase_{phase_num:02d}_types.txt")
+                    )
+            plugin_config.invoke_modify_output(
+                "generate_domain_context",
+                output_files=output_files,
+            )
+
+    if not _domain_context_complete(work_dir):
+        raise RuntimeError(
+            "Stage generate_domain_context failed: domain context output files "
+            "are missing or incomplete. Please re-run this stage to produce valid "
+            "domain context files."
         )
-        try:
-            run_opencode_traced(
-                proj_dir=proj_dir,
-                work_dir=work_dir,
-                command=command,
-                stage="generate_domain_context",
-                input_files=[
-                    "fm_agent/workflow_generate_domain_context.md",
-                    "fm_agent/phases.json",
-                    *list_staged_domain_knowledge_relpaths(work_dir),
-                ],
-                output_files=[
-                    "fm_agent/spec_prompts/domain_context/engine_overview.txt",
-                ],
-                summary=f"OpenCode generate domain context attempt {attempt}",
-                metadata={"attempt": attempt},
-            )
-        except subprocess.CalledProcessError as e:
-            logging.warning(f"Stage 2 attempt {attempt}: opencode exited with code {e.returncode}")
-
-        if _domain_context_complete(work_dir):
-            break
-
-        if attempt < OPENCODE_MAX_RETRIES:
-            delay = 10
-            print(
-                f"[Pipeline] Stage 2 failed to produce domain context "
-                f"(attempt {attempt}/{OPENCODE_MAX_RETRIES}). "
-                f"Retrying in {delay}s..."
-            )
-            logging.warning(f"Stage 2 attempt {attempt} failed: domain context outputs missing. Retrying in {delay}s.")
-            time.sleep(delay)
-        else:
-            print(
-                f"[Pipeline] ERROR: Stage 2 failed after {OPENCODE_MAX_RETRIES} attempts. "
-                f"Domain context outputs missing. "
-                f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
-            )
-            sys.exit(1)
-
-    if plugin_stage is not None and plugin_stage.type == "modify" and plugin_stage.output_process:
-        print("[Pipeline] Stage 2/6: Running plugin post-process for generate_domain_context...")
-        from .plugin import run_plugin_command
-        run_plugin_command(plugin_stage.output_process, plugin_root, proj_dir, label="generate_domain_context post-process")
 
 
 def _run_setup_extract(proj_dir, work_dir, script_dir, is_incremental=False,
@@ -1247,10 +1298,12 @@ def _run_setup_extract(proj_dir, work_dir, script_dir, is_incremental=False,
     plugin_root = plugin_config.root if plugin_config else None
 
     _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental, resume, submodules,
-                         plugin_stage=phase_stage, plugin_root=plugin_root)
+                         plugin_stage=phase_stage, plugin_root=plugin_root,
+                         plugin_config=plugin_config)
     phases_modified = _post_process_phases(proj_dir, work_dir, required_source_files, submodules, one_phase=one_phase)
     _run_generate_domain_context(proj_dir, work_dir, script_dir, resume and not phases_modified,
-                                 plugin_stage=context_stage, plugin_root=plugin_root)
+                                 plugin_stage=context_stage, plugin_root=plugin_root,
+                                 plugin_config=plugin_config)
 
     if not _setup_outputs_complete(work_dir):
         print(

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -1,11 +1,19 @@
 """FM-Agent plugin loading, validation, and execution."""
 
+import importlib.util
+import inspect
 import json
 import os
-import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from types import ModuleType
+from typing import Dict, List, Optional, get_args, get_origin
+
+
+# ---------------------------------------------------------------------------
+# Plugin data models
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -13,17 +21,13 @@ class PluginStageConfig:
     """Configuration for a single pipeline stage modification."""
 
     type: str = ""  # "pass", "replace", or "modify"
-    replace_cmd: Optional[str] = None
-    input_md: Optional[str] = None  # relative to plugin root
-    output_process: Optional[str] = None
+    input_md: Optional[str] = None  # relative to plugin root; optional for modify
 
     @staticmethod
     def from_dict(data: dict) -> "PluginStageConfig":
         return PluginStageConfig(
             type=data.get("type", ""),
-            replace_cmd=data.get("replace_cmd"),
             input_md=data.get("input_md"),
-            output_process=data.get("output_process"),
         )
 
     def validated(self) -> List[str]:
@@ -34,79 +38,185 @@ class PluginStageConfig:
                 "stage type must be 'pass', 'replace', or 'modify', "
                 f"got '{self.type}'"
             )
-        if self.type == "replace" and not self.replace_cmd:
-            errors.append("type=replace requires 'replace_cmd'")
-        if (
-            self.type == "modify"
-            and not self.input_md
-            and not self.output_process
-        ):
-            errors.append(
-                "type=modify requires at least one of 'input_md' or 'output_process'"
-            )
         return errors
 
 
 @dataclass
 class PluginConfig:
-    """Parsed plugin.json with resolved plugin root path."""
+    """Parsed plugin.json with resolved plugin root path and loaded module."""
 
     name: str
     version: str
     root: Path
     stages: Dict[str, PluginStageConfig] = field(default_factory=dict)
+    module: Optional[ModuleType] = None
 
     def get_stage(self, stage_name: str) -> Optional[PluginStageConfig]:
-        """Return the stage config for *stage_name*, or None if not configured."""
         return self.stages.get(stage_name)
 
+    # ── invoke helpers ─────────────────────────────────────────────
 
-def _resolve_command(cmd: str, plugin_root: Path) -> str:
-    """Rewrite relative file paths in *cmd* to absolute paths under *plugin_root*.
+    def invoke_replace(
+        self, stage_name: str, input_files: List[str], context: dict
+    ) -> List[str]:
+        fn = getattr(self.module, f"replace_{stage_name}")
+        return fn(input_files, context)
 
-    Each whitespace-delimited token in *cmd* is checked: if ``plugin_root / token``
-    points to an existing file, the token is replaced with its absolute path.
-    Tokens starting with ``/``, ``$``, or ``-`` are left unchanged.
+    def invoke_modify_input(self, stage_name: str, input_file: str) -> None:
+        fn = getattr(self.module, f"modify_{stage_name}_input")
+        fn(input_file)
+
+    def invoke_modify_output(
+        self, stage_name: str, output_files: List[str]
+    ) -> None:
+        fn = getattr(self.module, f"modify_{stage_name}_output")
+        fn(output_files)
+
+
+# ---------------------------------------------------------------------------
+# Function signature validation (inspect-based)
+# ---------------------------------------------------------------------------
+
+# Stage name → (param_types_tuple, return_type)
+_REPLACE_SPEC: Dict[str, tuple] = {
+    "generate_phase_plan": (
+        (List[str], dict),
+        List[str],
+    ),
+    "generate_domain_context": (
+        (List[str], dict),
+        List[str],
+    ),
+}
+
+_MODIFY_SPEC: Dict[str, tuple] = {
+    "generate_phase_plan": (
+        (str,),
+        (List[str],),
+    ),
+    "generate_domain_context": (
+        (str,),
+        (List[str],),
+    ),
+}
+
+
+def _types_match(actual, expected) -> bool:
+    """Compare two type annotations robustly across typing variants.
+
+    Handles ``list[str]`` vs ``typing.List[str]``, ``None`` vs ``type(None)``,
+    and nested generics.
     """
-    tokens = cmd.split()
-    resolved = []
-    for token in tokens:
-        if token.startswith("/") or token.startswith("$"):
-            resolved.append(token)
-            continue
-        candidate = plugin_root / token
-        if candidate.is_file():
-            resolved.append(str(candidate))
-        else:
-            resolved.append(token)
-    return " ".join(resolved)
+    origin_a = get_origin(actual)
+    origin_e = get_origin(expected)
+
+    # None vs NoneType
+    if actual is type(None) and expected is type(None):
+        return True
+    if actual is None and expected is type(None):
+        return True
+    if actual is type(None) and expected is None:
+        return True
+
+    # Resolve None originating from bare type(None) annotation
+    if actual is type(None):
+        actual = None
+    if expected is type(None):
+        expected = None
+
+    if (origin_a or actual) != (origin_e or expected):
+        return False
+    if origin_a is not None and origin_e is not None:
+        return get_args(actual) == get_args(expected)
+    return True
 
 
-def run_plugin_command(
-    cmd: str, plugin_root: Path, proj_dir: str, label: str = ""
-) -> None:
-    """Execute a plugin bash command with ``check=True`` so failure stops the pipeline.
+def _check_fn(module, fn_name: str, param_types: tuple, return_type) -> List[str]:
+    """Validate a single plugin function's signature.
 
-    Relative file paths in *cmd* are resolved under *plugin_root*. The command runs
-    in *proj_dir* with ``FM_AGENT_PLUGIN_ROOT`` set to the plugin root.
+    Checks: existence → callable → inspectable → param count → param types → return type.
+    Returns a list of error strings (empty on success).
     """
-    resolved = _resolve_command(cmd, plugin_root)
-    env = dict(os.environ, FM_AGENT_PLUGIN_ROOT=str(plugin_root))
+    errors: List[str] = []
+
+    fn = getattr(module, fn_name, None)
+    if fn is None:
+        return [f"  {fn_name}: function not found"]
+    if not callable(fn):
+        return [f"  {fn_name}: is not callable"]
+
     try:
-        subprocess.run(resolved, shell=True, check=True, cwd=proj_dir, env=env)
-    except subprocess.CalledProcessError as e:
-        label_prefix = f"Plugin {label}: " if label else ""
-        print(
-            f"[Pipeline] ERROR: {label_prefix}command exited with code {e.returncode}: "
-            f"{resolved}"
+        sig = inspect.signature(fn)
+    except (ValueError, TypeError):
+        return [f"  {fn_name}: cannot inspect signature"]
+
+    params = list(sig.parameters.values())
+    if len(params) != len(param_types):
+        errors.append(
+            f"  {fn_name}: expected {len(param_types)} parameter(s), "
+            f"got {len(params)}"
         )
-        raise
+
+    for i, param in enumerate(params):
+        if i >= len(param_types):
+            break
+        ann = param.annotation
+        if ann is inspect.Parameter.empty:
+            errors.append(
+                f"  {fn_name}: parameter '{param.name}' missing type annotation"
+            )
+        elif not _types_match(ann, param_types[i]):
+            errors.append(
+                f"  {fn_name}: parameter '{param.name}' type mismatch "
+                f"(expected {param_types[i]}, got {ann})"
+            )
+
+    if sig.return_annotation is inspect.Signature.empty:
+        errors.append(f"  {fn_name}: missing return type annotation")
+    elif not _types_match(sig.return_annotation, return_type):
+        errors.append(
+            f"  {fn_name}: return type mismatch "
+            f"(expected {return_type}, got {sig.return_annotation})"
+        )
+
+    return errors
+
+
+def _validate_stage_functions(
+    module: ModuleType, stages: Dict[str, PluginStageConfig]
+) -> List[str]:
+    """Check that every stage declared in plugin.json has matching functions."""
+    errors: List[str] = []
+
+    for stage_name, config in stages.items():
+        if config.type == "replace":
+            spec = _REPLACE_SPEC.get(stage_name)
+            if spec is not None:
+                errors += _check_fn(
+                    module, f"replace_{stage_name}", spec[0], spec[1]
+                )
+        elif config.type == "modify":
+            spec = _MODIFY_SPEC.get(stage_name)
+            if spec is not None:
+                errors += _check_fn(
+                    module, f"modify_{stage_name}_input", spec[0], type(None)
+                )
+                errors += _check_fn(
+                    module, f"modify_{stage_name}_output", spec[1], type(None)
+                )
+        # pass: nothing to validate
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Plugin loading
+# ---------------------------------------------------------------------------
 
 
 def _validate_plugin_json_content(
     plugin_dir: Path, name: str, data: dict
 ) -> Optional[PluginConfig]:
-    """Validate the content of a parsed plugin.json; returns PluginConfig or None."""
     plugin_name = data.get("name", "")
     if plugin_name != name:
         print(
@@ -119,7 +229,7 @@ def _validate_plugin_json_content(
         print(f"Invalid plugin '{name}': 'version' field is missing or empty")
         return None
 
-    stages = {}
+    stages: Dict[str, PluginStageConfig] = {}
     stages_data = data.get("stages", {})
     if not isinstance(stages_data, dict):
         print(f"Invalid plugin '{name}': 'stages' must be a JSON object")
@@ -158,11 +268,47 @@ def _validate_plugin_json_content(
     )
 
 
+def _load_plugin_module(plugin_dir: Path, name: str) -> Optional[ModuleType]:
+    """Import ``plugin.py`` from *plugin_dir* and return the module object.
+
+    Returns None after printing errors when the file is missing or unimportable.
+    """
+    plugin_py = plugin_dir / "plugin.py"
+    if not plugin_py.is_file():
+        print(
+            f"Invalid plugin '{name}': plugin.py not found — "
+            "every plugin must include a plugin.py file"
+        )
+        return None
+
+    module_name = f"fm_agent_plugin_{name}"
+    spec = importlib.util.spec_from_file_location(module_name, str(plugin_py))
+    if spec is None or spec.loader is None:
+        print(
+            f"Invalid plugin '{name}': could not create module spec "
+            f"for {plugin_py}"
+        )
+        return None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        print(
+            f"Invalid plugin '{name}': plugin.py raised an error during import: {exc}"
+        )
+        del sys.modules[module_name]
+        return None
+
+    return module
+
+
 def validate_plugin(plugin_dir: Path) -> Optional[PluginConfig]:
     """Validate a single plugin directory.
 
-    Returns a ``PluginConfig`` if the plugin is valid, otherwise ``None``
-    (after printing validation errors to stdout).
+    Checks plugin.json, imports plugin.py, and validates function signatures.
+    Returns a ``PluginConfig`` if valid, otherwise ``None``.
     """
     name = plugin_dir.name
     plugin_json = plugin_dir / "plugin.json"
@@ -193,18 +339,32 @@ def validate_plugin(plugin_dir: Path) -> Optional[PluginConfig]:
         )
         return None
 
-    return _validate_plugin_json_content(plugin_dir, name, data)
+    config = _validate_plugin_json_content(plugin_dir, name, data)
+    if config is None:
+        return None
+
+    module = _load_plugin_module(plugin_dir, name)
+    if module is None:
+        return None
+
+    func_errors = _validate_stage_functions(module, config.stages)
+    if func_errors:
+        print(
+            f"Invalid plugin '{name}': function signature errors:\n"
+            + "\n".join(func_errors)
+        )
+        return None
+
+    config.module = module
+    return config
 
 
 def load_plugins(plugins_dir: Path) -> Dict[str, PluginConfig]:
-    """Scan *plugins_dir* for subdirectories, validate each, return valid plugins.
-
-    Invalid plugins are printed with their error reason and skipped.
-    """
+    """Scan *plugins_dir* for subdirectories, validate each, return valid plugins."""
     if not plugins_dir.is_dir():
         return {}
 
-    plugins = {}
+    plugins: Dict[str, PluginConfig] = {}
     for entry in sorted(plugins_dir.iterdir()):
         if not entry.is_dir():
             continue


### PR DESCRIPTION
Closes #144

### Motivation

Previously, plugin stage customization relied on shell commands declared in `plugin.json`. While functional, this design required launching subprocesses, offered limited validation, and tightly coupled plugins to command-line execution.

This PR introduces a Python function-based plugin API, enabling plugins to be loaded as modules, validated at startup, and invoked directly from the pipeline.

### What changed

- Remove the `replace_cmd` and `output_process` fields from `plugin.json`
- Introduce `plugin.py` as the implementation entry point for plugins
- Define standard hook interfaces for stage replacement and input/output modification
- Validate plugin hook existence and function signatures during plugin loading via `inspect`
- Store imported plugin modules in `PluginConfig` with `invoke_replace`/`invoke_modify_input`/`invoke_modify_output` helpers
- Replace subprocess-based plugin execution with direct Python function invocation
- Update the `generate_phase_plan` and `generate_domain_context` stages to use the new API
- Enforce artifact contract: unified exit validation for all plugin types (pass/replace/modify/normal), ensuring stages always produce required outputs before proceeding
- Introduce `load_phases()` in `file_utils.py` as a single entry point for loading `phases.json` with validation; migrate all bare `open(phases.json)` calls

### Standard hook signatures

```python
# Replace a stage entirely
def replace_<stage>(input_files: list[str], context: dict) -> list[str]: ...

# Modify stage input (workflow markdown) in-place
def modify_<stage>_input(input_file: str) -> None: ...

# Modify stage output files in-place
def modify_<stage>_output(output_files: list[str]) -> None: ...
```

### Files changed

| File | Change |
|------|--------|
| `src/plugin.py` | Complete rewrite: drop command API, add inspect validation, module loading, invoke helpers |
| `src/pipeline_setup.py` | Replace `run_plugin_command()` calls with `invoke_replace()`/`invoke_modify_output()`; unified exit validation |
| `main.py` | Pass `plugin_config` to stage functions |