### PR TITLE
Fix incremental Erlang change detection

### DIFF
--- a/src/extract.py
+++ b/src/extract.py
@@ -665,14 +665,19 @@ def _function_spans(filepath, lang_key, proj_dir=None):
     return spans, raw_lines
 
 
-def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
+def run_extraction(
+    proj_dir, work_dir=None, force=False, verbose=False,
+    return_unavailable_backends=False,
+):
     """Run function extraction on a project directory.
 
     Reads phases.json from work_dir (or proj_dir), extracts functions from
     source files in proj_dir, writes them to work_dir/extracted_functions/,
     and validates the output.
 
-    Returns (written_count, skipped_count).
+    Returns (written_count, skipped_count). When
+    ``return_unavailable_backends`` is true, appends the languages whose
+    semantic full-project extraction backend failed.
     """
     if work_dir is None:
         work_dir = proj_dir
@@ -683,7 +688,13 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
     with open(phases_path, 'r') as f:
         phases_data = json.load(f)
 
-    registry_funcs, registry_langs = batch_extract_all(proj_dir)
+    registry_result = batch_extract_all(
+        proj_dir, include_unavailable=return_unavailable_backends
+    )
+    if return_unavailable_backends:
+        registry_funcs, registry_langs, unavailable_backends = registry_result
+    else:
+        registry_funcs, registry_langs = registry_result
     registry_funcs = {
         os.path.normcase(os.path.normpath(path)): funcs
         for path, funcs in registry_funcs.items()
@@ -772,7 +783,10 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
 
     if written == 0 and skipped == 0:
         logging.error("Nothing was extracted — check phases.json source_files paths.")
-        return written, skipped
+        return (
+            (written, skipped, unavailable_backends)
+            if return_unavailable_backends else (written, skipped)
+        )
 
     # --- Validation (Step 2) ---
     validation_failures = _validate_extraction(output_base, registry_langs=registry_langs)
@@ -791,7 +805,10 @@ def run_extraction(proj_dir, work_dir=None, force=False, verbose=False):
         if verbose:
             print("Validation passed: every extracted file contains exactly one function.")
 
-    return written, skipped
+    return (
+        (written, skipped, unavailable_backends)
+        if return_unavailable_backends else (written, skipped)
+    )
 
 
 def _validate_extraction(extracted_dir, registry_langs=None):

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -54,7 +54,10 @@ from .opencode_trace import run_opencode_traced
 from .llm_client import _llm_provider_client, _llm_json_call, build_llm_cli_command
 from .scope import _parse_issue_signals, rank_functions_in_file
 from .languages.codegraph import CodeGraphExtractor, try_codegraph_init
-from .languages import erlang as erlang_language
+from .languages.registry import (
+    extract_incremental_sources,
+    supports_incremental_source_extraction,
+)
 from .verification import _verify_single_file, _validate_single_bug, _generate_validation_summary, EXT_TO_LANG as _VERIFY_EXT_TO_LANG
 from .domain_knowledge import (
     format_domain_knowledge_bullets,
@@ -358,14 +361,13 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
     version, then compared by source text.
 
     Returns a dict mapping each changed file's absolute path to a dict with keys "added",
-    "removed", and "modified", each a sorted list of function names. For every
-    non-Erlang language that CodeGraph can index, both revisions are compared using
-    its class-qualified identifiers. Erlang uses its ELP semantic backend, while
-    CodeGraph-unavailable non-Erlang files retain the previous regex comparison.
-    Files with no detectable function-level change are omitted. Raises
+    "removed", and "modified", each a sorted list of function names. Languages
+    with a registered semantic source backend use it for both revisions; other
+    languages use CodeGraph when available, then the regex fallback. Files with
+    no detectable function-level change are omitted. Raises
     subprocess.CalledProcessError if proj_dir is not a git repository or
-    old_commit_id is not a valid commit, and RuntimeError if ELP cannot extract
-    a changed Erlang revision.
+    old_commit_id is not a valid commit, and RuntimeError if a registered source
+    backend cannot extract a changed revision.
     """
     # Pathspecs limiting git to recognized source-file extensions (e.g. "*.py", "*.cpp").
     pathspecs = [f"*.{ext}" for ext in EXT_TO_LANG]
@@ -396,18 +398,20 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
         and _is_under_submodules(f, submodules)
     ]
 
-    # Erlang uses ELP below; every other changed language gets a CodeGraph
-    # comparison when both indexes are usable.
     file_languages = {
         rel_path: EXT_TO_LANG[rel_path.rsplit(".", 1)[-1]]
         for rel_path in files
         if "." in rel_path
         and rel_path.rsplit(".", 1)[-1] in EXT_TO_LANG
     }
+    source_backend_languages = {
+        lang_key for lang_key in set(file_languages.values())
+        if supports_incremental_source_extraction(lang_key)
+    }
     codegraph_file_languages = {
         rel_path: lang_key
         for rel_path, lang_key in file_languages.items()
-        if lang_key != "erlang"
+        if lang_key not in source_backend_languages
     }
     codegraph_langs = set(codegraph_file_languages.values())
     current_codegraph = (
@@ -449,32 +453,41 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
         finally:
             os.unlink(tmp_path)
 
-    current_erlang_sources = {}
-    baseline_erlang_sources = {}
+    current_source_batches = defaultdict(dict)
+    baseline_source_batches = defaultdict(dict)
     for rel_path, lang_key in file_languages.items():
-        if lang_key != "erlang":
+        if lang_key not in source_backend_languages:
             continue
         abs_path = os.path.abspath(os.path.join(proj_dir, rel_path))
         if os.path.exists(abs_path):
             with open(abs_path, "r", errors="replace") as f:
-                current_erlang_sources[abs_path] = f.read()
+                current_source_batches[lang_key][abs_path] = f.read()
         if _path_exists_in_commit(rel_path):
-            baseline_erlang_sources[abs_path] = _git(
+            baseline_source_batches[lang_key][abs_path] = _git(
                 "show", f"{old_commit_id}:{rel_path}"
             )
 
-    current_erlang_functions = erlang_language.extract_functions_from_sources(
-        proj_dir, current_erlang_sources
-    ) if current_erlang_sources else {}
-    baseline_erlang_functions = erlang_language.extract_functions_from_sources(
-        proj_dir, baseline_erlang_sources
-    ) if baseline_erlang_sources else {}
-    if current_erlang_functions is None or baseline_erlang_functions is None:
-        raise RuntimeError(
-            "ELP extraction failed while comparing Erlang changes; incremental "
-            "analysis was aborted to avoid treating unavailable results as removed "
-            "functions."
+    current_source_functions = {}
+    baseline_source_functions = {}
+    for lang_key in sorted(source_backend_languages):
+        current_result = (
+            extract_incremental_sources(
+                proj_dir, lang_key, current_source_batches[lang_key]
+            ) if current_source_batches[lang_key] else {}
         )
+        baseline_result = (
+            extract_incremental_sources(
+                proj_dir, lang_key, baseline_source_batches[lang_key]
+            ) if baseline_source_batches[lang_key] else {}
+        )
+        if current_result is None or baseline_result is None:
+            raise RuntimeError(
+                f"Incremental source extraction failed for {lang_key}; analysis "
+                "was aborted to avoid treating unavailable results as removed "
+                "functions."
+            )
+        current_source_functions[lang_key] = current_result
+        baseline_source_functions[lang_key] = baseline_result
 
     result = {}
     for rel_path in files:
@@ -483,16 +496,17 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
         if not lang_key:
             continue
 
-        # Use CodeGraph for both revisions whenever it can index this non-Erlang
-        # file. This keeps the comparison identity identical to the extracted
-        # function filename (for example, ``LocalStorage::Flush``) and avoids
-        # bare-name collisions between same-named C++ members.
+        # Use CodeGraph for both revisions whenever this language does not supply
+        # a semantic source backend and CodeGraph can index the file. This keeps
+        # comparison identifiers aligned with extracted filenames (for example,
+        # ``LocalStorage::Flush``) and avoids bare-name collisions.
         abs_path = os.path.abspath(os.path.join(proj_dir, rel_path))
         current_exists = os.path.exists(abs_path)
         old_exists = _path_exists_in_commit(rel_path)
         rel_key = _normalized_relative_path(proj_dir, rel_path)
+        uses_source_backend = lang_key in source_backend_languages
         use_codegraph = (
-            lang_key != "erlang"
+            not uses_source_backend
             and current_codegraph is not None
             and baseline_codegraph is not None
             and (not current_exists or current_coverage.get(rel_key, False))
@@ -503,14 +517,18 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
             new_funcs = current_codegraph.get(rel_key, {})
             old_funcs = baseline_codegraph.get(rel_key, {})
         else:
-            if lang_key != "erlang" and codegraph_langs:
+            if not uses_source_backend and codegraph_langs:
                 logging.warning(
                     "CodeGraph could not provide both revisions for %s; using "
                     "legacy regex comparison.", rel_path,
                 )
-            if lang_key == "erlang":
-                new_funcs = dict(current_erlang_functions.get(abs_path, ()))
-                old_funcs = dict(baseline_erlang_functions.get(abs_path, ()))
+            if uses_source_backend:
+                new_funcs = dict(
+                    current_source_functions[lang_key].get(abs_path, ())
+                )
+                old_funcs = dict(
+                    baseline_source_functions[lang_key].get(abs_path, ())
+                )
             else:
                 new_funcs = (
                     dict(extract_functions_from_file(abs_path, lang_key))

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -469,6 +469,7 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
 
     current_source_functions = {}
     baseline_source_functions = {}
+    available_source_backend_languages = set()
     for lang_key in sorted(source_backend_languages):
         current_result = (
             extract_incremental_sources(
@@ -481,13 +482,15 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
             ) if baseline_source_batches[lang_key] else {}
         )
         if current_result is None or baseline_result is None:
-            raise RuntimeError(
-                f"Incremental source extraction failed for {lang_key}; analysis "
-                "was aborted to avoid treating unavailable results as removed "
-                "functions."
+            logging.warning(
+                "Incremental source extraction is unavailable for %s; using "
+                "legacy comparison for that language.",
+                lang_key,
             )
+            continue
         current_source_functions[lang_key] = current_result
         baseline_source_functions[lang_key] = baseline_result
+        available_source_backend_languages.add(lang_key)
 
     result = {}
     for rel_path in files:
@@ -504,7 +507,7 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
         current_exists = os.path.exists(abs_path)
         old_exists = _path_exists_in_commit(rel_path)
         rel_key = _normalized_relative_path(proj_dir, rel_path)
-        uses_source_backend = lang_key in source_backend_languages
+        uses_source_backend = lang_key in available_source_backend_languages
         use_codegraph = (
             not uses_source_backend
             and current_codegraph is not None

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -362,9 +362,10 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
     non-Erlang language that CodeGraph can index, both revisions are compared using
     its class-qualified identifiers. Erlang uses its ELP semantic backend, while
     CodeGraph-unavailable non-Erlang files retain the previous regex comparison.
-    Files with no detectable function-level
-    change are omitted. Raises subprocess.CalledProcessError if proj_dir is not a
-    git repository or old_commit_id is not a valid commit.
+    Files with no detectable function-level change are omitted. Raises
+    subprocess.CalledProcessError if proj_dir is not a git repository or
+    old_commit_id is not a valid commit, and RuntimeError if ELP cannot extract
+    a changed Erlang revision.
     """
     # Pathspecs limiting git to recognized source-file extensions (e.g. "*.py", "*.cpp").
     pathspecs = [f"*.{ext}" for ext in EXT_TO_LANG]
@@ -448,11 +449,31 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
         finally:
             os.unlink(tmp_path)
 
-    def _erlang_funcs_from_source(rel_path, source):
-        """Extract Erlang functions from an in-memory source version via ELP."""
-        path = os.path.abspath(os.path.join(proj_dir, rel_path))
-        return dict(
-            erlang_language.extract_functions_from_source(proj_dir, path, source)
+    current_erlang_sources = {}
+    baseline_erlang_sources = {}
+    for rel_path, lang_key in file_languages.items():
+        if lang_key != "erlang":
+            continue
+        abs_path = os.path.abspath(os.path.join(proj_dir, rel_path))
+        if os.path.exists(abs_path):
+            with open(abs_path, "r", errors="replace") as f:
+                current_erlang_sources[abs_path] = f.read()
+        if _path_exists_in_commit(rel_path):
+            baseline_erlang_sources[abs_path] = _git(
+                "show", f"{old_commit_id}:{rel_path}"
+            )
+
+    current_erlang_functions = erlang_language.extract_functions_from_sources(
+        proj_dir, current_erlang_sources
+    ) if current_erlang_sources else {}
+    baseline_erlang_functions = erlang_language.extract_functions_from_sources(
+        proj_dir, baseline_erlang_sources
+    ) if baseline_erlang_sources else {}
+    if current_erlang_functions is None or baseline_erlang_functions is None:
+        raise RuntimeError(
+            "ELP extraction failed while comparing Erlang changes; incremental "
+            "analysis was aborted to avoid treating unavailable results as removed "
+            "functions."
         )
 
     result = {}
@@ -488,17 +509,8 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
                     "legacy regex comparison.", rel_path,
                 )
             if lang_key == "erlang":
-                if current_exists:
-                    with open(abs_path, "r", errors="replace") as f:
-                        new_funcs = _erlang_funcs_from_source(rel_path, f.read())
-                else:
-                    new_funcs = {}
-                old_funcs = (
-                    _erlang_funcs_from_source(
-                        rel_path, _git("show", f"{old_commit_id}:{rel_path}")
-                    )
-                    if old_exists else {}
-                )
+                new_funcs = dict(current_erlang_functions.get(abs_path, ()))
+                old_funcs = dict(baseline_erlang_functions.get(abs_path, ()))
             else:
                 new_funcs = (
                     dict(extract_functions_from_file(abs_path, lang_key))

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -352,11 +352,47 @@ def _codegraph_functions_at_revision(proj_dir, revision, file_languages):
 class _ChangedFunctionResults(dict):
     """Changed-function mapping plus semantic backends that could not compare."""
 
-    def __init__(self, *args, unavailable_source_backend_languages=(), **kwargs):
+    def __init__(
+        self,
+        *args,
+        source_backend_languages=(),
+        unavailable_source_backend_languages=(),
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
+        self.source_backend_languages = frozenset(source_backend_languages)
         self.unavailable_source_backend_languages = frozenset(
             unavailable_source_backend_languages
         )
+
+
+def _raise_if_incremental_source_backends_unavailable(
+    changed_functions, stage4_unavailable_backends=(),
+):
+    """Stop before downstream stages can consume stale semantic extraction."""
+    stale_extraction_backends = (
+        changed_functions.source_backend_languages
+        & frozenset(stage4_unavailable_backends)
+    )
+    unavailable_backends = (
+        changed_functions.unavailable_source_backend_languages
+        | stale_extraction_backends
+    )
+    if not unavailable_backends:
+        return
+
+    languages = ", ".join(sorted(unavailable_backends))
+    if stale_extraction_backends:
+        raise RuntimeError(
+            "Cannot safely complete incremental analysis because Stage 4 did "
+            f"not refresh extracted source files for: {languages}. Install or "
+            "repair the required language backend, then retry."
+        )
+    raise RuntimeError(
+        "Cannot safely complete incremental analysis because semantic source "
+        f"extraction is unavailable for: {languages}. Install or repair the "
+        "required language backend, then retry."
+    )
 
 
 def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
@@ -509,6 +545,7 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
         available_source_backend_languages.add(lang_key)
 
     result = _ChangedFunctionResults(
+        source_backend_languages=source_backend_languages,
         unavailable_source_backend_languages=unavailable_source_backend_languages
     )
     for rel_path in files:
@@ -898,7 +935,13 @@ def run_incremental_pipeline(
     # stale index would yield boundaries for the old code. try_codegraph_init rebuilds by
     # default; no-op when codegraph is uninstalled (extraction then falls back to regex).
     try_codegraph_init(proj_dir)
-    run_extraction(proj_dir, work_dir=work_dir, force=True, verbose=True)
+    _written, _skipped, stage4_unavailable_backends = run_extraction(
+        proj_dir,
+        work_dir=work_dir,
+        force=True,
+        verbose=True,
+        return_unavailable_backends=True,
+    )
     logging.info("  -> function sources re-extracted; metadata sidecars retained.")
 
     # 5. Collect changed functions by comparing against the old version of functions in commit_id
@@ -913,14 +956,9 @@ def run_incremental_pipeline(
         "  -> %d changed file(s): %d added, %d modified, %d removed function(s).",
         len(changed_functions), n_added, n_modified, n_removed,
     )
-    unavailable_backends = changed_functions.unavailable_source_backend_languages
-    if unavailable_backends:
-        languages = ", ".join(sorted(unavailable_backends))
-        raise RuntimeError(
-            "Cannot safely complete incremental analysis because semantic "
-            f"source extraction is unavailable for: {languages}. Install or "
-            "repair the required language backend, then retry."
-        )
+    _raise_if_incremental_source_backends_unavailable(
+        changed_functions, stage4_unavailable_backends
+    )
 
     # 5b. Delete extracted-function files for functions (or whole source files) that were
     #     removed since old_commit_id. Re-extraction never rewrites these, so without this

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -54,6 +54,7 @@ from .opencode_trace import run_opencode_traced
 from .llm_client import _llm_provider_client, _llm_json_call, build_llm_cli_command
 from .scope import _parse_issue_signals, rank_functions_in_file
 from .languages.codegraph import CodeGraphExtractor, try_codegraph_init
+from .languages import erlang as erlang_language
 from .verification import _verify_single_file, _validate_single_bug, _generate_validation_summary, EXT_TO_LANG as _VERIFY_EXT_TO_LANG
 from .domain_knowledge import (
     format_domain_knowledge_bullets,
@@ -359,8 +360,9 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
     Returns a dict mapping each changed file's absolute path to a dict with keys "added",
     "removed", and "modified", each a sorted list of function names. For every
     non-Erlang language that CodeGraph can index, both revisions are compared using
-    its class-qualified identifiers. Erlang and CodeGraph-unavailable files retain
-    the previous regex-based comparison. Files with no detectable function-level
+    its class-qualified identifiers. Erlang uses its ELP semantic backend, while
+    CodeGraph-unavailable non-Erlang files retain the previous regex comparison.
+    Files with no detectable function-level
     change are omitted. Raises subprocess.CalledProcessError if proj_dir is not a
     git repository or old_commit_id is not a valid commit.
     """
@@ -393,9 +395,8 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
         and _is_under_submodules(f, submodules)
     ]
 
-    # Erlang intentionally remains on its existing extraction path: its ELP
-    # integration has different project and tooling requirements. Every other
-    # changed language gets a CodeGraph comparison when both indexes are usable.
+    # Erlang uses ELP below; every other changed language gets a CodeGraph
+    # comparison when both indexes are usable.
     file_languages = {
         rel_path: EXT_TO_LANG[rel_path.rsplit(".", 1)[-1]]
         for rel_path in files
@@ -447,6 +448,13 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
         finally:
             os.unlink(tmp_path)
 
+    def _erlang_funcs_from_source(rel_path, source):
+        """Extract Erlang functions from an in-memory source version via ELP."""
+        path = os.path.abspath(os.path.join(proj_dir, rel_path))
+        return dict(
+            erlang_language.extract_functions_from_source(proj_dir, path, source)
+        )
+
     result = {}
     for rel_path in files:
         ext = rel_path.rsplit(".", 1)[-1] if "." in rel_path else ""
@@ -479,13 +487,26 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
                     "CodeGraph could not provide both revisions for %s; using "
                     "legacy regex comparison.", rel_path,
                 )
-            new_funcs = (
-                dict(extract_functions_from_file(abs_path, lang_key))
-                if current_exists else {}
-            )
-            old_funcs = (
-                _funcs_from_commit(rel_path, lang_key, ext) if old_exists else {}
-            )
+            if lang_key == "erlang":
+                if current_exists:
+                    with open(abs_path, "r", errors="replace") as f:
+                        new_funcs = _erlang_funcs_from_source(rel_path, f.read())
+                else:
+                    new_funcs = {}
+                old_funcs = (
+                    _erlang_funcs_from_source(
+                        rel_path, _git("show", f"{old_commit_id}:{rel_path}")
+                    )
+                    if old_exists else {}
+                )
+            else:
+                new_funcs = (
+                    dict(extract_functions_from_file(abs_path, lang_key))
+                    if current_exists else {}
+                )
+                old_funcs = (
+                    _funcs_from_commit(rel_path, lang_key, ext) if old_exists else {}
+                )
 
         added = sorted(n for n in new_funcs if n not in old_funcs)
         removed = sorted(n for n in old_funcs if n not in new_funcs)

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -349,6 +349,16 @@ def _codegraph_functions_at_revision(proj_dir, revision, file_languages):
         shutil.rmtree(parent_dir, ignore_errors=True)
 
 
+class _ChangedFunctionResults(dict):
+    """Changed-function mapping plus semantic backends that could not compare."""
+
+    def __init__(self, *args, unavailable_source_backend_languages=(), **kwargs):
+        super().__init__(*args, **kwargs)
+        self.unavailable_source_backend_languages = frozenset(
+            unavailable_source_backend_languages
+        )
+
+
 def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
     """
     Determine which functions changed between commit old_commit_id and the current working
@@ -364,7 +374,11 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
     "removed", and "modified", each a sorted list of function names. Languages
     with a registered semantic source backend use it for both revisions; other
     languages use CodeGraph when available, then the regex fallback. Files with
-    no detectable function-level change are omitted. Raises
+    no detectable function-level change are omitted. If a registered semantic
+    source backend is unavailable, that language is omitted rather than passed
+    to a less-capable extractor; its key is recorded on the returned mapping's
+    ``unavailable_source_backend_languages`` attribute so the pipeline can
+    stop before silently skipping its changed functions. Raises
     subprocess.CalledProcessError if proj_dir is not a git repository or
     old_commit_id is not a valid commit, and RuntimeError if a registered source
     backend cannot extract a changed revision.
@@ -470,6 +484,7 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
     current_source_functions = {}
     baseline_source_functions = {}
     available_source_backend_languages = set()
+    unavailable_source_backend_languages = set()
     for lang_key in sorted(source_backend_languages):
         current_result = (
             extract_incremental_sources(
@@ -483,16 +498,19 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
         )
         if current_result is None or baseline_result is None:
             logging.warning(
-                "Incremental source extraction is unavailable for %s; using "
-                "legacy comparison for that language.",
+                "Incremental source extraction is unavailable for %s; "
+                "function-level comparison for that language is unsafe.",
                 lang_key,
             )
+            unavailable_source_backend_languages.add(lang_key)
             continue
         current_source_functions[lang_key] = current_result
         baseline_source_functions[lang_key] = baseline_result
         available_source_backend_languages.add(lang_key)
 
-    result = {}
+    result = _ChangedFunctionResults(
+        unavailable_source_backend_languages=unavailable_source_backend_languages
+    )
     for rel_path in files:
         ext = rel_path.rsplit(".", 1)[-1] if "." in rel_path else ""
         lang_key = EXT_TO_LANG.get(ext)
@@ -507,6 +525,11 @@ def _collect_changed_functions(proj_dir, old_commit_id, submodules=None):
         current_exists = os.path.exists(abs_path)
         old_exists = _path_exists_in_commit(rel_path)
         rel_key = _normalized_relative_path(proj_dir, rel_path)
+        if lang_key in unavailable_source_backend_languages:
+            # Semantic-only languages cannot safely fall back to a local regex
+            # extractor. The caller will abort the incremental pipeline after
+            # retaining other languages' comparison results.
+            continue
         uses_source_backend = lang_key in available_source_backend_languages
         use_codegraph = (
             not uses_source_backend
@@ -890,6 +913,14 @@ def run_incremental_pipeline(
         "  -> %d changed file(s): %d added, %d modified, %d removed function(s).",
         len(changed_functions), n_added, n_modified, n_removed,
     )
+    unavailable_backends = changed_functions.unavailable_source_backend_languages
+    if unavailable_backends:
+        languages = ", ".join(sorted(unavailable_backends))
+        raise RuntimeError(
+            "Cannot safely complete incremental analysis because semantic "
+            f"source extraction is unavailable for: {languages}. Install or "
+            "repair the required language backend, then retry."
+        )
 
     # 5b. Delete extracted-function files for functions (or whole source files) that were
     #     removed since old_commit_id. Re-extraction never rewrites these, so without this

--- a/src/languages/erlang.py
+++ b/src/languages/erlang.py
@@ -482,27 +482,8 @@ def _symbol_line_span(symbol_range: dict) -> tuple[int, int]:
     return start, end
 
 
-def extract_functions_from_source(
-    proj_dir: str, filepath: str, source: str
-) -> list[tuple[str, str]]:
-    """Extract Erlang functions from an in-memory version of ``filepath``.
-
-    ELP identifies functions by document URI, while the supplied source is
-    authoritative after ``didOpen``. This lets incremental change detection
-    parse Git-baseline source without checking out a separate project workspace.
-    """
-    path = os.path.abspath(filepath)
-    try:
-        with ElpClient(proj_dir) as client:
-            client.initialize(path, source)
-            symbols = client.request(
-                "textDocument/documentSymbol",
-                {"textDocument": {"uri": Path(path).as_uri()}},
-            ) or []
-    except Exception as exc:
-        logging.warning("ELP Erlang extraction unavailable for %s: %s", path, exc)
-        return []
-
+def _functions_from_document_symbols(path: str, source: str, symbols: list[dict]):
+    """Convert ELP document symbols into this project's function representation."""
     source_index = _SourceIndex.build(source)
     functions = []
     seen = set()
@@ -523,6 +504,53 @@ def extract_functions_from_source(
         seen.add(function_id)
         functions.append((function_id, source_index.source_for_range(symbol_range)))
     return functions
+
+
+def extract_functions_from_sources(
+    proj_dir: str, sources: dict[str, str]
+) -> dict[str, list[tuple[str, str]]] | None:
+    """Extract several in-memory Erlang documents through one ELP session.
+
+    ``None`` denotes an unavailable or failed ELP session. It is deliberately
+    different from a successful empty function list, so callers never mistake
+    tooling failure for removal of every function in a source file.
+    """
+    normalized_sources = {
+        os.path.abspath(path): source for path, source in sources.items()
+    }
+    if not normalized_sources:
+        return {}
+
+    paths = list(normalized_sources)
+    try:
+        with ElpClient(proj_dir) as client:
+            first_path = paths[0]
+            client.initialize(first_path, normalized_sources[first_path])
+            for path in paths[1:]:
+                client.open_document(path, normalized_sources[path])
+
+            result = {}
+            for path in paths:
+                symbols = client.request(
+                    "textDocument/documentSymbol",
+                    {"textDocument": {"uri": Path(path).as_uri()}},
+                ) or []
+                result[path] = _functions_from_document_symbols(
+                    path, normalized_sources[path], symbols
+                )
+            return result
+    except Exception as exc:
+        logging.warning("ELP Erlang extraction unavailable for %s: %s", proj_dir, exc)
+        return None
+
+
+def extract_functions_from_source(
+    proj_dir: str, filepath: str, source: str
+) -> list[tuple[str, str]] | None:
+    """Extract one in-memory Erlang document, preserving ELP failure state."""
+    path = os.path.abspath(filepath)
+    result = extract_functions_from_sources(proj_dir, {path: source})
+    return None if result is None else result[path]
 
 
 def _analyze_project_uncached(proj_dir: str) -> ErlangAnalysis:

--- a/src/languages/erlang.py
+++ b/src/languages/erlang.py
@@ -482,6 +482,49 @@ def _symbol_line_span(symbol_range: dict) -> tuple[int, int]:
     return start, end
 
 
+def extract_functions_from_source(
+    proj_dir: str, filepath: str, source: str
+) -> list[tuple[str, str]]:
+    """Extract Erlang functions from an in-memory version of ``filepath``.
+
+    ELP identifies functions by document URI, while the supplied source is
+    authoritative after ``didOpen``. This lets incremental change detection
+    parse Git-baseline source without checking out a separate project workspace.
+    """
+    path = os.path.abspath(filepath)
+    try:
+        with ElpClient(proj_dir) as client:
+            client.initialize(path, source)
+            symbols = client.request(
+                "textDocument/documentSymbol",
+                {"textDocument": {"uri": Path(path).as_uri()}},
+            ) or []
+    except Exception as exc:
+        logging.warning("ELP Erlang extraction unavailable for %s: %s", path, exc)
+        return []
+
+    source_index = _SourceIndex.build(source)
+    functions = []
+    seen = set()
+    for symbol in symbols:
+        if symbol.get("kind") != _FUNCTION_KIND:
+            continue
+        symbol_range = _symbol_range(symbol)
+        if not symbol_range:
+            continue
+        symbol_uri = _symbol_uri(symbol, Path(path).as_uri())
+        try:
+            function_id = _function_id(symbol_uri, symbol.get("name", ""))
+        except ValueError:
+            logging.warning("Ignoring malformed ELP function symbol: %r", symbol)
+            continue
+        if function_id in seen:
+            continue
+        seen.add(function_id)
+        functions.append((function_id, source_index.source_for_range(symbol_range)))
+    return functions
+
+
 def _analyze_project_uncached(proj_dir: str) -> ErlangAnalysis:
     proj_dir = os.path.abspath(proj_dir)
     files = _erlang_files(proj_dir)

--- a/src/languages/erlang.py
+++ b/src/languages/erlang.py
@@ -684,17 +684,23 @@ def _analyze_project(proj_dir: str) -> ErlangAnalysis:
     return analysis
 
 
-def _analysis_or_empty(proj_dir: str) -> ErlangAnalysis:
+def _analysis_or_none(proj_dir: str) -> ErlangAnalysis | None:
     try:
         return _analyze_project(proj_dir)
     except Exception as exc:
         logging.warning("ELP Erlang analysis unavailable for %s: %s", proj_dir, exc)
-        return ErlangAnalysis(functions={}, edges={})
+        return None
 
 
-def batch_extract(proj_dir: str) -> dict:
-    """Return ``{abs_filepath: [(function_id, body)]}`` for Erlang files."""
-    return _analysis_or_empty(proj_dir).functions
+def _analysis_or_empty(proj_dir: str) -> ErlangAnalysis:
+    analysis = _analysis_or_none(proj_dir)
+    return analysis or ErlangAnalysis(functions={}, edges={})
+
+
+def batch_extract(proj_dir: str) -> dict | None:
+    """Return extracted functions, or ``None`` when the ELP session failed."""
+    analysis = _analysis_or_none(proj_dir)
+    return None if analysis is None else analysis.functions
 
 
 def function_spans(proj_dir: str, filepath: str):

--- a/src/languages/erlang.py
+++ b/src/languages/erlang.py
@@ -100,7 +100,7 @@ class ElpClient:
     """Minimal synchronous LSP client for an ``elp server`` subprocess."""
 
     def __init__(self, proj_dir: str):
-        self.proj_dir = os.path.abspath(proj_dir)
+        self.proj_dir = str(Path(proj_dir).resolve())
         self.root_uri = Path(self.proj_dir).as_uri()
         self.timeout = _timeout_seconds()
         self._messages: queue.Queue = queue.Queue()
@@ -109,6 +109,11 @@ class ElpClient:
         self._write_lock = threading.Lock()
         self._proc = None
         self._reader = None
+
+    @staticmethod
+    def document_uri(path: str) -> str:
+        """Return the canonical URI used consistently for every ELP request."""
+        return Path(path).resolve().as_uri()
 
     def __enter__(self):
         self._proc = subprocess.Popen(
@@ -249,7 +254,7 @@ class ElpClient:
             "textDocument/didOpen",
             {
                 "textDocument": {
-                    "uri": document.as_uri(),
+                    "uri": self.document_uri(path),
                     "languageId": "erlang",
                     "version": 1,
                     "text": source,
@@ -493,7 +498,7 @@ def _functions_from_document_symbols(path: str, source: str, symbols: list[dict]
         symbol_range = _symbol_range(symbol)
         if not symbol_range:
             continue
-        symbol_uri = _symbol_uri(symbol, Path(path).as_uri())
+        symbol_uri = _symbol_uri(symbol, ElpClient.document_uri(path))
         try:
             function_id = _function_id(symbol_uri, symbol.get("name", ""))
         except ValueError:
@@ -522,21 +527,28 @@ def extract_functions_from_sources(
         return {}
 
     paths = list(normalized_sources)
+    resolved_paths = {path: str(Path(path).resolve()) for path in paths}
     try:
         with ElpClient(proj_dir) as client:
             first_path = paths[0]
-            client.initialize(first_path, normalized_sources[first_path])
+            client.initialize(
+                resolved_paths[first_path], normalized_sources[first_path]
+            )
             for path in paths[1:]:
-                client.open_document(path, normalized_sources[path])
+                client.open_document(resolved_paths[path], normalized_sources[path])
 
             result = {}
             for path in paths:
                 symbols = client.request(
                     "textDocument/documentSymbol",
-                    {"textDocument": {"uri": Path(path).as_uri()}},
+                    {
+                        "textDocument": {
+                            "uri": client.document_uri(resolved_paths[path])
+                        }
+                    },
                 ) or []
                 result[path] = _functions_from_document_symbols(
-                    path, normalized_sources[path], symbols
+                    resolved_paths[path], normalized_sources[path], symbols
                 )
             return result
     except Exception as exc:
@@ -575,7 +587,7 @@ def _analyze_project_uncached(proj_dir: str) -> ErlangAnalysis:
             source = sources[path]
             source_index = _SourceIndex.build(source)
             caller_module = _caller_module(path)
-            uri = Path(path).as_uri()
+            uri = client.document_uri(path)
             symbols = client.request(
                 "textDocument/documentSymbol", {"textDocument": {"uri": uri}}
             ) or []

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -16,16 +16,18 @@ from src.languages import erlang as _erlang
 class LanguageHandler:
     """Extraction and call-graph backend for one language.
 
-    batch_extract(proj_dir)             -> {abs_filepath: [(func_name, body)]}
+    batch_extract(proj_dir)             -> {abs_filepath: [(func_name, body)]} | None
     call_edges(proj_dir)                -> {caller_fqn: {callee_fqns}}
     function_spans(proj_dir, filepath)  -> [(func_name, start_idx, end_idx)] | None
     incremental_source_extract(proj_dir, sources)
         -> {abs_filepath: [(func_name, body)]} | None
 
     Each function handles its own backend (e.g. codegraph) internally.
-    batch_extract / call_edges return an empty dict when the backend is
-    unavailable; function_spans returns None so the caller can fall back to the
-    regex extractor for that file.
+    batch_extract returns ``None`` when a semantic backend cannot safely
+    extract its sources, distinct from a successful empty dict. call_edges
+    returns an empty dict when its backend is unavailable; function_spans
+    returns None so the caller can fall back to the regex extractor for that
+    file.
 
     To add a new language:
       1. Create src/languages/<lang>.py implementing batch_extract, call_edges,
@@ -52,19 +54,27 @@ REGISTRY: dict = {
 }
 
 
-def batch_extract_all(proj_dir: str) -> tuple:
+def batch_extract_all(proj_dir: str, include_unavailable: bool = False) -> tuple:
     """Call batch_extract for every registered language and merge results.
 
     Returns (funcs, langs) where funcs is {abs_filepath: [(func_name, body)]}
-    and langs is the set of language keys that returned data.
+    and langs is the set of language keys that returned data. When
+    ``include_unavailable`` is true, appends the set of languages whose
+    semantic extraction backend failed.
     """
     funcs = {}
     langs = set()
+    unavailable = set()
     for lang, handler in REGISTRY.items():
         result = handler.batch_extract(proj_dir)
+        if result is None:
+            unavailable.add(lang)
+            continue
         if result:
             funcs.update(result)
             langs.add(lang)
+    if include_unavailable:
+        return funcs, langs, unavailable
     return funcs, langs
 
 

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -19,6 +19,8 @@ class LanguageHandler:
     batch_extract(proj_dir)             -> {abs_filepath: [(func_name, body)]}
     call_edges(proj_dir)                -> {caller_fqn: {callee_fqns}}
     function_spans(proj_dir, filepath)  -> [(func_name, start_idx, end_idx)] | None
+    incremental_source_extract(proj_dir, sources)
+        -> {abs_filepath: [(func_name, body)]} | None
 
     Each function handles its own backend (e.g. codegraph) internally.
     batch_extract / call_edges return an empty dict when the backend is
@@ -27,13 +29,14 @@ class LanguageHandler:
 
     To add a new language:
       1. Create src/languages/<lang>.py implementing batch_extract, call_edges,
-         and function_spans
+         function_spans, and optionally incremental_source_extract
       2. Import it here and add one entry to REGISTRY
     No other files need to change.
     """
     batch_extract: Callable
     call_edges: Callable
     function_spans: Callable
+    incremental_source_extract: Callable | None = None
 
 
 REGISTRY: dict = {
@@ -45,7 +48,7 @@ REGISTRY: dict = {
     "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges,       function_spans=_rust.function_spans),
     "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges, function_spans=_javascript.function_spans),
     "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges, function_spans=_typescript.function_spans),
-    "erlang":     LanguageHandler(batch_extract=_erlang.batch_extract,     call_edges=_erlang.call_edges,     function_spans=_erlang.function_spans),
+    "erlang":     LanguageHandler(batch_extract=_erlang.batch_extract,     call_edges=_erlang.call_edges,     function_spans=_erlang.function_spans, incremental_source_extract=_erlang.extract_functions_from_sources),
 }
 
 
@@ -78,6 +81,26 @@ def function_spans_for_file(proj_dir: str, filepath: str, lang_key: str):
     if handler is None:
         return None
     return handler.function_spans(proj_dir, filepath)
+
+
+def supports_incremental_source_extraction(lang_key: str) -> bool:
+    """Return whether a language supplies semantic extraction for source snapshots."""
+    handler = REGISTRY.get(lang_key)
+    return handler is not None and handler.incremental_source_extract is not None
+
+
+def extract_incremental_sources(proj_dir: str, lang_key: str, sources: dict):
+    """Dispatch source-snapshot extraction to a language's registered backend.
+
+    The backend returns ``None`` when it is unavailable or fails, distinct from
+    a successful extraction whose individual source files contain no functions.
+    """
+    handler = REGISTRY.get(lang_key)
+    if handler is None or handler.incremental_source_extract is None:
+        raise ValueError(
+            f"Language {lang_key!r} has no incremental source extraction backend"
+        )
+    return handler.incremental_source_extract(proj_dir, sources)
 
 
 def call_edges_all(proj_dir: str, lang_keys) -> tuple:


### PR DESCRIPTION
Fixes #156 
## Summary

Fix incremental change detection for Erlang functions.

## Root cause

The incremental path used the regex extractor, which intentionally returns no functions for Erlang because Erlang extraction is handled by ELP.

## Changes

- Parse current and baseline Erlang source through ELP document symbols.
- Compare ELP function IDs and source bodies to classify changes.
- Add a regression test for a modified Erlang function.