### PR TITLE
feat: add WP (weakest precondition) bottom-up reasoning

### DIFF
--- a/config.py
+++ b/config.py
@@ -69,6 +69,7 @@ _ENV_MAP: dict[str, tuple[str, str]] = {
     "BUG_VALIDATION_MAX_RETRIES": ("runtime", "bug_validation_max_retries"),
     "OPENCODE_TIMEOUT_SECONDS": ("runtime", "opencode_timeout_s"),
     "FM_AGENT_DOMAIN_KNOWLEDGE": ("runtime", "domain_knowledge_paths"),
+    "REASONING_DIRECTION": ("runtime", "reasoning_direction"),
     # [scope]
     "SCOPE_TOP_K": ("scope", "top_k"),
     "SCOPE_LLM_TRIGGER_FUNCS": ("scope", "llm_trigger_funcs"),
@@ -125,6 +126,11 @@ class RuntimeCfg(_Section):
     # Extra domain-knowledge markdown paths (os.pathsep- or newline-separated);
     # env-driven, so no committed default.
     domain_knowledge_paths: str = ""
+    # Reasoning direction: "topdown" = strongest postcondition (forward, default),
+    # "bottomup" = weakest precondition (backward). WP derives the minimal
+    # pre-condition from the spec's post-condition, checking spec_pre ⊨ wp at
+    # function entry. The two directions find complementary bug classes.
+    reasoning_direction: Literal["topdown", "bottomup"] = "topdown"
 
 
 class ScopeCfg(_Section):
@@ -254,6 +260,9 @@ OPENCODE_MAX_RETRIES = settings.runtime.opencode_max_retries
 BUG_VALIDATION_MAX_RETRIES = settings.runtime.bug_validation_max_retries
 OPENCODE_TIMEOUT_SECONDS = settings.runtime.opencode_timeout_s
 
+REASONING_DIRECTION = settings.runtime.reasoning_direction
+REASONER_WP_MODEL = LLM_MODEL
+
 SCOPE_TOP_K = settings.scope.top_k
 SCOPE_LLM_TRIGGER_FUNCS = settings.scope.llm_trigger_funcs
 SCOPE_LLM_TOP_K = settings.scope.llm_top_k
@@ -281,6 +290,8 @@ __all__ = [
     "OPENCODE_MAX_RETRIES",
     "BUG_VALIDATION_MAX_RETRIES",
     "OPENCODE_TIMEOUT_SECONDS",
+    "REASONING_DIRECTION",
+    "REASONER_WP_MODEL",
     "SCOPE_TOP_K",
     "SCOPE_LLM_TRIGGER_FUNCS",
     "SCOPE_LLM_TOP_K",

--- a/docs/wp_reasoning_design.md
+++ b/docs/wp_reasoning_design.md
@@ -1,0 +1,814 @@
+# FM-Agent 自底向上推理（最弱前置条件）设计方案
+
+## 1. 背景与动机
+
+### 1.1 当前架构：自顶向下 / 最强后置条件 (SP)
+
+FM-Agent 当前采用 **Hoare 逻辑的前向推理**（Strongest Postcondition, SP）：
+
+```
+spec_pre → block_1 → post_1 → block_2 → post_2 → ... → post_n
+                                                          ↓
+                                               检查: post_n ⊨ spec_post?
+```
+
+**核心代码路径**：`reasoner.py::reasoner()` 逐 block 前向推导，`prompts.py::_generate_block_post_condition()` 让 LLM 从 pre-condition + code block 推导 post-condition，`prompts.py::_check_post_implies_spec()` 检查推导出的 post-condition 是否蕴含 spec 的 post-condition。
+
+**调用图方向**：`generate_topdown_layers.py::_compute_layers()` 基于 `callers_map` 做拓扑排序——Layer 0 = 无调用者的入口函数，逐层向下到叶子函数。
+
+### 1.2 SP 的局限
+
+| 局限 | 说明 |
+|------|------|
+| **遗漏型缺陷检测弱** | SP 从前向后推导，如果代码缺少某个分支（如未处理某种输入情况），SP 推导出的 post-condition 可能恰好"不包含"该情况，从而与 spec post-condition 不产生矛盾——遗漏被掩盖 |
+| **前置条件验证不足** | SP 只在函数出口检查 post-condition，不验证入口的 pre-condition 是否充分。如果 spec 的 pre-condition 太弱（没约束住某些边界），SP 无法发现 |
+| **被调用者信息未利用** | 自顶向下处理时，分析 caller 时 callee 的 spec 可能尚未生成或未被传播。caller 无法获知 callee 的精确前置要求 |
+| **虚假路径** | SP 对不可达路径也会推导 post-condition，可能产生虚假的 MISMATCH |
+
+### 1.3 提议：自底向上 / 最弱前置条件 (WP)
+
+```
+spec_post ← block_n ← wp_n ← block_{n-1} ← wp_{n-1} ← ... ← wp_1
+                                                                    ↓
+                                              检查: spec_pre ⊨ wp_1?
+```
+
+WP 从 spec 的 post-condition 出发，**逆向**推导每个 block 需要什么前置条件才能保证后续 post-condition 成立。最终在函数入口检查 spec 的 pre-condition 是否蕴含推导出的 wp_1。
+
+**调用图方向**：自底向上——Layer 0 = 无被调用者的叶子函数，逐层向上到入口函数。分析 caller 时，所有 callee 的 WP 已知，可精确传播 callee 的前置要求。
+
+## 2. 理论基础
+
+### 2.1 Hoare 逻辑中的 SP 与 WP
+
+| 属性 | SP (最强后置条件) | WP (最弱前置条件) |
+|------|-------------------|-------------------|
+| **方向** | 前向 (forward) | 后向 (backward) |
+| **定义** | SP(S, P) = 执行 S 后成立的最强条件，给定 P 在执行前成立 | WP(S, Q) = 保证 Q 在 S 执行后成立的最弱条件 |
+| **计算** | 从 P 出发，经过 S，推导出 post | 从 Q 出发，逆向经过 S，推导出 pre |
+| **验证** | SP(S, P) ⊨ Q ? | P ⊨ WP(S, Q) ? |
+| **发现** | 代码做了错误的事 | 代码没有保证应保证的事 |
+
+### 2.2 WP 的关键规则（谓词变换器）
+
+```
+WP(skip, Q)           = Q
+WP(x := e, Q)         = Q[x/e]          (代入)
+WP(S1; S2, Q)         = WP(S1, WP(S2, Q))
+WP(if b then S1 else S2, Q) = (b ∧ WP(S1, Q)) ∨ (¬b ∧ WP(S2, Q))
+WP(while b do S, Q)   = I ∧ ...          (需要循环不变式 I)
+WP(return e, Q)       = Q[return_value/e]
+WP(throw e, Q)        = Q[exception/e]   (异常路径)
+```
+
+在 FM-Agent 中，这些规则不通过形式化计算实现，而是通过 LLM 推理完成——LLM 扮演谓词变换器的角色，给定 code block 和 post-condition，计算 weakest pre-condition。
+
+### 2.3 SP 与 WP 的互补性
+
+SP 和 WP 发现的 Bug 类型不同：
+
+| Bug 类型 | SP 能发现 | WP 能发现 |
+|----------|-----------|-----------|
+| 代码计算出错误值 | ✓ (post 不蕴含 spec) | ✓ (wp 包含值约束) |
+| 代码缺少分支/遗漏情况 | △ (可能被掩盖) | ✓ (wp 包含必须处理的情况) |
+| 前置条件太弱 | ✗ | ✓ (spec_pre 不蕴含 wp) |
+| 前置条件太强 | ✓ (post 无法满足) | △ |
+| 不可达路径矛盾 | △ (可能虚假 MISMATCH) | ✓ (wp 为 false 表示不可达) |
+| 被调用者要求未满足 | ✗ | ✓ (callee WP 向上传播) |
+
+**双向交叉验证**：同时运行 SP 和 WP，取并集，可最大化 Bug 召回率。
+
+## 3. 总体架构
+
+### 3.1 设计原则
+
+1. **Spec 生成不变**：`[SPEC]`/`[INFO]` 注释块是方向无关的（同时包含 pre 和 post），两种推理方式共用同一套 spec
+2. **WP 推理器独立**：新增 `wp_reasoner()`，与现有 `reasoner()` 并行，通过配置选择
+3. **分层算法复用**：`_compute_layers()` 参数化方向，自底向上只需翻转 callee/caller 角色
+4. **验证管线兼容**：`streaming_reasoner` → `_verify_single_file` 增加方向参数，路由到对应 reasoner
+5. **Trace 结构统一**：WP 的 LLM 调用记录到同一 trace 体系，新增 `stage: "wp_verification"` 标签
+
+### 3.2 架构全景
+
+```
+                    ┌─────────────────────────┐
+                    │     fm-agent.toml       │
+                    │  reasoning_direction =  │
+                    │  "topdown" | "bottomup" │
+                    └────────────┬────────────┘
+                                 │
+                    ┌────────────▼────────────┐
+                    │       main.py            │
+                    │  --reasoning-direction   │
+                    └────────────┬────────────┘
+                                 │
+              ┌──────────────────┼──────────────────┐
+              │                  │                  │
+    ┌─────────▼────────┐ ┌──────▼───────┐ ┌────────▼────────┐
+    │ Stage 1-5: 不变  │ │ 层次计算      │ │ Stage 6: 推理    │
+    │ (spec 生成)      │ │ (方向感知)    │ │ (方向路由)      │
+    └──────────────────┘ └──────────────┘ └──────────────────┘
+                                              │
+                           ┌──────────────────┼──────────────────┐
+                           │                  │                  │
+                    ┌──────▼──────┐    ┌──────▼──────┐    ┌──────▼──────┐
+                    │ topdown     │    │ bottomup    │    │ bidirectional│
+                    │ _compute_   │    │ _compute_   │    │ (未来扩展)   │
+                    │ layers()    │    │ bottomup_   │    │             │
+                    │             │    │ layers()    │    │             │
+                    └─────────────┘    └─────────────┘    └─────────────┘
+                           │                  │
+                    ┌──────▼──────┐    ┌──────▼──────┐
+                    │ reasoner()  │    │ wp_reasoner │
+                    │ (SP/前向)   │    │ () (WP/后向)│
+                    └─────────────┘    └─────────────┘
+```
+
+## 4. 详细设计
+
+### 4.1 WP 推理器 (`src/reasoner.py`)
+
+新增 `wp_reasoner()` 函数，与现有 `reasoner()` 对称：
+
+```python
+def wp_reasoner(func, spec, info, language, trace_context=None):
+    """Weakest Precondition reasoner — backward chain derivation.
+
+    与 reasoner() 的区别:
+    - 从 spec_post_condition 出发, 逆向遍历 blocks
+    - 每个 block 计算 WP (而非 post-condition)
+    - 在函数入口检查 spec_pre ⊨ wp_1 (而非在出口检查 post_n ⊨ spec_post)
+    """
+    trace_context = trace_context or {}
+    trace_dir = trace_context.get("trace_dir")
+
+    # Step 1: 解析 pre/post condition (与 reasoner 相同)
+    pre_condition, spec_post_condition = _parse_spec_conditions(spec)
+    if not pre_condition or not spec_post_condition:
+        return "Failed to parse pre/post conditions from the spec."
+
+    # Step 2: 分块 (与 reasoner 相同, 复用 _split_into_blocks_braced)
+    blocks = _split_into_blocks_braced(func, language)
+
+    # Step 3: 逆向遍历 — 从最后一个 block 开始, 向前推导 WP
+    current_post = spec_post_condition  # 从 spec 的 post-condition 出发
+
+    for i in reversed(range(len(blocks))):
+        block = blocks[i]
+        trace_meta = {
+            "function_id": trace_context.get("function_id"),
+            "function_file": trace_context.get("function_file"),
+            "language": language,
+            "block_index": i,
+            "block_count": len(blocks),
+            "direction": "backward",  # 标记方向
+        }
+
+        # 3a: 计算 WP — 给定 code block 和 post-condition, 推导 pre-condition
+        wp = _generate_block_wp(
+            block,
+            current_post,
+            info,
+            language,
+            trace_dir=trace_dir,
+            trace_meta=trace_meta,
+        )
+        if not wp:
+            return f"Failed to generate weakest pre-condition for block {i+1}."
+
+        # 3b: 在函数入口 (i==0) 或终止语句处, 检查 spec_pre 是否蕴含 wp
+        is_first_block = (i == 0)
+        if is_first_block or _has_terminating_statement(block, language):
+            passed, stmts, reason, wp_cond = _check_pre_implies_wp(
+                block,
+                wp,
+                pre_condition,  # spec 的 pre-condition (调用者保证的)
+                info,
+                language,
+                trace_dir=trace_dir,
+                trace_meta=trace_meta,
+            )
+            if not passed:
+                return (
+                    f"Verification FAILED (WP).\n"
+                    f"Statements triggering the violation:\n{stmts}\n\n"
+                    f"Weakest pre-condition:\n{wp_cond}\n\n"
+                    f"Reason for violation:\n{reason}"
+                )
+
+        # 3c: 当前 block 的 WP 成为前一个 block 的 post-condition
+        current_post = wp
+
+    return ("The function passes the WP verification. "
+            "The specification's pre-condition is sufficient to guarantee "
+            "the post-condition across all code paths.")
+```
+
+**与 `reasoner()` 的关键差异**：
+
+| 维度 | `reasoner()` (SP) | `wp_reasoner()` (WP) |
+|------|--------------------|-----------------------|
+| 遍历方向 | `for i in range(len(blocks))` (正向) | `for i in reversed(range(len(blocks)))` (逆向) |
+| 初始条件 | `current_pre = pre_condition` | `current_post = spec_post_condition` |
+| 每步计算 | `_generate_block_post_condition(block, pre, ...)` | `_generate_block_wp(block, post, ...)` |
+| 状态传递 | `current_pre = post_condition` (post 变 pre) | `current_post = wp` (wp 变 post) |
+| 验证时机 | 终止语句或最后 block | 函数入口 (i==0) 或终止语句 |
+| 验证内容 | `post_n ⊨ spec_post?` | `spec_pre ⊨ wp_1?` |
+| 验证函数 | `_check_post_implies_spec()` | `_check_pre_implies_wp()` |
+
+### 4.2 提示词设计 (`src/prompts.py`)
+
+#### 4.2.1 `_generate_block_wp()` — WP 生成
+
+```python
+def _generate_block_wp(block, post_condition, knowledge, language,
+                       trace_dir=None, trace_meta=None):
+    """计算 code block 的最弱前置条件 (逆向推理).
+
+    与 _generate_block_post_condition() 对称:
+    - 输入: code block + post-condition (而非 pre-condition)
+    - 输出: weakest pre-condition (而非 post-condition)
+    - 推理方向: 后向 (给定目标 Q, 求最小前提 P 使 {P} S {Q})
+    """
+    info_str = f"\nAdditional context:\n{knowledge}" if knowledge else ""
+    messages = [
+        {"role": "system", "content": (
+            f"You are an expert in formal verification of {language} programs. "
+            f"Given a {language} code block and its post-condition (what must be true "
+            "after execution), compute the WEAKEST PRE-CONDITION: the minimal condition "
+            "that must hold before the block to GUARANTEE the post-condition holds after. "
+            "Cover all execution paths including early returns, exceptions, and normal "
+            f"flow-through. Apply {language}-specific semantics. "
+            "The weakest pre-condition should be as permissive as possible while still "
+            "guaranteeing the post-condition. Express it in natural language and formal logic."
+        )},
+        {"role": "user", "content": (
+            f"Programming language: {language}\n\n"
+            f"Post-condition (must hold AFTER this block):\n{post_condition}\n\n"
+            f"Code block:\n```{language.lower()}\n{block}\n```\n"
+            f"{info_str}\n"
+            "Compute the weakest pre-condition. Return only a valid JSON object: "
+            '{"pre_condition": "..."}. Do not include Markdown, tags, or prose '
+            "outside the JSON object."
+        )}
+    ]
+    meta = {
+        "purpose": "generate_block_wp",
+        "summary": "Generated weakest pre-condition for code block",
+        "direction": "backward",
+        **(trace_meta or {}),
+    }
+    return _llm_json_call(
+        _llm_provider_client,
+        REASONER_WP_MODEL,  # 新增配置, 默认同 REASONER_POST_CONDITION_MODEL
+        messages,
+        _parse_wp_json,
+        '{"pre_condition": "non-empty string"}',
+        trace_dir=trace_dir,
+        trace_meta=meta,
+    )
+
+
+def _parse_wp_json(data):
+    """Validate the WP response (mirrors _parse_post_condition_json)."""
+    if not isinstance(data, dict):
+        raise ValueError("WP JSON must be an object")
+    pre_condition = data.get("pre_condition")
+    if not isinstance(pre_condition, str) or not pre_condition.strip():
+        raise ValueError("WP JSON requires a non-empty string field: pre_condition")
+    return pre_condition.strip()
+```
+
+**提示词设计要点**：
+
+1. **"weakest" 强调**：明确要求 LLM 计算**最弱**前置条件（尽可能宽松），而非任意前置条件。这确保只有真正必要的约束才被检查
+2. **"guarantee" 语义**：强调"保证"关系——WP 必须足以保证 post-condition 成立，而非仅仅是相关条件
+3. **路径覆盖**：与 SP 提示词一致，要求覆盖所有执行路径（early return, exception, normal flow）
+4. **输出格式**：与 `_generate_block_post_condition` 对称，只是字段名从 `post_condition` 改为 `pre_condition`
+
+#### 4.2.2 `_check_pre_implies_wp()` — 前置条件蕴含检查
+
+```python
+def _check_pre_implies_wp(block, wp, spec_pre_condition, knowledge, language,
+                          trace_dir=None, trace_meta=None):
+    """检查 spec_pre_condition 是否蕴含 wp (最弱前置条件).
+
+    与 _check_post_implies_spec() 对称:
+    - SP 检查: post (代码实际做的) ⊨ spec_post (规约要求的)? — 前向矛盾
+    - WP 检查: spec_pre (调用者保证的) ⊨ wp (代码需要的)? — 后向不足
+
+    如果 spec_pre 不蕴含 wp, 说明存在满足 spec_pre 但不满足 wp 的输入,
+    即调用者的保证不足以让代码正确运行 — 这是潜在 Bug.
+    """
+    info_str = f"\nAdditional context:\n{knowledge}" if knowledge else ""
+    lang_expertise = _LANGUAGE_EXPERTISE.get(language.lower(), ...)
+    messages = [
+        {"role": "system", "content": (
+            lang_expertise +
+            "Given a code block, its weakest pre-condition A (what the code REQUIRES "
+            "before execution to guarantee correctness), and a specification pre-condition "
+            "B (what callers GUARANTEE before calling), determine whether there exists a "
+            "concrete valid input where B holds but A does not. "
+            "If such an input exists, the function may fail because the caller's guarantees "
+            "are insufficient — the code requires more than what the spec promises. "
+            "Focus on finding CONCRETE COUNTEREXAMPLES: specific input values where B is "
+            "satisfied but A is violated. "
+            "Check these common violation patterns:\n"
+            "  1. B allows input ranges/shapes that A restricts (e.g., B says 'non-negative' "
+            "but A requires 'positive').\n"
+            "  2. B does not constrain a variable that A requires to be in a specific state.\n"
+            "  3. B allows null/empty/edge-case values that A excludes.\n"
+            "For each potential violation, construct a specific input, verify B holds, "
+            "then check if A is violated. "
+            "Return JSON: {\"verdict\": \"MATCH|MISMATCH\", \"counterexample\": ..., "
+            "\"offending_statements\": ..., \"reason\": ...}"
+        )},
+        {"role": "user", "content": (
+            f"Programming language: {language}\n\n"
+            f"Code block:\n```{language.lower()}\n{block}\n```\n\n"
+            f"Condition A (weakest pre-condition — what the code requires):\n{wp}\n\n"
+            f"Condition B (spec pre-condition — what callers guarantee):\n{spec_pre_condition}\n"
+            f"{info_str}\n"
+            "Is there a concrete valid input where B holds but A does not? "
+            "Provide a specific counterexample if any case exists. "
+            "Return only the JSON object."
+        )}
+    ]
+    # 重试逻辑与 _check_post_implies_spec 完全一致 (复用 MAX_SPC_ITER)
+    # ...
+```
+
+**与 `_check_post_implies_spec()` 的关键差异**：
+
+| 维度 | SP 检查 | WP 检查 |
+|------|---------|---------|
+| 条件 A | 代码实际 post-condition (做了什么) | 代码需要的 WP (要求什么) |
+| 条件 B | spec post-condition (应做什么) | spec pre-condition (保证什么) |
+| 检查方向 | A ⊨ B? (代码做了的 ⊇ 应做的) | B ⊨ A? (保证的 ⊇ 需要的) |
+| 反例含义 | 存在输入使代码行为违反 spec | 存在输入满足 spec_pre 但不满足 WP |
+| Bug 性质 | 代码做错了 | 代码没保证到 |
+
+### 4.3 自底向上分层计算 (`src/generate_topdown_layers.py`)
+
+#### 4.3.1 新增 `_compute_bottomup_layers()`
+
+```python
+def _compute_bottomup_layers(phase_fqns, callees_map, callers_map):
+    """自底向上拓扑分层: Layer 0 = 叶子函数 (无 callees), 逐层向上到入口.
+
+    与 _compute_layers() 的区别:
+    - 就绪条件: "所有 callees 已分配" (而非 "所有 callers 已分配")
+    - SCC 检测: 基于 callees_map 构建 SCC (而非 callers_map)
+    - 效果: 叶子函数先处理, 入口函数后处理
+
+    这样在分析 caller 时, 所有 callee 的 WP 已计算完毕,
+    可将 callee 的前置要求传播给 caller.
+    """
+    phase_set = set(phase_fqns)
+    remaining = set(phase_set)
+    assigned = {}
+    layers = []
+
+    while remaining:
+        ready = set()
+        for fqn in remaining:
+            # 关键区别: 检查 callees 是否都已分配 (而非 callers)
+            phase_callees = callees_map.get(fqn, set()) & phase_set
+            unassigned_callees = phase_callees - set(assigned.keys())
+            if not unassigned_callees:
+                ready.add(fqn)
+
+        if ready:
+            layer_idx = len(layers)
+            for fqn in ready:
+                assigned[fqn] = layer_idx
+            layers.append({"layer": layer_idx, "functions": sorted(ready),
+                          "cycle_resolution": False})
+            remaining -= ready
+        else:
+            # 环检测 — 基于 callees_map (而非 callers_map) 构建 SCC
+            sub_edges = {}
+            for fqn in remaining:
+                sub_edges[fqn] = callees_map.get(fqn, set()) & remaining
+
+            sccs = _tarjan_scc(remaining, sub_edges)
+
+            # 构建 SCC DAG 并分配层次 (与 _compute_layers 逻辑对称)
+            fqn_to_scc = {}
+            for i, scc in enumerate(sccs):
+                for fqn in scc:
+                    fqn_to_scc[fqn] = i
+
+            scc_callees = defaultdict(set)  # scc_idx -> callees SCC
+            for fqn in remaining:
+                scc_i = fqn_to_scc[fqn]
+                for callee_fqn in callees_map.get(fqn, set()) & remaining:
+                    scc_j = fqn_to_scc[callee_fqn]
+                    if scc_i != scc_j:
+                        scc_callees[scc_i].add(scc_j)
+
+            # 拓扑排序: callee SCC 先分配
+            scc_assigned = {}
+            scc_remaining = set(range(len(sccs)))
+
+            while scc_remaining:
+                scc_ready = set()
+                for scc_idx in scc_remaining:
+                    unassigned_scc_callees = scc_callees.get(scc_idx, set()) - set(scc_assigned.keys())
+                    if not unassigned_scc_callees:
+                        scc_ready.add(scc_idx)
+
+                if not scc_ready:
+                    # 退化处理 (与 _compute_layers 一致)
+                    layer_idx = len(layers)
+                    all_fqns = set()
+                    for scc_idx in scc_remaining:
+                        all_fqns.update(sccs[scc_idx])
+                    for fqn in all_fqns:
+                        assigned[fqn] = layer_idx
+                    layers.append({"layer": layer_idx, "functions": sorted(all_fqns),
+                                  "cycle_resolution": True})
+                    remaining -= all_fqns
+                    break
+
+                layer_idx = len(layers)
+                layer_fqns = set()
+                is_cycle = False
+                for scc_idx in scc_ready:
+                    scc_assigned[scc_idx] = layer_idx
+                    layer_fqns.update(sccs[scc_idx])
+                    if len(sccs[scc_idx]) > 1:
+                        is_cycle = True
+
+                for fqn in layer_fqns:
+                    assigned[fqn] = layer_idx
+                layers.append({"layer": layer_idx, "functions": sorted(layer_fqns),
+                              "cycle_resolution": is_cycle})
+                remaining -= layer_fqns
+                scc_remaining -= scc_ready
+
+    return layers
+```
+
+#### 4.3.2 新增 `generate_bottomup_layers()`
+
+```python
+def generate_bottomup_layers(proj_dir, phase_numbers=None, extra_call_edges=None):
+    """生成自底向上层次 JSON (与 generate_topdown_layers 对称).
+
+    输出文件: phase_XX_bottomup_layers.json
+    结构与 topdown_layers.json 完全一致, 只是层次顺序反转.
+    """
+    # ... (与 generate_topdown_layers 结构相同, 仅替换 _compute_layers 为 _compute_bottomup_layers)
+    layers = _compute_bottomup_layers(phase_fqns, callees_map, callers_map)
+
+    out_path = os.path.join(output_dir, f"phase_{phase_num:02d}_bottomup_layers.json")
+    # ...
+```
+
+#### 4.3.3 分层对比
+
+```
+自顶向下 (_compute_layers):          自底向上 (_compute_bottomup_layers):
+┌─────────────────────┐              ┌─────────────────────┐
+│ Layer 0: entry()    │              │ Layer 0: leaf_a()   │
+│   calls helper()    │              │   (no callees)      │
+├─────────────────────┤              ├─────────────────────┤
+│ Layer 1: helper()   │              │ Layer 1: helper()   │
+│   calls leaf_a()    │              │   calls leaf_a()    │
+├─────────────────────┤              ├─────────────────────┤
+│ Layer 2: leaf_a()   │              │ Layer 2: entry()    │
+│   (no callees)      │              │   calls helper()    │
+└─────────────────────┘              └─────────────────────┘
+```
+
+### 4.4 被调用者 WP 传播
+
+这是自底向上推理的**核心优势**：分析 caller 时，所有 callee 的 WP 已知。
+
+#### 4.4.1 WP 传播机制
+
+```python
+def _collect_callee_wps(fqn, phase_fqns, wp_cache, callees_map):
+    """收集 fqn 的所有被调用者的 WP, 作为 [INFO] 补充上下文.
+
+    在自底向上模式下, 分析 caller 时 callee 的 WP 已计算完毕.
+    将 callee 的 WP 摘要注入到 caller 的推理上下文中, 使 WP 计算更精确:
+    - caller 必须在调用 callee 前保证 callee 的 WP
+    - 这些约束成为 caller WP 的一部分
+    """
+    callee_wps = {}
+    for callee_fqn in callees_map.get(fqn, set()) & phase_fqns:
+        if callee_fqn in wp_cache:
+            callee_wps[callee_fqn] = wp_cache[callee_fqn]
+    return callee_wps
+
+
+def _format_callee_wps(callee_wps):
+    """将 callee WP 格式化为 info 文本, 注入到 _generate_block_wp 的 knowledge 参数."""
+    if not callee_wps:
+        return ""
+    lines = ["Callee pre-condition requirements (from WP analysis):"]
+    for callee, wp in callee_wps.items():
+        short_name = callee.split("::")[-1]
+        lines.append(f"  {short_name} requires: {wp[:200]}...")  # 截断防止上下文爆炸
+    return "\n".join(lines)
+```
+
+#### 4.4.2 WP 缓存
+
+```python
+# 在 pipeline 层维护 wp_cache
+wp_cache = {}  # fqn -> wp_string
+
+# 每个函数推理完成后, 缓存其 WP
+def _verify_single_file_wp(file_path, ..., wp_cache=None):
+    result = wp_reasoner(func, spec, info, language, ...)
+    if wp_cache is not None:
+        fqn = _file_to_fqn(file_path, proj_dir)
+        # 提取 wp_1 (函数入口的 WP) 缓存
+        wp_cache[fqn] = extract_wp_from_result(result)
+    return result
+```
+
+#### 4.4.3 传播效果示例
+
+```
+分析顺序 (自底向上):
+
+1. leaf_a(): WP = "input x > 0 and list is non-empty"
+   → wp_cache["leaf_a"] = "input x > 0 and list is non-empty"
+
+2. helper(): 调用 leaf_a(x, lst)
+   → _collect_callee_wps 发现 leaf_a 的 WP
+   → 注入到 helper 的 WP 计算上下文:
+     "leaf_a requires: x > 0 and list is non-empty"
+   → helper 的 WP 自动包含: "x > 0 and lst is non-empty"
+     (因为 helper 必须在调用 leaf_a 前保证这些条件)
+
+3. entry(): 调用 helper(x, lst)
+   → _collect_callee_wps 发现 helper 的 WP
+   → entry 的 WP 自动包含 helper 的所有前置要求
+```
+
+### 4.5 验证流程集成
+
+#### 4.5.1 `verification.py` 修改
+
+```python
+from .reasoner import reasoner, wp_reasoner, _parse_spec_conditions
+
+def _verify_single_file(file_path, output_dir, proj_dir=None, work_dir=None,
+                        reasoning_direction="topdown", wp_cache=None):
+    """验证单个函数文件 — 根据方向路由到 SP 或 WP reasoner."""
+    # ... (解析 func, spec, info, language — 不变)
+
+    if reasoning_direction == "bottomup":
+        # 注入 callee WP 上下文
+        callee_wp_info = ""
+        if wp_cache:
+            callee_wps = _collect_callee_wps(fqn, phase_fqns, wp_cache, callees_map)
+            callee_wp_info = _format_callee_wps(callee_wps)
+        enhanced_info = (info or "") + ("\n\n" + callee_wp_info if callee_wp_info else "")
+
+        result = wp_reasoner(func, spec, enhanced_info, language, trace_context=...)
+        # 缓存 WP 供上层 caller 使用
+        if wp_cache is not None:
+            wp_cache[fqn] = extract_wp_from_result(result)
+    else:
+        result = reasoner(func, spec, info, language, trace_context=...)
+
+    # ... (写入结果文件 — 不变)
+```
+
+#### 4.5.2 `streaming_reasoner()` 修改
+
+```python
+def streaming_reasoner(input_dir, output_dir, ..., reasoning_direction="topdown"):
+    """增加 reasoning_direction 参数, 传递给 _verify_single_file."""
+    # 自底向上模式需要维护 wp_cache
+    wp_cache = {} if reasoning_direction == "bottomup" else None
+
+    # ... 其余逻辑不变, 仅在调用 _verify_single_file 时传递方向和 wp_cache
+    future = executor.submit(
+        _verify_single_file,
+        file_path, output_dir,
+        proj_dir=proj_dir, work_dir=work_dir,
+        reasoning_direction=reasoning_direction,
+        wp_cache=wp_cache,
+    )
+```
+
+### 4.6 配置与 CLI
+
+#### 4.6.1 `fm-agent.toml` 新增
+
+```toml
+[runtime]
+# 推理方向: "topdown" (SP/前向, 默认) 或 "bottomup" (WP/后向)
+reasoning_direction = "topdown"
+```
+
+#### 4.6.2 `config.py` 修改
+
+```python
+class RuntimeCfg(_Section):
+    # ... 现有字段 ...
+    reasoning_direction: Literal["topdown", "bottomup"] = "topdown"
+
+# 模块级常量
+REASONING_DIRECTION = settings.runtime.reasoning_direction
+REASONER_WP_MODEL = LLM_MODEL  # WP 推理使用同一模型, 可独立配置
+
+# 加入 __all__
+__all__ = [
+    ...,
+    "REASONING_DIRECTION",
+    "REASONER_WP_MODEL",
+]
+```
+
+#### 4.6.3 `main.py` CLI 参数
+
+```python
+parser.add_argument(
+    "--reasoning-direction",
+    choices=["topdown", "bottomup"],
+    default=None,
+    help="Reasoning direction: 'topdown' (strongest postcondition, forward) "
+         "or 'bottomup' (weakest precondition, backward). "
+         "Defaults to fm-agent.toml [runtime] reasoning_direction.",
+)
+
+# 在 run_pipeline 中:
+reasoning_direction = args.reasoning_direction or REASONING_DIRECTION
+
+# Stage 5: 根据方向生成分层
+if reasoning_direction == "bottomup":
+    print("[Pipeline] Stage 5/6: Generating bottom-up layers...")
+    generate_bottomup_layers(work_dir, extra_call_edges=extra_call_edges)
+else:
+    print("[Pipeline] Stage 5/6: Generating topdown layers...")
+    generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
+
+# Stage 6: 传递方向到验证管线
+streaming_reasoner(..., reasoning_direction=reasoning_direction)
+```
+
+## 5. 关键设计决策
+
+### 5.1 为什么不修改现有 `reasoner()` 而是新建 `wp_reasoner()`？
+
+- **单一职责**：SP 和 WP 是两种不同的推理范式，逻辑差异大（遍历方向、验证点、检查内容都不同）
+- **向后兼容**：现有 `reasoner()` 经过充分测试，不应冒险修改
+- **可组合性**：未来双向模式需要同时调用两者，独立函数更易组合
+
+### 5.2 为什么 WP 仍然用 block 粒度而非语句粒度？
+
+- **与 SP 对称**：复用 `_split_into_blocks_braced()` 和 `GRANULARITY` 配置
+- **LLM 上下文效率**：40 行 block 让 LLM 有足够上下文理解控制流，语句级太碎
+- **可行性**：LLM 可以在单个 block 内处理 if/else/loop 的 WP（通过谓词变换器规则的隐式应用）
+
+### 5.3 为什么 WP 检查在函数入口 (i==0) 而非出口？
+
+- **WP 语义**：WP 的目标是在函数入口验证 pre-condition 的充分性。逆向推导到 i==0 时，wp_1 就是整个函数的 WP
+- **终止语句处理**：在逆向遍历中遇到终止语句（return/throw）时，也做检查——此时 WP 包含返回值的约束，检查的是该返回路径的前置条件是否被满足
+- **与 SP 对称**：SP 在最后 block 或终止语句检查 post-condition；WP 在第一 block 或终止语句检查 pre-condition
+
+### 5.4 被调用者 WP 传播为什么用缓存而非修改 [INFO] block？
+
+- **[INFO] block 在 spec 阶段生成**：修改它需要重新生成 spec，代价大
+- **运行时注入更灵活**：wp_cache 在 pipeline 运行时维护，不污染 spec 文件
+- **截断控制**：传播时截断 WP 文本（200 字符），防止上下文爆炸
+
+### 5.5 为什么 SCC 处理翻转 callee/caller 角色？
+
+- **方向一致性**：自底向上要求 callee 先于 caller 处理。SCC 内部的函数互相调用（循环），无法严格排序，但 SCC 之间可以按 callee 依赖关系排序
+- **Tarjan 算法不变**：`_tarjan_scc()` 本身是方向无关的，只是传入的 edges 方向不同
+
+## 6. 挑战与应对
+
+### 6.1 循环不变式
+
+**挑战**：WP 的 `while` 规则需要循环不变式，LLM 可能无法自动推导出正确的不变式。
+
+**应对**：
+- Block 粒度（40 行）通常将整个循环包含在一个 block 内，LLM 在 block 级别隐式处理
+- 如果 LLM 推导的 WP 过强（太严格），会产生虚假 MISMATCH——通过 `_check_pre_implies_wp` 的反例机制过滤
+- 未来可增加循环不变式推断的专用 LLM 调用
+
+### 6.2 WP 过强问题
+
+**挑战**：LLM 计算的 WP 可能不是"最弱"的，而是过强的（包含不必要的约束），导致虚假 MISMATCH。
+
+**应对**：
+- 提示词明确强调 "weakest" 和 "as permissive as possible"
+- `_check_pre_implies_wp` 要求具体反例——如果 WP 过强但 spec_pre 确实不满足，反例必须是**具体输入值**，而非抽象推理
+- 可配置 `wp_relaxation`：如果连续 N 个函数都产生 MISMATCH 但无法提供具体反例，自动放宽 WP
+
+### 6.3 多返回路径
+
+**挑战**：函数可能有多个 return 语句，每条路径的 WP 不同。
+
+**应对**：
+- 逆向遍历自然处理：从 spec_post 出发，遇到 return 时 WP 包含返回值约束
+- 如果 block 内有 if/else 各自 return，LLM 在 block 级别计算 WP 时取**析取**（disjunction）——任一路径满足即可
+- 终止语句检查点确保每条返回路径都被验证
+
+### 6.4 异常路径
+
+**挑战**：throw/raise 语句的 WP 需要处理异常语义。
+
+**应对**：
+- 提示词中明确要求 "Cover all execution paths including early returns, exceptions"
+- WP 对 throw 的处理：`WP(throw e, Q) = Q[exception/e]`——LLM 隐式应用
+- spec 的 post-condition 应已包含异常约定（error contract），WP 会自然继承
+
+### 6.5 上下文窗口限制
+
+**挑战**：callee WP 传播可能使上下文过长。
+
+**应对**：
+- 截断 callee WP 到 200 字符
+- 只传播直接 callee（不递归传递孙 callee 的 WP）
+- 可配置 `max_callee_wps`（默认 5），超过时按调用频率排序取 top-K
+
+## 7. 实施路线图
+
+### Phase 1: 核心推理器（最小可用）
+
+**目标**：`wp_reasoner()` 独立可用，能对单个函数做 WP 验证。
+
+| 步骤 | 文件 | 改动 |
+|------|------|------|
+| 1.1 | `src/prompts.py` | 新增 `_generate_block_wp()`, `_check_pre_implies_wp()`, `_parse_wp_json()` |
+| 1.2 | `src/reasoner.py` | 新增 `wp_reasoner()` |
+| 1.3 | `config.py` | 新增 `REASONER_WP_MODEL` 常量 |
+| 1.4 | 测试 | 对已知有 Bug 的函数运行 WP 验证，确认能发现 SP 遗漏的缺陷 |
+
+### Phase 2: 分层与管线集成
+
+**目标**：`--reasoning-direction bottomup` 完整可运行。
+
+| 步骤 | 文件 | 改动 |
+|------|------|------|
+| 2.1 | `src/generate_topdown_layers.py` | 新增 `_compute_bottomup_layers()`, `generate_bottomup_layers()` |
+| 2.2 | `src/verification.py` | `_verify_single_file` 增加 `reasoning_direction` 参数 |
+| 2.3 | `src/verification.py` | `streaming_reasoner` 增加 `reasoning_direction` 参数 |
+| 2.4 | `main.py` | 新增 `--reasoning-direction` CLI 参数，路由分层和验证 |
+| 2.5 | `config.py` + `fm-agent.toml` | 新增 `reasoning_direction` 配置项 |
+| 2.6 | 测试 | 端到端运行 `--reasoning-direction bottomup`，验证全流程 |
+
+### Phase 3: 被调用者 WP 传播
+
+**目标**：callee WP 向上传播，提升 caller 分析精度。
+
+| 步骤 | 文件 | 改动 |
+|------|------|------|
+| 3.1 | `src/reasoner.py` 或新文件 | 新增 `_collect_callee_wps()`, `_format_callee_wps()` |
+| 3.2 | `src/verification.py` | `streaming_reasoner` 维护 `wp_cache`，传递给 `_verify_single_file` |
+| 3.3 | `src/incremental_reasoner.py` | 增量管线支持 `reasoning_direction` |
+| 3.4 | 测试 | 对比有无 WP 传播的 MISMATCH 检出率 |
+
+### Phase 4: 双向推理（未来扩展）
+
+**目标**：同时运行 SP 和 WP，交叉验证，取并集。
+
+```python
+# 未来 CLI:
+parser.add_argument(
+    "--reasoning-direction",
+    choices=["topdown", "bottomup", "bidirectional"],
+    default="topdown",
+)
+
+# bidirectional 模式:
+# 1. 先运行 topdown (SP), 收集 MISMATCH 集合 A
+# 2. 再运行 bottomup (WP), 收集 MISMATCH 集合 B
+# 3. 最终 Bug 集合 = A ∪ B (取并集)
+# 4. A ∩ B 的 Bug 置信度最高 (双向确认)
+```
+
+## 8. 文件变更清单
+
+| 文件 | 变更类型 | 估计行数 |
+|------|----------|----------|
+| `src/prompts.py` | 新增函数 | +120 |
+| `src/reasoner.py` | 新增函数 | +60 |
+| `src/generate_topdown_layers.py` | 新增函数 | +100 |
+| `src/verification.py` | 修改 | +30 |
+| `main.py` | 修改 | +15 |
+| `config.py` | 修改 | +10 |
+| `fm-agent.toml` | 修改 | +2 |
+| `src/incremental_reasoner.py` | 修改 | +20 |
+| **合计** | | **~357** |
+
+## 9. 总结
+
+本方案在 FM-Agent 现有自顶向下 SP 推理基础上，新增自底向上 WP 推理方式：
+
+- **理论互补**：SP 发现"代码做错了什么"，WP 发现"代码遗漏了什么"，两者覆盖不同 Bug 类型
+- **架构对称**：WP 推理器、WP 提示词、自底向上分层算法与现有 SP 实现严格对称，降低理解成本
+- ** callee WP 传播**：自底向上的核心优势——callee 的前置要求向上传播，使 caller 分析更精确
+- **非侵入式**：通过配置和 CLI 参数切换方向，不修改现有 SP 逻辑，向后完全兼容
+- **渐进式实施**：Phase 1 即可独立可用，Phase 2-3 逐步增强，Phase 4 双向验证是自然扩展

--- a/examples/wp_demo/README.md
+++ b/examples/wp_demo/README.md
@@ -1,0 +1,80 @@
+# WP Reasoning Demo Examples
+
+This directory contains example C source files demonstrating the complementary
+bug detection capabilities of SP (Strongest Postcondition, forward) and WP
+(Weakest Precondition, backward) reasoning.
+
+## Files
+
+| File | Bug Type | SP Detects | WP Detects |
+|------|----------|:----------:|:----------:|
+| `precondition_too_weak.c` | Pre-condition too weak (missing upper bound check) | No | **Yes** |
+| `missing_branch.c` | Missing branch (unhandled zero case) | No | **Yes** |
+| `callee_requirement_unmet.c` | Caller doesn't guarantee callee's pre-condition | No | **Yes** |
+| `both_detect.c` | Computation error (add instead of multiply) | **Yes** | **Yes** |
+| `clean.c` | No bug (correct binary search) | Pass | Pass |
+
+## Running
+
+### SP mode (default, top-down):
+```bash
+python main.py examples/wp_demo --reasoning-direction topdown
+```
+
+### WP mode (bottom-up):
+```bash
+python main.py examples/wp_demo --reasoning-direction bottomup
+```
+
+### Expected results
+
+- **SP mode**: Detects the bug in `both_detect.c`, but misses the bugs in
+  `precondition_too_weak.c`, `missing_branch.c`, and `callee_requirement_unmet.c`.
+  Passes `clean.c`.
+
+- **WP mode**: Detects bugs in all four buggy files. Passes `clean.c`.
+
+## Bug Analysis
+
+### 1. Pre-condition too weak (`precondition_too_weak.c`)
+
+The spec says "index is non-negative" but the code accesses `array[index]`
+without checking `index < array_length`.
+
+- **SP misses**: Forward derivation from the weak pre-condition produces an
+  equally weak post-condition — no contradiction.
+- **WP catches**: Backward derivation from "no out-of-bounds access" requires
+  `index < array_length`. The spec only guarantees `index >= 0`, which does
+  not entail this — MISMATCH.
+
+### 2. Missing branch (`missing_branch.c`)
+
+The function handles positive and negative but forgets the zero case,
+returning an uninitialized value.
+
+- **SP misses**: Forward derivation for the zero case produces "result is
+  unspecified" — no contradiction with a spec that doesn't explicitly mention zero.
+- **WP catches**: Backward derivation from "result correctly classifies input"
+  requires all cases handled. Missing zero case means WP includes `input != 0`,
+  but spec allows `input == 0` — MISMATCH.
+
+### 3. Callee requirement unmet (`callee_requirement_unmet.c`)
+
+The caller calls `divide()` without checking `divisor != 0`.
+
+- **SP misses**: In top-down mode, the caller is analyzed before the callee.
+  The callee's precise pre-condition isn't available during caller analysis.
+- **WP catches**: In bottom-up mode, `divide()` is analyzed first. Its WP
+  (`divisor != 0`) is cached and propagated to the caller. The caller's WP
+  includes this constraint, but the spec only says "divisor is an integer" —
+  MISMATCH.
+
+### 4. Both detect (`both_detect.c`)
+
+A clear computation error (addition instead of multiplication). Both methods
+catch this because the post-condition is directly violated.
+
+### 5. Clean (`clean.c`)
+
+A correct binary search implementation. Both methods should pass it without
+false positives.

--- a/examples/wp_demo/both_detect.c
+++ b/examples/wp_demo/both_detect.c
@@ -1,0 +1,26 @@
+/*
+ * Example 4: Computation error — both SP and WP detect.
+ *
+ * Bug: The function should return a * b but returns a + b.
+ * Both SP and WP should catch this because:
+ * - SP: forward derivation shows post-condition is "result == a + b",
+ *   which contradicts spec post-condition "result == a * b".
+ * - WP: backward derivation from "result == a * b" requires "the function
+ *   computes multiplication", but the code does addition — the WP
+ *   (paraphrased: "code must multiply a and b") is not satisfied by the code.
+ *
+ * This example serves as a baseline: bugs that are pure computation errors
+ * are detectable by both methods.
+ */
+
+// [SPEC]
+// Pre-condition:
+//   a and b are integers.
+//
+// Post-condition:
+//   result == a * b (integer multiplication of inputs).
+
+int multiply(int a, int b) {
+    // BUG: returns a + b instead of a * b
+    return a + b;
+}

--- a/examples/wp_demo/callee_requirement_unmet.c
+++ b/examples/wp_demo/callee_requirement_unmet.c
@@ -1,0 +1,46 @@
+/*
+ * Example 3: Callee requirement unmet — WP catches via propagation, SP misses.
+ *
+ * Bug: The caller (safe_divide_wrapper) calls divide() without ensuring
+ * divisor != 0. The spec for safe_divide_wrapper says "divisor is an integer"
+ * (no constraint on zero), but divide() requires divisor != 0.
+ *
+ * Why SP misses: In top-down mode, the caller is analyzed before the callee.
+ * The caller's [INFO] block (callee contract) may not yet include the precise
+ * pre-condition that divide() requires. SP derives a forward post-condition
+ * for the caller that doesn't catch the missing zero-check.
+ *
+ * Why WP catches: In bottom-up mode, divide() is analyzed first. Its WP
+ * ("divisor != 0") is cached. When analyzing safe_divide_wrapper, the callee's
+ * WP is injected into the reasoning context. WP derivation for the caller
+ * includes "divisor != 0" (required by callee). But the spec pre-condition
+ * only says "divisor is an integer" — MISMATCH.
+ */
+
+// [SPEC]
+// Pre-condition:
+//   dividend and divisor are integers.
+//
+// Post-condition:
+//   Returns dividend / divisor on success.
+//   Returns -1 and sets error flag if divisor == 0.
+
+int divide(int dividend, int divisor) {
+    // [SPEC]
+    // Pre-condition:
+    //   divisor != 0.
+    //
+    // Post-condition:
+    //   Returns dividend / divisor (exact integer division).
+    if (divisor == 0) {
+        return 0;  // This path violates the spec — divide requires divisor != 0
+    }
+    return dividend / divisor;
+}
+
+int safe_divide_wrapper(int dividend, int divisor) {
+    // BUG: no check for divisor == 0 before calling divide()
+    // The callee divide() requires divisor != 0, but this caller doesn't guarantee it.
+    int result = divide(dividend, divisor);
+    return result;
+}

--- a/examples/wp_demo/clean.c
+++ b/examples/wp_demo/clean.c
@@ -1,0 +1,40 @@
+/*
+ * Example 5: Clean function — both SP and WP should pass.
+ *
+ * This is a correctly implemented binary search. Both reasoning directions
+ * should verify it successfully:
+ * - SP: forward derivation confirms the post-condition (returns correct index).
+ * - WP: backward derivation confirms spec_pre is sufficient to guarantee
+ *   the post-condition (array sorted + value in range → found or -1).
+ *
+ * This example ensures WP doesn't produce false positives on correct code.
+ */
+
+// [SPEC]
+// Pre-condition:
+//   array is sorted in ascending order.
+//   array_length > 0.
+//   array has at least array_length elements allocated.
+//
+// Post-condition:
+//   If target is found in array[0..array_length-1], returns its index.
+//   If target is not found, returns -1.
+//   No out-of-bounds access occurs.
+
+int binary_search(int *array, int array_length, int target) {
+    int low = 0;
+    int high = array_length - 1;
+
+    while (low <= high) {
+        int mid = low + (high - low) / 2;
+        if (array[mid] == target) {
+            return mid;
+        } else if (array[mid] < target) {
+            low = mid + 1;
+        } else {
+            high = mid - 1;
+        }
+    }
+
+    return -1;
+}

--- a/examples/wp_demo/missing_branch.c
+++ b/examples/wp_demo/missing_branch.c
@@ -1,0 +1,36 @@
+/*
+ * Example 2: Missing branch — WP catches, SP misses.
+ *
+ * Bug: The function handles "positive" and "negative" cases but forgets
+ * the "zero" case. When input == 0, the function falls through without
+ * setting result, returning an uninitialized value.
+ *
+ * Why SP misses: SP derives forward from the pre-condition. For the zero
+ * case, SP's derived post-condition simply says "result is unspecified for
+ * zero input" — which doesn't contradict the spec post-condition if the
+ * spec doesn't explicitly mention zero.
+ *
+ * Why WP catches: WP starts from the post-condition "result correctly
+ * classifies the input" and derives backward: "to guarantee correct
+ * classification, all cases (positive, negative, zero) must be handled."
+ * The missing zero case means the WP includes "input != 0", but the spec
+ * pre-condition allows input == 0 — MISMATCH.
+ */
+
+// [SPEC]
+// Pre-condition:
+//   input is an integer (any value, including zero).
+//
+// Post-condition:
+//   result is 1 if input > 0, -1 if input < 0, 0 if input == 0.
+
+int classify(int input) {
+    int result;
+    if (input > 0) {
+        result = 1;
+    } else if (input < 0) {
+        result = -1;
+    }
+    // BUG: missing "else { result = 0; }" — result is uninitialized when input == 0
+    return result;
+}

--- a/examples/wp_demo/precondition_too_weak.c
+++ b/examples/wp_demo/precondition_too_weak.c
@@ -1,0 +1,34 @@
+/*
+ * Example 1: Pre-condition too weak — WP catches, SP misses.
+ *
+ * Bug: The spec says "index is non-negative" but the code accesses
+ * array[index] without checking index < array_length. This is an
+ * out-of-bounds access when index >= array_length.
+ *
+ * Why SP misses: SP starts from the (weak) pre-condition and derives
+ * post-conditions forward. Since the pre-condition allows any non-negative
+ * index, SP's forward derivation doesn't flag the missing upper-bound check —
+ * it simply produces a post-condition that's also weak.
+ *
+ * Why WP catches: WP starts from the post-condition (array[index] is read
+ * successfully) and derives backward: "to guarantee this, index must be
+ * < array_length". Then it checks spec_pre ⊨ wp: the spec only guarantees
+ * "index >= 0", which does NOT entail "index < array_length" — MISMATCH.
+ */
+
+// [SPEC]
+// Pre-condition:
+//   index is a non-negative integer.
+//   array is a valid int array.
+//
+// Post-condition:
+//   Returns the element at array[index].
+//   No out-of-bounds memory access occurs.
+
+int get_element(int *array, int array_length, int index) {
+    if (index < 0) {
+        return -1;
+    }
+    // BUG: no check for index >= array_length
+    return array[index];
+}

--- a/fm-agent.toml
+++ b/fm-agent.toml
@@ -20,6 +20,7 @@ granularity                = 40    # GRANULARITY
 opencode_max_retries       = 5     # OPENCODE_MAX_RETRIES
 bug_validation_max_retries = 1     # BUG_VALIDATION_MAX_RETRIES
 opencode_timeout_s         = 1800  # OPENCODE_TIMEOUT_SECONDS — hard cap on one `opencode run`
+reasoning_direction        = "topdown"  # REASONING_DIRECTION — topdown (SP/forward) | bottomup (WP/backward)
 
 [scope]
 top_k                    = 5    # SCOPE_TOP_K

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from src.file_utils import (
     _is_under_submodules,
 )
 from src.extract import run_extraction, EXT_TO_LANG
-from src.generate_topdown_layers import generate_topdown_layers
+from src.generate_topdown_layers import generate_topdown_layers, generate_bottomup_layers
 from src.spec_generation_and_verification import run_spec_generation_and_verification
 from src.incremental_reasoner import run_incremental_pipeline
 from src.git import (
@@ -116,6 +116,7 @@ def run_pipeline(
     only_spec=False,
     bug_validator_path=None,
     plugin_config=None,
+    reasoning_direction=None,
 ):
     if not os.path.isdir(proj_dir):
         print(f"[Pipeline] ERROR: proj_dir does not exist or is not a directory: {proj_dir}")
@@ -131,6 +132,11 @@ def run_pipeline(
     output_dir = os.path.join(work_dir, "logic_verification_results")
     script_dir = os.path.dirname(os.path.abspath(__file__))
     extra_call_edges = load_call_edges(extra_call_edges_path)
+
+    # Resolve reasoning direction: CLI arg > config (fm-agent.toml/.env) > default "topdown"
+    if reasoning_direction is None:
+        from config import REASONING_DIRECTION as _cfg_direction
+        reasoning_direction = _cfg_direction or "topdown"
 
     # Clean files from the previous run — unless resuming, where we keep all
     # prior progress (phases.json, generated specs, verification results) and
@@ -230,9 +236,13 @@ def run_pipeline(
         print("[Pipeline] No functions found to verify. Skipping spec generation.")
         return
 
-    # --- Stage 5: Generate topdown layers ---
-    print("[Pipeline] Stage 5/6: Generating topdown layers...")
-    generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
+    # --- Stage 5: Generate layers (direction-aware) ---
+    if reasoning_direction == "bottomup":
+        print("[Pipeline] Stage 5/6: Generating bottom-up layers (WP reasoning)...")
+        generate_bottomup_layers(work_dir, extra_call_edges=extra_call_edges)
+    else:
+        print("[Pipeline] Stage 5/6: Generating topdown layers...")
+        generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
 
     # --- Stage 6: Execute spec generation workflow (per phase, per layer) ---
     if only_spec:
@@ -251,6 +261,7 @@ def run_pipeline(
         extra_call_edges=extra_call_edges,
         only_spec=only_spec,
         bug_validator_path=bug_validator_path,
+        reasoning_direction=reasoning_direction,
     )
 
     # Print confirmed bug count (skipped in only-spec mode, which runs no
@@ -369,6 +380,16 @@ if __name__ == "__main__":
         default=None,
         help="load and activate the named plugin from the plugins/ directory.",
     )
+    parser.add_argument(
+        "--reasoning-direction",
+        choices=["topdown", "bottomup"],
+        default=None,
+        help="reasoning direction: 'topdown' (strongest postcondition, forward, default) "
+        "or 'bottomup' (weakest precondition, backward). "
+        "WP derives the minimal pre-condition from the spec's post-condition, "
+        "finding complementary bug classes to SP. "
+        "Defaults to fm-agent.toml [runtime] reasoning_direction.",
+    )
     args = parser.parse_args()
 
     if args.list_plugin:
@@ -458,6 +479,7 @@ if __name__ == "__main__":
             only_spec=args.only_spec,
             bug_validator_path=bug_validator_path,
             plugin_config=plugin_config,
+            reasoning_direction=args.reasoning_direction,
         )
         end_time = time.time()
         logging.info(f"Total time: {end_time - start_time:.2f} seconds")
@@ -518,6 +540,7 @@ if __name__ == "__main__":
                     extra_call_edges_path=extra_call_edges_path,
                     bug_validator_path=bug_validator_path,
                     plugin_config=plugin_config,
+                    reasoning_direction=args.reasoning_direction,
                 )
             else:
                 run_pipeline(
@@ -530,6 +553,7 @@ if __name__ == "__main__":
                     only_spec=args.only_spec,
                     bug_validator_path=bug_validator_path,
                     plugin_config=plugin_config,
+                    reasoning_direction=args.reasoning_direction,
                 )
             # Record the commit that was processed. Written after the pipeline since
             # it recreates fm_agent/; with --isolate it lives in the snapshot and is

--- a/src/entry_reasoning_pipeline.py
+++ b/src/entry_reasoning_pipeline.py
@@ -255,6 +255,7 @@ def run_entry_pipeline(
     only_spec=False,
     bug_validator_path=None,
     plugin_config=None,
+    reasoning_direction=None,
 ):
     """Run the entry-point-scoped reasoning pipeline.
 
@@ -317,6 +318,7 @@ def run_entry_pipeline(
             only_spec=only_spec,
             bug_validator_path=bug_validator_path,
             plugin_config=plugin_config,
+            reasoning_direction=reasoning_direction,
         )
     finally:
         clear_test_file_exemptions()
@@ -467,6 +469,7 @@ def _run_entry_pipeline_inner(
     only_spec=False,
     bug_validator_path=None,
     plugin_config=None,
+    reasoning_direction=None,
 ):
     """Body of run_entry_pipeline; runs with the entry source file exempted."""
     # 1. Selection: extract fresh into a temp workspace and build the call graph.
@@ -516,6 +519,7 @@ def _run_entry_pipeline_inner(
             only_spec=only_spec,
             bug_validator_path=bug_validator_path,
             plugin_config=plugin_config,
+            reasoning_direction=reasoning_direction,
         )
     finally:
         # 4. Copy the generated fm_agent/ back into proj_dir, then discard the

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -638,8 +638,107 @@ def _compute_layers(phase_fqns, callees_map, callers_map):
 
 
 # ---------------------------------------------------------------------------
-# Main entry point
+# Bottom-up layer computation (for WP reasoning)
 # ---------------------------------------------------------------------------
+
+def _compute_bottomup_layers(phase_fqns, callees_map, callers_map):
+    """Compute bottom-up topological layers: Layer 0 = leaf functions (no callees).
+
+    Mirrors _compute_layers(), but the readiness condition is flipped:
+    - _compute_layers: a function is ready when all its *callers* are assigned
+      (entry functions first, leaves last)
+    - _compute_bottomup_layers: a function is ready when all its *callees* are
+      assigned (leaf functions first, entry functions last)
+
+    This ensures that when analyzing a caller in WP mode, all its callees'
+    weakest pre-conditions have already been computed and can be propagated
+    upward via wp_cache.
+    """
+    phase_set = set(phase_fqns)
+    remaining = set(phase_set)
+    assigned = {}
+    layers = []
+
+    while remaining:
+        # Find functions whose all same-phase callees are already assigned
+        ready = set()
+        for fqn in remaining:
+            phase_callees = callees_map.get(fqn, set()) & phase_set
+            unassigned_callees = phase_callees - set(assigned.keys())
+            if not unassigned_callees:
+                ready.add(fqn)
+
+        if ready:
+            layer_idx = len(layers)
+            for fqn in ready:
+                assigned[fqn] = layer_idx
+            layers.append({"layer": layer_idx, "functions": sorted(ready),
+                          "cycle_resolution": False})
+            remaining -= ready
+        else:
+            # Cycle detected — use Tarjan's SCC on the callee graph
+            # Build subgraph of remaining functions using callee edges
+            sub_edges = {}
+            for fqn in remaining:
+                sub_edges[fqn] = callees_map.get(fqn, set()) & remaining
+
+            sccs = _tarjan_scc(remaining, sub_edges)
+
+            # Build SCC DAG based on callee edges
+            fqn_to_scc = {}
+            for i, scc in enumerate(sccs):
+                for fqn in scc:
+                    fqn_to_scc[fqn] = i
+
+            scc_callees = defaultdict(set)  # scc_idx -> set of scc_idx it calls
+            for fqn in remaining:
+                scc_i = fqn_to_scc[fqn]
+                for callee_fqn in callees_map.get(fqn, set()) & remaining:
+                    scc_j = fqn_to_scc[callee_fqn]
+                    if scc_i != scc_j:
+                        scc_callees[scc_i].add(scc_j)
+
+            # Topological sort: callee SCCs first (leaves before roots)
+            scc_assigned = {}
+            scc_remaining = set(range(len(sccs)))
+
+            while scc_remaining:
+                scc_ready = set()
+                for scc_idx in scc_remaining:
+                    unassigned_scc_callees = scc_callees.get(scc_idx, set()) - set(scc_assigned.keys())
+                    if not unassigned_scc_callees:
+                        scc_ready.add(scc_idx)
+
+                if not scc_ready:
+                    # Degenerate: assign all remaining to the same layer
+                    layer_idx = len(layers)
+                    all_fqns = set()
+                    for scc_idx in scc_remaining:
+                        all_fqns.update(sccs[scc_idx])
+                    for fqn in all_fqns:
+                        assigned[fqn] = layer_idx
+                    layers.append({"layer": layer_idx, "functions": sorted(all_fqns),
+                                  "cycle_resolution": True})
+                    remaining -= all_fqns
+                    break
+
+                layer_idx = len(layers)
+                layer_fqns = set()
+                is_cycle = False
+                for scc_idx in scc_ready:
+                    scc_assigned[scc_idx] = layer_idx
+                    layer_fqns.update(sccs[scc_idx])
+                    if len(sccs[scc_idx]) > 1:
+                        is_cycle = True
+
+                for fqn in layer_fqns:
+                    assigned[fqn] = layer_idx
+                layers.append({"layer": layer_idx, "functions": sorted(layer_fqns),
+                              "cycle_resolution": is_cycle})
+                remaining -= layer_fqns
+                scc_remaining -= scc_ready
+
+    return layers
 
 def generate_topdown_layers(proj_dir, phase_numbers=None, extra_call_edges=None):
     """Generate topdown layer JSON files for the specified phases (or all phases).
@@ -758,5 +857,123 @@ def generate_topdown_layers(proj_dir, phase_numbers=None, extra_call_edges=None)
 
         output_files.append(out_path)
         print(f"[TopdownLayers] Phase {phase_num} ({phase_name}): {total_functions} functions, {total_layers} layers -> {os.path.relpath(out_path, proj_dir)}")
+
+    return output_files
+
+
+def generate_bottomup_layers(proj_dir, phase_numbers=None, extra_call_edges=None):
+    """Generate bottom-up layer JSON files for the specified phases (or all phases).
+
+    Mirrors generate_topdown_layers(), but uses _compute_bottomup_layers() which
+    orders leaf functions (no callees) first and entry functions last. This is
+    the layering used by WP (weakest precondition) reasoning: when analyzing a
+    caller, all its callees' WPs are already computed and can be propagated.
+
+    Output files: phase_XX_bottomup_layers.json (same structure as topdown, but
+    with reversed layer order).
+    """
+    phases_data = _load_phases(proj_dir)
+
+    output_dir = os.path.join(proj_dir, "spec_prompts")
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Build global stem->FQN mapping across ALL phases for all_callees
+    global_stem_to_fqns = defaultdict(set)
+    for pi in phases_data["phases"]:
+        for filepath, _ in _collect_phase_files(proj_dir, pi):
+            fqn = _file_to_fqn(filepath, proj_dir)
+            stem = fqn.split("::")[-1]
+            global_stem_to_fqns[stem].add(fqn)
+
+    output_files = []
+
+    for phase_info in phases_data["phases"]:
+        phase_num = phase_info["phase"]
+        phase_name = phase_info["name"]
+
+        if phase_numbers and phase_num not in phase_numbers:
+            continue
+
+        phase_files = _collect_phase_files(proj_dir, phase_info)
+        if not phase_files:
+            logging.warning(f"Phase {phase_num} ({phase_name}): no extracted files found, skipping.")
+            continue
+
+        (
+            callees_map,
+            callers_map,
+            all_callees_map,
+            file_map,
+            module_map,
+            edge_aliases_map,
+        ) = _build_call_graph(
+            phase_files, proj_dir, global_stem_to_fqns, extra_call_edges=extra_call_edges
+        )
+        phase_fqns = set(file_map.keys())
+
+        # Compute bottom-up topological layers (callees first, callers last)
+        layers = _compute_bottomup_layers(phase_fqns, callees_map, callers_map)
+
+        # Build phase-specific key names (same as topdown for compatibility)
+        phase_callers_key = f"phase{phase_num}_callers"
+        phase_callees_key = f"phase{phase_num}_callees"
+        phase_info_names_key = f"phase{phase_num}_callee_info_names_by_caller"
+
+        total_functions = len(phase_fqns)
+        total_layers = len(layers)
+
+        output_layers = []
+        for layer_info in layers:
+            layer_dict = {
+                "layer": layer_info["layer"],
+            }
+            if layer_info["cycle_resolution"]:
+                layer_dict["cycle_resolution"] = True
+
+            func_entries = []
+            for fqn in layer_info["functions"]:
+                filepath = file_map[fqn]
+                rel_path = os.path.relpath(filepath, proj_dir)
+                unit = module_map.get(fqn, "")
+
+                phase_callers = sorted(callers_map.get(fqn, set()) & phase_fqns)
+                phase_callees = sorted(callees_map.get(fqn, set()) & phase_fqns)
+                all_callees = sorted(all_callees_map.get(fqn, set()))
+
+                entry = {
+                    "name": fqn,
+                    "file": rel_path,
+                    "unit": unit,
+                    phase_callers_key: phase_callers,
+                    phase_callees_key: phase_callees,
+                    "all_callees": all_callees,
+                }
+                info_names_by_caller = {
+                    caller: sorted(info_names)
+                    for caller, info_names in edge_aliases_map.get(fqn, {}).items()
+                    if caller in phase_fqns and info_names
+                }
+                if info_names_by_caller:
+                    entry[phase_info_names_key] = info_names_by_caller
+                func_entries.append(entry)
+
+            layer_dict["functions"] = func_entries
+            output_layers.append(layer_dict)
+
+        output = {
+            "phase": phase_num,
+            "phase_name": phase_name,
+            "total_functions": total_functions,
+            "total_layers": total_layers,
+            "layers": output_layers,
+            "direction": "bottomup",
+        }
+
+        out_path = os.path.join(output_dir, f"phase_{phase_num:02d}_bottomup_layers.json")
+        with open(out_path, "w") as f:
+            json.dump(output, f, indent=2, ensure_ascii=False)
+
+        output_files.append(out_path)
+        print(f"[BottomupLayers] Phase {phase_num} ({phase_name}): {total_functions} functions, {total_layers} layers -> {os.path.relpath(out_path, proj_dir)}")
 
     return output_files

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -32,6 +32,7 @@ from .generate_topdown_layers import (
     _file_to_fqn,
     _load_phases,
     generate_topdown_layers,
+    generate_bottomup_layers,
 )
 from .call_graph_edges import load_call_edges
 from .file_utils import (
@@ -659,17 +660,24 @@ def _remove_stale_extracted(proj_dir, modified_functions):
         _reconcile_extracted_dir(proj_dir, abs_src)
 
 
-def _topdown_ordered_fqns(work_dir, extra_call_edges=None):
+def _topdown_ordered_fqns(work_dir, extra_call_edges=None, reasoning_direction=None):
     """
-    Return every extracted-function FQN in the top-down order used by run_pipeline for
+    Return every extracted-function FQN in the order used by run_pipeline for
     spec generation: phases in ascending phase number, layers from 0 upward, and the
-    functions in the order listed within each layer (callers precede the callees they
-    depend on).
+    functions in the order listed within each layer.
 
-    Regenerates the per-phase topdown-layer JSON files under work_dir/spec_prompts/ as
-    a side effect (mirroring run_pipeline's generate_topdown_layers(work_dir) call).
+    In topdown mode, callers precede the callees they depend on.
+    In bottomup mode, callees precede the callers that invoke them.
+
+    Regenerates the per-phase layer JSON files under work_dir/spec_prompts/ as
+    a side effect (mirroring run_pipeline's layer generation call).
     """
-    generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
+    if reasoning_direction == "bottomup":
+        generate_bottomup_layers(work_dir, extra_call_edges=extra_call_edges)
+        _layers_suffix = "bottomup_layers"
+    else:
+        generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
+        _layers_suffix = "topdown_layers"
     phases_data = _load_phases(work_dir)
     spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
 
@@ -677,7 +685,7 @@ def _topdown_ordered_fqns(work_dir, extra_call_edges=None):
     for phase_info in sorted(phases_data.get("phases", []), key=lambda p: p["phase"]):
         phase_num = phase_info["phase"]
         layers_path = os.path.join(
-            spec_prompts_dir, f"phase_{phase_num:02d}_topdown_layers.json"
+            spec_prompts_dir, f"phase_{phase_num:02d}_{_layers_suffix}.json"
         )
         if not os.path.exists(layers_path):
             continue
@@ -699,6 +707,7 @@ def run_incremental_pipeline(
     extra_call_edges_path=None,
     bug_validator_path=None,
     plugin_config=None,
+    reasoning_direction=None,
 ):
     """
     Run the pipeline in incremental mode, intent_file_path is a file (absolute path) defining the goal of modification.
@@ -855,12 +864,16 @@ def run_incremental_pipeline(
         )
     logging.info("  -> file list has %d entr(ies).", len(file_list))
 
-    # 7. Update top-down layers
-    logging.info("[Stage 7/10] Generating topdown layers...")
+    # 7. Update layers (direction-aware)
     with open(os.path.join(work_dir, "phases.json"), "r") as f:
         phases_data = json.load(f)
-    generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
-    logging.info("  -> topdown layers generated for %d phase(s).", len(phases_data.get("phases", [])))
+    if reasoning_direction == "bottomup":
+        logging.info("[Stage 7/10] Generating bottom-up layers (WP reasoning)...")
+        generate_bottomup_layers(work_dir, extra_call_edges=extra_call_edges)
+    else:
+        logging.info("[Stage 7/10] Generating topdown layers...")
+        generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
+    logging.info("  -> layers generated for %d phase(s).", len(phases_data.get("phases", [])))
 
     # 8. Collect the scope of functions relevant to the developer intent (the intent file defines the goal of modification).
     logging.info("[Stage 8/10] Collecting functions relevant to the developer intent...")
@@ -891,6 +904,7 @@ def run_incremental_pipeline(
         proj_dir, work_dir, changed_functions, updated_spec_files,
         submodules=submodules,
         bug_validator_path=bug_validator_path,
+        reasoning_direction=reasoning_direction,
     )
     logging.info("=" * 70)
     logging.info(
@@ -2019,7 +2033,7 @@ def _update_specs_for_intent(
 
 def _verify_incremental_functions(
     proj_dir, work_dir, changed_functions, updated_spec_files, submodules=None,
-    bug_validator_path=None,
+    bug_validator_path=None, reasoning_direction="topdown",
 ):
     """
     Step 10: re-run the verification stage (reasoner + bug validation) on only the functions
@@ -2097,7 +2111,8 @@ def _verify_incremental_functions(
     def _verify(rel):
         fpath = os.path.join(extracted_dir, rel)
         language = _VERIFY_EXT_TO_LANG.get(os.path.splitext(fpath)[1], "C")
-        _, verdict = _verify_single_file(fpath, extracted_dir, output_dir, language, work_dir=work_dir)
+        _, verdict = _verify_single_file(fpath, extracted_dir, output_dir, language, work_dir=work_dir,
+                                         reasoning_direction=reasoning_direction)
         return rel, verdict
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -13,6 +13,200 @@ from .trace_writer import (
 )
 
 
+# ---- WP (Weakest Precondition) prompt functions ----
+# These mirror the SP (Strongest Postcondition) functions above, but operate
+# in the backward direction: given a post-condition and a code block, derive
+# the weakest pre-condition that guarantees the post-condition holds.
+
+def _parse_wp_json(data):
+    """Validate the WP response (mirrors _parse_post_condition_json)."""
+    if not isinstance(data, dict):
+        raise ValueError("WP JSON must be an object")
+    pre_condition = data.get("pre_condition")
+    if not isinstance(pre_condition, str) or not pre_condition.strip():
+        raise ValueError("WP JSON requires a non-empty string field: pre_condition")
+    return pre_condition.strip()
+
+
+def _generate_block_wp(block, post_condition, knowledge, language,
+                       trace_dir=None, trace_meta=None):
+    """Compute the weakest pre-condition for a code block (backward derivation).
+
+    Mirrors _generate_block_post_condition(), but:
+    - Input: code block + post-condition (what must hold AFTER)
+    - Output: weakest pre-condition (what must hold BEFORE)
+    - Direction: backward (given target Q, find minimal P s.t. {P} S {Q})
+    """
+    info_str = f"\nAdditional context:\n{knowledge}" if knowledge else ""
+    messages = [
+        {"role": "system", "content": (
+            f"You are an expert in formal verification of {language} programs. "
+            f"Given a {language} code block and its post-condition (what must be true "
+            "after execution), compute the WEAKEST PRE-CONDITION: the minimal condition "
+            "that must hold before the block to GUARANTEE the post-condition holds after. "
+            "Cover all execution paths including early returns, exceptions, and normal "
+            f"flow-through. Apply {language}-specific semantics (ownership, lifetimes, error handling, etc.) as appropriate. "
+            "The weakest pre-condition should be as permissive as possible while still "
+            "guaranteeing the post-condition. Express it in natural language and formal logic."
+        )},
+        {"role": "user", "content": (
+            f"Programming language: {language}\n\n"
+            f"Post-condition (must hold AFTER this block):\n{post_condition}\n\n"
+            f"Code block:\n```{language.lower()}\n{block}\n```\n"
+            f"{info_str}\n"
+            "Compute the weakest pre-condition. Return only a valid JSON object with this "
+            "required field: {\"pre_condition\": \"...\"}. Do not include Markdown, "
+            "tags, or prose outside the JSON object."
+        )}
+    ]
+    meta = {
+        "purpose": "generate_block_wp",
+        "summary": "Generated weakest pre-condition for code block",
+        "direction": "backward",
+        **(trace_meta or {}),
+    }
+    return _llm_json_call(
+        _llm_provider_client,
+        REASONER_WP_MODEL,
+        messages,
+        _parse_wp_json,
+        '{"pre_condition": "non-empty string"}',
+        trace_dir=trace_dir,
+        trace_meta=meta,
+    )
+
+
+def _check_pre_implies_wp(block, wp, spec_pre_condition, knowledge, language,
+                          trace_dir=None, trace_meta=None):
+    """Check whether spec_pre_condition entails wp (the weakest pre-condition).
+
+    Mirrors _check_post_implies_spec(), but:
+    - SP checks: post (what code does) ⊨ spec_post (what it should do)? — forward contradiction
+    - WP checks: spec_pre (what callers guarantee) ⊨ wp (what code requires)? — backward gap
+
+    If spec_pre does NOT entail wp, there exists an input satisfying spec_pre but
+    violating wp — the caller's guarantees are insufficient for the code to work
+    correctly. This is a potential bug (pre-condition too weak).
+    """
+    info_str = f"\nAdditional context:\n{knowledge}" if knowledge else ""
+    lang_expertise = _LANGUAGE_EXPERTISE.get(language.lower(), f"You are an expert in logic, formal verification, and {language} programming. ")
+    messages = [
+        {"role": "system", "content": (
+            lang_expertise +
+            "Given a code block, its weakest pre-condition A (what the code REQUIRES "
+            "before execution to guarantee correctness), and a specification pre-condition "
+            "B (what callers GUARANTEE before calling), determine whether there exists a "
+            "concrete valid input where B holds but A does not. "
+            "If such an input exists, the function may fail because the caller's guarantees "
+            "are insufficient — the code requires more than what the spec promises. "
+            "Focus on finding CONCRETE COUNTEREXAMPLES: specific input values where B is "
+            "satisfied but A is violated. "
+            "Check these common violation patterns:\n"
+            "  1. B allows input ranges/shapes that A restricts (e.g., B says 'non-negative' "
+            "but A requires 'positive').\n"
+            "  2. B does not constrain a variable that A requires to be in a specific state.\n"
+            "  3. B allows null/empty/edge-case values that A excludes.\n"
+            "For each potential violation, construct a specific input, verify B holds, "
+            "then check if A is violated. "
+            "Return only a valid JSON object. Do not include markdown, tags, or prose. "
+            "Use exactly this schema: "
+            "{\"verdict\": \"MATCH|MISMATCH\", \"counterexample\": string|null, "
+            "\"offending_statements\": string|null, \"reason\": string}. "
+            "For MISMATCH, counterexample, offending_statements, and reason must be non-empty strings; "
+            "offending_statements must preserve any 'Line N:' prefixes from the code block. "
+            "For MATCH, counterexample and offending_statements must be null or empty, and reason may be empty."
+        )},
+        {"role": "user", "content": (
+            f"Programming language: {language}\n\n"
+            f"Code block:\n```{language.lower()}\n{block}\n```\n\n"
+            f"Condition A (weakest pre-condition — what the code requires):\n{wp}\n\n"
+            f"Condition B (spec pre-condition — what callers guarantee):\n{spec_pre_condition}\n"
+            f"{info_str}\n"
+            "Is there a concrete valid input where B holds but A does not? "
+            "Provide a specific counterexample if any case exists. Return only the JSON object."
+        )}
+    ]
+    trace_meta = trace_meta or {}
+    for attempt in range(1, MAX_SPC_ITER + 1):
+        event_id = new_event_id("llm")
+        started = utc_now_iso()
+        response = None
+        usage = {}
+        try:
+            response, usage = _retry_create(_llm_provider_client, REASONER_SPEC_CHECK_MODEL, messages)
+        except Exception as exc:
+            event = {
+                "event_id": event_id,
+                "type": "llm_call",
+                "stage": "wp_verification",
+                "status": "error",
+                "start_time": started,
+                "end_time": utc_now_iso(),
+                "summary": f"LLM WP implication check failed: {exc}",
+                "metadata": {
+                    **trace_meta,
+                    "purpose": "check_pre_implies_wp",
+                    "model": REASONER_SPEC_CHECK_MODEL,
+                    "attempt": attempt,
+                    "error": str(exc),
+                },
+            }
+            record_llm_exchange(trace_dir, event_id, event, messages)
+            raise
+        parsed_result = None
+        parse_error = None
+        try:
+            has_violation, stmts, reason, parsed_result = _parse_spec_check_json(response)
+            status = "mismatch" if has_violation else "success"
+        except ValueError as exc:
+            has_violation = None
+            stmts = reason = None
+            parse_error = str(exc)
+            status = "format_error"
+        event = {
+            "event_id": event_id,
+            "type": "llm_call",
+            "stage": "wp_verification",
+            "status": status,
+            "start_time": started,
+            "end_time": utc_now_iso(),
+            "summary": "Checked whether spec pre-condition implies the weakest pre-condition",
+            "metadata": {
+                **trace_meta,
+                "purpose": "check_pre_implies_wp",
+                "model": REASONER_SPEC_CHECK_MODEL,
+                "attempt": attempt,
+                "usage": usage,
+                "parsed_json": parsed_result,
+                "parse_error": parse_error,
+            },
+        }
+        record_llm_exchange(trace_dir, event_id, event, messages, response)
+        if has_violation is not None:
+            if has_violation:
+                stmts = stmts or "(unable to extract)"
+                reason = reason or "(unable to extract)"
+                return False, stmts, wp, reason
+            else:
+                return True, None, None, None
+        messages = messages + [
+            {"role": "assistant", "content": response or ""},
+            {
+                "role": "user",
+                "content": (
+                    "Return only valid JSON with schema: "
+                    "{\"verdict\": \"MATCH|MISMATCH\", "
+                    "\"counterexample\": string|null, "
+                    "\"offending_statements\": string|null, "
+                    "\"reason\": string}. "
+                    "For MISMATCH, all evidence fields must be non-empty strings. "
+                    "For MATCH, counterexample and offending_statements must be null or empty, and reason may be empty."
+                ),
+            }
+        ]
+    raise ValueError("Could not parse a valid structured JSON verdict from WP spec-check response.")
+
+
 def _load_spec_check_json(response):
     """Load a single JSON object from a specification-check response.
 

--- a/src/reasoner.py
+++ b/src/reasoner.py
@@ -1,6 +1,11 @@
 import re
 from config import *
-from .prompts import _generate_block_post_condition, _check_post_implies_spec
+from .prompts import (
+    _generate_block_post_condition,
+    _check_post_implies_spec,
+    _generate_block_wp,
+    _check_pre_implies_wp,
+)
 
 
 def _split_into_blocks(func):
@@ -242,6 +247,127 @@ def reasoner(func, spec, info, language, trace_context=None):
         current_pre = post_condition
 
     return "The function passes the verification. All code blocks satisfy the specification's post-condition."
+
+
+def wp_reasoner(func, spec, info, language, trace_context=None):
+    """Weakest Precondition reasoner — backward chain derivation.
+
+    Mirrors reasoner() but operates in reverse:
+    - Starts from spec_post_condition, traverses blocks backward
+    - Each block computes WP (the minimal pre-condition guaranteeing the post-condition)
+    - At function entry (i==0), checks spec_pre ⊨ wp (rather than post_n ⊨ spec_post at exit)
+
+    Returns (result_string, entry_wp):
+    - result_string: human-readable verdict (same interface as reasoner() for the string part)
+    - entry_wp: the WP at function entry (block 0), or None on failure.  Callers can
+      cache this for bottom-up callee→caller WP propagation.
+
+    This finds complementary bug classes to SP:
+    - SP finds "code did wrong" (forward contradiction)
+    - WP finds "code failed to guarantee" (backward gap / pre-condition too weak)
+    """
+    trace_context = trace_context or {}
+    trace_dir = trace_context.get("trace_dir")
+
+    # Step 1: Parse pre-condition and post-condition from spec (same as reasoner)
+    pre_condition, spec_post_condition = _parse_spec_conditions(spec)
+    if not pre_condition or not spec_post_condition:
+        return "Failed to parse pre/post conditions from the spec.", None
+
+    # Step 2: Split function into blocks (same as reasoner, reuse _split_into_blocks_braced)
+    blocks = _split_into_blocks_braced(func, language)
+
+    # Step 3: Backward traversal — start from the last block, derive WP toward the first
+    current_post = spec_post_condition  # Start from spec's post-condition
+    entry_wp = None  # WP at function entry (block 0); cached for upward propagation
+
+    for i in reversed(range(len(blocks))):
+        block = blocks[i]
+        trace_meta = {
+            "function_id": trace_context.get("function_id"),
+            "function_file": trace_context.get("function_file"),
+            "language": language,
+            "block_index": i,
+            "block_count": len(blocks),
+            "direction": "backward",
+        }
+
+        # 3a: Compute WP — given code block and post-condition, derive pre-condition
+        wp = _generate_block_wp(
+            block,
+            current_post,
+            info,
+            language,
+            trace_dir=trace_dir,
+            trace_meta=trace_meta,
+        )
+        if not wp:
+            return f"Failed to generate weakest pre-condition for block {i+1}.", None
+
+        # 3b: At function entry (i==0) or terminating statements, check spec_pre ⊨ wp
+        is_first_block = (i == 0)
+        if is_first_block:
+            entry_wp = wp  # Cache the function-entry WP for propagation
+        if is_first_block or _has_terminating_statement(block, language):
+            # Return order from _check_pre_implies_wp: (passed, stmts, wp, reason)
+            passed, stmts, wp_cond, reason = _check_pre_implies_wp(
+                block,
+                wp,
+                pre_condition,  # spec's pre-condition (what callers guarantee)
+                info,
+                language,
+                trace_dir=trace_dir,
+                trace_meta=trace_meta,
+            )
+            if not passed:
+                return (
+                    f"Verification FAILED (WP).\n"
+                    f"Statements triggering the violation:\n{stmts}\n\n"
+                    f"Weakest pre-condition:\n{wp_cond}\n\n"
+                    f"Reason for violation:\n{reason}"
+                ), wp
+
+        # 3c: This block's WP becomes the post-condition for the previous block
+        current_post = wp
+
+    return ("The function passes the WP verification. "
+            "The specification's pre-condition is sufficient to guarantee "
+            "the post-condition across all code paths."), entry_wp
+
+
+# ---------------------------------------------------------------------------
+# Callee WP propagation (bottom-up reasoning advantage)
+# ---------------------------------------------------------------------------
+
+def _collect_callee_wps(fqn, phase_fqns, wp_cache, callees_map):
+    """Collect WPs of all callees of fqn that are in phase_fqns and wp_cache.
+
+    In bottom-up mode, callees are processed before callers. When analyzing a
+    caller, all its callees' WPs are already cached. Injecting them into the
+    caller's reasoning context makes WP computation more precise: the caller
+    must guarantee each callee's pre-condition before calling it.
+    """
+    callee_wps = {}
+    for callee_fqn in callees_map.get(fqn, set()) & phase_fqns:
+        if callee_fqn in wp_cache:
+            callee_wps[callee_fqn] = wp_cache[callee_fqn]
+    return callee_wps
+
+
+def _format_callee_wps(callee_wps):
+    """Format callee WPs as info text for injection into the reasoning context.
+
+    Truncates each WP to 200 characters to prevent context explosion.
+    Only direct callees are propagated (no recursive grand-callee WPs).
+    """
+    if not callee_wps:
+        return ""
+    lines = ["Callee pre-condition requirements (from WP analysis):"]
+    for callee, wp in callee_wps.items():
+        short_name = callee.split("::")[-1]
+        truncated = wp[:200] + ("..." if len(wp) > 200 else "")
+        lines.append(f"  {short_name} requires: {truncated}")
+    return "\n".join(lines)
 
 def _sanitize_strings(obj):
     """Remove non-ASCII characters from all string values in a dict/list."""

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -12,7 +12,7 @@ import time
 from config import MAX_WORKERS, OPENCODE_MAX_RETRIES, OPENCODE_SPEC_MODEL
 from src.domain_knowledge import list_staged_domain_knowledge_relpaths
 from src.file_utils import _get_incomplete_verification_files, _get_phase_files, is_file_ready
-from src.generate_topdown_layers import generate_topdown_layers
+from src.generate_topdown_layers import generate_topdown_layers, generate_bottomup_layers
 from src.llm_client import build_llm_cli_command
 from src.opencode_trace import function_id_from_extracted_path, run_opencode_traced
 from src.verification import streaming_reasoner
@@ -112,7 +112,7 @@ def _run_spec_generation_batch(
 def run_spec_generation_and_verification(
     proj_dir, work_dir, input_dir, output_dir, script_dir, spec_prompts_dir,
     phases_data, resume=False, extra_call_edges=None, only_spec=False,
-    bug_validator_path=None,
+    bug_validator_path=None, reasoning_direction="topdown",
 ):
     # --- Stage 4: Execute spec generation workflow (per phase, per layer) ---
     batch_md_src = os.path.join(script_dir, "md", "workflow_spec_step4_batch.md")
@@ -133,11 +133,15 @@ def run_spec_generation_and_verification(
             continue
 
         # Determine how many layers this phase has
+        _layers_suffix = "bottomup_layers" if reasoning_direction == "bottomup" else "topdown_layers"
         layers_json_path = os.path.join(
-            spec_prompts_dir, f"phase_{phase_num:02d}_topdown_layers.json"
+            spec_prompts_dir, f"phase_{phase_num:02d}_{_layers_suffix}.json"
         )
         if not os.path.exists(layers_json_path):
-            generate_topdown_layers(work_dir, [phase_num], extra_call_edges=extra_call_edges)
+            if reasoning_direction == "bottomup":
+                generate_bottomup_layers(work_dir, [phase_num], extra_call_edges=extra_call_edges)
+            else:
+                generate_topdown_layers(work_dir, [phase_num], extra_call_edges=extra_call_edges)
         with open(layers_json_path, "r") as f:
             layers_data = json.load(f)
         total_layers = layers_data.get("total_layers", 1)
@@ -201,6 +205,7 @@ def run_spec_generation_and_verification(
                                 already_processed=all_processed | layer_processed,
                                 resume=resume,
                                 bug_validator_path=bug_validator_path,
+                                reasoning_direction=reasoning_direction,
                             )
                             layer_processed.update(newly_processed)
                     break
@@ -245,6 +250,7 @@ def run_spec_generation_and_verification(
                             already_processed=all_processed | layer_processed,
                             resume=resume,
                             bug_validator_path=bug_validator_path,
+                            reasoning_direction=reasoning_direction,
                         )
                         layer_processed.update(newly_processed)
 

--- a/src/verification.py
+++ b/src/verification.py
@@ -1,7 +1,14 @@
 import config
 from config import MAX_WORKERS, OPENCODE_BUG_VALIDATION_MODEL
 from .parser import parse_input_function
-from .reasoner import reasoner, _parse_spec_conditions, _sanitize_strings
+from .reasoner import (
+    reasoner,
+    wp_reasoner,
+    _parse_spec_conditions,
+    _sanitize_strings,
+    _collect_callee_wps,
+    _format_callee_wps,
+)
 from .file_utils import is_file_ready
 from .opencode_trace import function_id_from_result_path, run_opencode_traced
 from .llm_client import build_llm_cli_command
@@ -72,6 +79,7 @@ def streaming_reasoner(
     already_processed=None,
     resume=False,
     bug_validator_path=None,
+    reasoning_direction="topdown",
 ):
     """Continuously watch input_dir for ready files, verify them, and validate bugs."""
     if work_dir is None:
@@ -110,6 +118,17 @@ def streaming_reasoner(
     logging.info(f"Watching {input_dir} for ready files (poll every {poll_interval}s)...")
     completed_count = 0
 
+    # WP cache: fqn -> wp_string. Maintained only in bottomup mode so that
+    # callees' WPs are available when analyzing their callers.
+    wp_cache = {} if reasoning_direction == "bottomup" else None
+    # Load callees_map from bottomup layers JSON for WP propagation
+    callees_map = None
+    phase_fqns = None
+    if reasoning_direction == "bottomup" and work_dir:
+        callees_map, phase_fqns = _load_callees_from_layers(work_dir)
+        if callees_map:
+            logging.info(f"Loaded {len(callees_map)} callee entries from bottomup layers for WP propagation")
+
     try:
         with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
             reasoning_futures = {}
@@ -137,7 +156,9 @@ def streaming_reasoner(
                         submitted.add(file_path)
                         language = EXT_TO_LANG.get(ext, "C")
                         future = executor.submit(
-                            _verify_single_file, file_path, input_dir, output_dir, language, work_dir, resume
+                            _verify_single_file, file_path, input_dir, output_dir, language, work_dir, resume,
+                            reasoning_direction=reasoning_direction, wp_cache=wp_cache,
+                            callees_map=callees_map, phase_fqns=phase_fqns,
                         )
                         reasoning_futures[future] = file_path
                         logging.info(f"Submitted: {file_path}")
@@ -265,7 +286,41 @@ def streaming_reasoner(
     return processed
 
 
-def _verify_single_file(file_path, input_dir, output_dir, language, work_dir=None, resume=False):
+def _load_callees_from_layers(work_dir):
+    """Load a global callees_map from all bottomup_layers.json files.
+
+    Used by WP reasoning to look up a function's callees for WP propagation.
+    Returns (callees_map, phase_fqns) where callees_map maps fqn -> set(callee_fqn).
+    """
+    from pathlib import Path
+    callees_map = {}
+    phase_fqns = set()
+    spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
+    if not os.path.isdir(spec_prompts_dir):
+        return callees_map, phase_fqns
+    for json_path in sorted(Path(spec_prompts_dir).glob("phase_*_bottomup_layers.json")):
+        try:
+            with open(json_path) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+        for layer in data.get("layers", []):
+            for func_entry in layer.get("functions", []):
+                fqn = func_entry["name"]
+                phase_fqns.add(fqn)
+                # Collect callees from phase-specific and all_callees fields
+                callees = set()
+                for key, val in func_entry.items():
+                    if key.endswith("_callees") or key == "all_callees":
+                        if isinstance(val, list):
+                            callees.update(val)
+                callees_map[fqn] = callees
+    return callees_map, phase_fqns
+
+
+def _verify_single_file(file_path, input_dir, output_dir, language, work_dir=None, resume=False,
+                        reasoning_direction="topdown", wp_cache=None,
+                        callees_map=None, phase_fqns=None):
     """Verify a single file and write the result JSON."""
     # Skip if resuming and a valid result already exists
     rel = os.path.relpath(file_path, input_dir)
@@ -299,26 +354,47 @@ def _verify_single_file(file_path, input_dir, output_dir, language, work_dir=Non
         domain_knowledge = load_staged_domain_knowledge_text(work_dir) if work_dir else ""
         if domain_knowledge:
             knowledge = f"{knowledge}\n\n{domain_knowledge}" if knowledge else domain_knowledge
-        result = reasoner(func, spec, knowledge, language, trace_context=trace_context)
 
-        if "passes the verification" in result:
+        if reasoning_direction == "bottomup":
+            # Inject callee WP info for more precise backward analysis
+            enhanced_info = knowledge
+            if wp_cache is not None and callees_map is not None and phase_fqns is not None:
+                fqn = trace_context["function_id"] if trace_context else None
+                if fqn:
+                    callee_wps = _collect_callee_wps(fqn, phase_fqns, wp_cache, callees_map)
+                    callee_wp_text = _format_callee_wps(callee_wps)
+                    if callee_wp_text:
+                        enhanced_info = f"{knowledge}\n\n{callee_wp_text}" if knowledge else callee_wp_text
+            result, entry_wp = wp_reasoner(func, spec, enhanced_info, language, trace_context=trace_context)
+            # Cache the actual WP for upward propagation to callers
+            if wp_cache is not None and trace_context:
+                fqn = trace_context.get("function_id")
+                if fqn and entry_wp:
+                    wp_cache[fqn] = entry_wp
+        else:
+            result = reasoner(func, spec, knowledge, language, trace_context=trace_context)
+
+        if "passes" in result and "verification" in result:
             output = {"function": file_path, "verdict": "MATCH", "gaps": None}
         elif result.startswith("Failed to "):
             output = {"function": file_path, "verdict": "ERROR", "gaps": None, "error": result}
         else:
             stmts = post_cond = reason_text = ""
+            # Handle both SP ("Post-condition:") and WP ("Weakest pre-condition:") formats
             stmts_match = re.search(
-                r"Statements triggering the violation:\n(.*?)\n\nPost-condition:", result, re.DOTALL
+                r"Statements triggering the violation:\n(.*?)\n\n(?:Post-condition|Weakest pre-condition):",
+                result, re.DOTALL
             )
-            post_match = re.search(
-                r"Post-condition:\n(.*?)\n\nReason for violation:", result, re.DOTALL
+            cond_match = re.search(
+                r"(?:Post-condition|Weakest pre-condition):\n(.*?)\n\nReason for violation:",
+                result, re.DOTALL
             )
             reason_match = re.search(r"Reason for violation:\n(.*)", result, re.DOTALL)
 
             if stmts_match:
                 stmts = stmts_match.group(1).strip()
-            if post_match:
-                post_cond = post_match.group(1).strip()
+            if cond_match:
+                post_cond = cond_match.group(1).strip()
             if reason_match:
                 reason_text = reason_match.group(1).strip()
 

--- a/tests/test_wp_reasoner.py
+++ b/tests/test_wp_reasoner.py
@@ -1,0 +1,669 @@
+"""
+Unit tests for WP (Weakest Precondition) reasoning components.
+
+Tests cover:
+1. _parse_wp_json() — WP JSON response validation
+2. _compute_bottomup_layers() — leaf-first topological layering + cycle handling
+3. _collect_callee_wps() / _format_callee_wps() — callee WP propagation
+4. _parse_spec_conditions() — spec pre/post condition parsing (shared with SP)
+5. Result format handling — both SP and WP verdict strings
+
+These tests do NOT make LLM calls — they test the pure-logic helper functions.
+Run with: python -m pytest tests/test_wp_reasoner.py -v
+"""
+
+import sys
+import os
+import json
+
+# Ensure the project root is on the path
+_proj_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _proj_root not in sys.path:
+    sys.path.insert(0, _proj_root)
+
+import pytest
+from src.reasoner import (
+    _parse_spec_conditions,
+    _collect_callee_wps,
+    _format_callee_wps,
+)
+from src.prompts import _parse_wp_json
+from src.generate_topdown_layers import (
+    _compute_layers,
+    _compute_bottomup_layers,
+    _tarjan_scc,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. _parse_wp_json — WP JSON response validation
+# ---------------------------------------------------------------------------
+
+class TestParseWpJson:
+    """Test _parse_wp_json() validates WP LLM responses correctly."""
+
+    def test_valid_json(self):
+        data = {"pre_condition": "x > 0 and y != None"}
+        result = _parse_wp_json(data)
+        assert result == "x > 0 and y != None"
+
+    def test_strips_whitespace(self):
+        data = {"pre_condition": "  x > 0  "}
+        result = _parse_wp_json(data)
+        assert result == "x > 0"
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            _parse_wp_json({"pre_condition": ""})
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            _parse_wp_json({"pre_condition": "   "})
+
+    def test_missing_field_raises(self):
+        with pytest.raises(ValueError, match="pre_condition"):
+            _parse_wp_json({"post_condition": "x > 0"})
+
+    def test_non_string_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            _parse_wp_json({"pre_condition": 123})
+
+    def test_non_dict_raises(self):
+        with pytest.raises(ValueError, match="object"):
+            _parse_wp_json("not a dict")
+
+    def test_none_raises(self):
+        with pytest.raises(ValueError, match="object"):
+            _parse_wp_json(None)
+
+    def test_complex_condition(self):
+        wp = ("For all elements e in array: e.field != NULL. "
+              "Array length > 0. Mutex m is locked.")
+        data = {"pre_condition": wp}
+        result = _parse_wp_json(data)
+        assert result == wp
+
+
+# ---------------------------------------------------------------------------
+# 2. _compute_bottomup_layers — leaf-first topological layering
+# ---------------------------------------------------------------------------
+
+class TestComputeBottomupLayers:
+    """Test _compute_bottomup_layers() produces correct leaf-first ordering."""
+
+    def test_simple_chain(self):
+        """entry -> helper -> leaf: bottom-up should be [leaf], [helper], [entry]."""
+        # callees_map: who each function calls
+        callees_map = {
+            "entry": {"helper"},
+            "helper": {"leaf"},
+            "leaf": set(),
+        }
+        callers_map = {
+            "entry": set(),
+            "helper": {"entry"},
+            "leaf": {"helper"},
+        }
+        phase_fqns = {"entry", "helper", "leaf"}
+
+        layers = _compute_bottomup_layers(phase_fqns, callees_map, callers_map)
+        assert len(layers) == 3
+        # Layer 0: leaf (no callees)
+        assert layers[0]["functions"] == ["leaf"]
+        assert not layers[0]["cycle_resolution"]
+        # Layer 1: helper (callees = {leaf}, already assigned)
+        assert layers[1]["functions"] == ["helper"]
+        # Layer 2: entry (callees = {helper}, already assigned)
+        assert layers[2]["functions"] == ["entry"]
+
+    def test_diamond(self):
+        """entry -> {a, b} -> leaf: bottom-up should be [leaf], [a, b], [entry]."""
+        callees_map = {
+            "entry": {"a", "b"},
+            "a": {"leaf"},
+            "b": {"leaf"},
+            "leaf": set(),
+        }
+        callers_map = {
+            "entry": set(),
+            "a": {"entry"},
+            "b": {"entry"},
+            "leaf": {"a", "b"},
+        }
+        phase_fqns = {"entry", "a", "b", "leaf"}
+
+        layers = _compute_bottomup_layers(phase_fqns, callees_map, callers_map)
+        assert len(layers) == 3
+        assert layers[0]["functions"] == ["leaf"]
+        # a and b should be in the same layer (both depend only on leaf)
+        assert set(layers[1]["functions"]) == {"a", "b"}
+        assert layers[2]["functions"] == ["entry"]
+
+    def test_isolated_functions(self):
+        """Functions with no callees and no callers go first."""
+        callees_map = {
+            "f1": set(),
+            "f2": set(),
+            "f3": set(),
+        }
+        callers_map = {
+            "f1": set(),
+            "f2": set(),
+            "f3": set(),
+        }
+        phase_fqns = {"f1", "f2", "f3"}
+
+        layers = _compute_bottomup_layers(phase_fqns, callees_map, callers_map)
+        assert len(layers) == 1
+        assert set(layers[0]["functions"]) == {"f1", "f2", "f3"}
+
+    def test_cycle_mutual_recursion(self):
+        """a <-> b (mutual recursion): both should be in the same cycle layer."""
+        callees_map = {
+            "a": {"b"},
+            "b": {"a"},
+        }
+        callers_map = {
+            "a": {"b"},
+            "b": {"a"},
+        }
+        phase_fqns = {"a", "b"}
+
+        layers = _compute_bottomup_layers(phase_fqns, callees_map, callers_map)
+        # Both should end up in a single layer (cycle resolution)
+        assert len(layers) >= 1
+        all_fns = set()
+        for layer in layers:
+            all_fns.update(layer["functions"])
+        assert all_fns == {"a", "b"}
+        # At least one layer should mark cycle_resolution
+        assert any(l.get("cycle_resolution") for l in layers)
+
+    def test_cycle_with_entry(self):
+        """entry -> {a, b} where a <-> b: leaf-first, cycle layer, then entry."""
+        callees_map = {
+            "entry": {"a", "b"},
+            "a": {"b"},
+            "b": {"a"},
+        }
+        callers_map = {
+            "entry": set(),
+            "a": {"entry", "b"},
+            "b": {"entry", "a"},
+        }
+        phase_fqns = {"entry", "a", "b"}
+
+        layers = _compute_bottomup_layers(phase_fqns, callees_map, callers_map)
+        # a and b form a cycle, entry depends on both
+        # Layer 0: {a, b} (cycle, all callees within cycle)
+        # Layer 1: {entry}
+        assert len(layers) == 2
+        assert set(layers[0]["functions"]) == {"a", "b"}
+        assert layers[0].get("cycle_resolution") is True
+        assert layers[1]["functions"] == ["entry"]
+
+    def test_topdown_vs_bottomup_reversed(self):
+        """Bottom-up layers should be the reverse of top-down for a simple chain."""
+        callees_map = {
+            "entry": {"mid"},
+            "mid": {"leaf"},
+            "leaf": set(),
+        }
+        callers_map = {
+            "entry": set(),
+            "mid": {"entry"},
+            "leaf": {"mid"},
+        }
+        phase_fqns = {"entry", "mid", "leaf"}
+
+        td_layers = _compute_layers(phase_fqns, callees_map, callers_map)
+        bu_layers = _compute_bottomup_layers(phase_fqns, callees_map, callers_map)
+
+        # Top-down: entry, mid, leaf
+        td_order = [f for l in td_layers for f in l["functions"]]
+        # Bottom-up: leaf, mid, entry
+        bu_order = [f for l in bu_layers for f in l["functions"]]
+        assert td_order == ["entry", "mid", "leaf"]
+        assert bu_order == ["leaf", "mid", "entry"]
+        assert bu_order == list(reversed(td_order))
+
+    def test_empty_input(self):
+        """Empty phase should produce empty layers."""
+        layers = _compute_bottomup_layers(set(), {}, {})
+        assert layers == []
+
+    def test_cross_phase_callees_ignored(self):
+        """Only same-phase callees affect readiness."""
+        callees_map = {
+            "f1": {"f2", "external_func"},  # external_func not in phase
+            "f2": set(),
+        }
+        callers_map = {
+            "f1": set(),
+            "f2": {"f1"},
+        }
+        phase_fqns = {"f1", "f2"}
+
+        layers = _compute_bottomup_layers(phase_fqns, callees_map, callers_map)
+        # f2 has no same-phase callees -> layer 0
+        # f1's only same-phase callee is f2 -> layer 1
+        assert len(layers) == 2
+        assert layers[0]["functions"] == ["f2"]
+        assert layers[1]["functions"] == ["f1"]
+
+
+# ---------------------------------------------------------------------------
+# 3. _collect_callee_wps / _format_callee_wps — WP propagation
+# ---------------------------------------------------------------------------
+
+class TestCalleeWpPropagation:
+    """Test callee WP collection and formatting for upward propagation."""
+
+    def test_collect_simple(self):
+        callees_map = {
+            "caller": {"callee_a", "callee_b"},
+        }
+        phase_fqns = {"caller", "callee_a", "callee_b"}
+        wp_cache = {
+            "callee_a": "x > 0",
+            "callee_b": "list is non-empty",
+        }
+        result = _collect_callee_wps("caller", phase_fqns, wp_cache, callees_map)
+        assert result == {"callee_a": "x > 0", "callee_b": "list is non-empty"}
+
+    def test_collect_filters_uncached(self):
+        """Callees not yet in wp_cache are skipped."""
+        callees_map = {
+            "caller": {"callee_a", "callee_b", "callee_c"},
+        }
+        phase_fqns = {"caller", "callee_a", "callee_b", "callee_c"}
+        wp_cache = {
+            "callee_a": "x > 0",
+            # callee_b not cached yet
+            "callee_c": "y != NULL",
+        }
+        result = _collect_callee_wps("caller", phase_fqns, wp_cache, callees_map)
+        assert "callee_a" in result
+        assert "callee_b" not in result
+        assert "callee_c" in result
+
+    def test_collect_filters_out_of_phase(self):
+        """Callees not in phase_fqns are excluded."""
+        callees_map = {
+            "caller": {"in_phase", "out_of_phase"},
+        }
+        phase_fqns = {"caller", "in_phase"}
+        wp_cache = {
+            "in_phase": "x > 0",
+            "out_of_phase": "should be ignored",
+        }
+        result = _collect_callee_wps("caller", phase_fqns, wp_cache, callees_map)
+        assert "in_phase" in result
+        assert "out_of_phase" not in result
+
+    def test_collect_no_callees(self):
+        """Function with no callees returns empty dict."""
+        callees_map = {"lonely": set()}
+        phase_fqns = {"lonely"}
+        wp_cache = {}
+        result = _collect_callee_wps("lonely", phase_fqns, wp_cache, callees_map)
+        assert result == {}
+
+    def test_collect_empty_cache(self):
+        """Empty wp_cache returns empty dict."""
+        callees_map = {"caller": {"callee"}}
+        phase_fqns = {"caller", "callee"}
+        wp_cache = {}
+        result = _collect_callee_wps("caller", phase_fqns, wp_cache, callees_map)
+        assert result == {}
+
+    def test_format_simple(self):
+        callee_wps = {
+            "module::callee_a": "x > 0",
+            "module::callee_b": "list is non-empty",
+        }
+        result = _format_callee_wps(callee_wps)
+        assert "Callee pre-condition requirements" in result
+        assert "callee_a requires: x > 0" in result
+        assert "callee_b requires: list is non-empty" in result
+
+    def test_format_truncates_long_wp(self):
+        long_wp = "A" * 250
+        callee_wps = {"mod::func": long_wp}
+        result = _format_callee_wps(callee_wps)
+        # Should be truncated to 200 chars + "..."
+        assert "..." in result
+        assert "AAAA" in result  # Still contains the content
+
+    def test_format_empty(self):
+        result = _format_callee_wps({})
+        assert result == ""
+
+    def test_format_short_name(self):
+        """FQN should be shortened to last component."""
+        callee_wps = {"a::b::c::deep_func": "x > 0"}
+        result = _format_callee_wps(callee_wps)
+        assert "deep_func requires:" in result
+        assert "a::b::c::deep_func requires:" not in result
+
+
+# ---------------------------------------------------------------------------
+# 4. _parse_spec_conditions — spec parsing (shared with SP)
+# ---------------------------------------------------------------------------
+
+class TestParseSpecConditions:
+    """Test spec pre/post condition parsing — critical for both SP and WP."""
+
+    def test_standard_format(self):
+        spec = """Pre-condition:
+x >= 0 and x < MAX_SIZE
+
+Post-condition:
+result == factorial(x) and result >= 1"""
+        pre, post = _parse_spec_conditions(spec)
+        assert pre is not None
+        assert "x >= 0" in pre
+        assert "x < MAX_SIZE" in pre
+        assert post is not None
+        assert "factorial(x)" in post
+
+    def test_missing_post_condition(self):
+        spec = """Pre-condition:
+x >= 0"""
+        pre, post = _parse_spec_conditions(spec)
+        assert pre is not None
+        assert post is None
+
+    def test_missing_pre_condition(self):
+        spec = """Post-condition:
+result == 0"""
+        pre, post = _parse_spec_conditions(spec)
+        assert pre is None
+        assert post is not None
+
+    def test_empty_spec(self):
+        pre, post = _parse_spec_conditions("")
+        assert pre is None
+        assert post is None
+
+    def test_multiline_conditions(self):
+        spec = """Pre-condition:
+- x must be a non-negative integer
+- buffer must have at least x bytes allocated
+- mutex must be held
+
+Post-condition:
+- buffer is filled with x bytes of data
+- return value is 0 on success, -1 on error"""
+        pre, post = _parse_spec_conditions(spec)
+        assert "non-negative" in pre
+        assert "mutex" in pre
+        assert "buffer is filled" in post
+        assert "return value is 0" in post
+
+
+# ---------------------------------------------------------------------------
+# 5. Result format handling — SP vs WP verdict strings
+# ---------------------------------------------------------------------------
+
+class TestResultFormatHandling:
+    """Test that the verification result regex handles both SP and WP formats.
+
+    This mirrors the regex logic in verification._verify_single_file().
+    """
+
+    def test_sp_success_string(self):
+        """SP success message should be detected as 'passes'."""
+        result = "The function passes the verification. All code blocks satisfy the specification's post-condition."
+        assert "passes" in result and "verification" in result
+
+    def test_wp_success_string(self):
+        """WP success message should be detected as 'passes'."""
+        result = ("The function passes the WP verification. "
+                  "The specification's pre-condition is sufficient to guarantee "
+                  "the post-condition across all code paths.")
+        assert "passes" in result and "verification" in result
+
+    def test_sp_failure_format(self):
+        """SP failure uses 'Post-condition:' label."""
+        import re
+        result = """Verification FAILED.
+Statements triggering the violation:
+Line 5: if (x == 0) return -1;
+
+Post-condition:
+result >= 0
+
+Reason for violation:
+The code can return -1 when x == 0, violating the post-condition that result >= 0."""
+
+        stmts_match = re.search(
+            r"Statements triggering the violation:\n(.*?)\n\n(?:Post-condition|Weakest pre-condition):",
+            result, re.DOTALL
+        )
+        assert stmts_match is not None
+        assert "Line 5" in stmts_match.group(1)
+
+        cond_match = re.search(
+            r"(?:Post-condition|Weakest pre-condition):\n(.*?)\n\nReason for violation:",
+            result, re.DOTALL
+        )
+        assert cond_match is not None
+        assert "result >= 0" in cond_match.group(1)
+
+    def test_wp_failure_format(self):
+        """WP failure uses 'Weakest pre-condition:' label."""
+        import re
+        result = """Verification FAILED (WP).
+Statements triggering the violation:
+Line 3: int result = array[index];
+
+Weakest pre-condition:
+index < array_length and index >= 0
+
+Reason for violation:
+The spec pre-condition only guarantees 'index is non-negative' but the code
+requires 'index < array_length' to avoid out-of-bounds access."""
+
+        stmts_match = re.search(
+            r"Statements triggering the violation:\n(.*?)\n\n(?:Post-condition|Weakest pre-condition):",
+            result, re.DOTALL
+        )
+        assert stmts_match is not None
+        assert "Line 3" in stmts_match.group(1)
+
+        cond_match = re.search(
+            r"(?:Post-condition|Weakest pre-condition):\n(.*?)\n\nReason for violation:",
+            result, re.DOTALL
+        )
+        assert cond_match is not None
+        assert "index < array_length" in cond_match.group(1)
+
+    def test_reason_extraction_both_formats(self):
+        """Reason for violation should be extractable from both SP and WP results."""
+        import re
+
+        sp_result = """Verification FAILED.
+Statements triggering the violation:
+Line 5: return -1;
+
+Post-condition:
+result >= 0
+
+Reason for violation:
+Returns negative value."""
+
+        wp_result = """Verification FAILED (WP).
+Statements triggering the violation:
+Line 3: x = 1 / y;
+
+Weakest pre-condition:
+y != 0
+
+Reason for violation:
+Division by zero when y == 0."""
+
+        for result in [sp_result, wp_result]:
+            reason_match = re.search(r"Reason for violation:\n(.*)", result, re.DOTALL)
+            assert reason_match is not None
+            assert len(reason_match.group(1).strip()) > 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: bottom-up layering simulates real call graphs
+# ---------------------------------------------------------------------------
+
+class TestBottomupLayeringIntegration:
+    """Integration tests with realistic call graph structures."""
+
+    def test_multi_phase_realistic(self):
+        """Simulate a realistic module with 6 functions and mixed dependencies."""
+        # f1 (entry) calls f2, f3
+        # f2 calls f4
+        # f3 calls f4, f5
+        # f4 calls f6 (leaf)
+        # f5 calls f6 (leaf)
+        # f6 is a leaf (no callees)
+        callees_map = {
+            "f1": {"f2", "f3"},
+            "f2": {"f4"},
+            "f3": {"f4", "f5"},
+            "f4": {"f6"},
+            "f5": {"f6"},
+            "f6": set(),
+        }
+        callers_map = {
+            "f1": set(),
+            "f2": {"f1"},
+            "f3": {"f1"},
+            "f4": {"f2", "f3"},
+            "f5": {"f3"},
+            "f6": {"f4", "f5"},
+        }
+        phase_fqns = set(callees_map.keys())
+
+        layers = _compute_bottomup_layers(phase_fqns, callees_map, callers_map)
+
+        # Verify leaf-first ordering
+        assigned_order = []
+        for layer in layers:
+            assigned_order.extend(layer["functions"])
+
+        # f6 must come before f4 and f5
+        assert assigned_order.index("f6") < assigned_order.index("f4")
+        assert assigned_order.index("f6") < assigned_order.index("f5")
+        # f4 and f5 must come before f2 and f3
+        assert assigned_order.index("f4") < assigned_order.index("f2")
+        assert assigned_order.index("f4") < assigned_order.index("f3")
+        assert assigned_order.index("f5") < assigned_order.index("f3")
+        # f2 and f3 must come before f1
+        assert assigned_order.index("f2") < assigned_order.index("f1")
+        assert assigned_order.index("f3") < assigned_order.index("f1")
+
+    def test_wp_propagation_simulation(self):
+        """Simulate the WP propagation flow: leaf WPs flow up to entry."""
+        callees_map = {
+            "entry": {"helper"},
+            "helper": {"leaf"},
+            "leaf": set(),
+        }
+        phase_fqns = {"entry", "helper", "leaf"}
+
+        # Simulate bottom-up processing
+        layers = _compute_bottomup_layers(phase_fqns, callees_map, {})
+        wp_cache = {}
+
+        for layer in layers:
+            for fqn in layer["functions"]:
+                # Simulate WP computation
+                if fqn == "leaf":
+                    wp_cache[fqn] = "input > 0"
+                elif fqn == "helper":
+                    # Collect callee WP
+                    callee_wps = _collect_callee_wps(fqn, phase_fqns, wp_cache, callees_map)
+                    assert "leaf" in callee_wps
+                    assert callee_wps["leaf"] == "input > 0"
+                    wp_cache[fqn] = "input > 0 (propagated from leaf)"
+                elif fqn == "entry":
+                    callee_wps = _collect_callee_wps(fqn, phase_fqns, wp_cache, callees_map)
+                    assert "helper" in callee_wps
+                    assert "propagated from leaf" in callee_wps["helper"]
+                    wp_cache[fqn] = "input > 0 (propagated through helper)"
+
+        assert "entry" in wp_cache
+        assert "helper" in wp_cache
+        assert "leaf" in wp_cache
+
+
+class TestWpReasonerReturnOrder:
+    """Regression test: verify _check_pre_implies_wp return values are correctly
+    mapped to the error message fields in wp_reasoner().
+
+    Bug: the return order (passed, stmts, wp, reason) was unpacked as
+    (passed, stmts, reason, wp_cond), swapping wp and reason in the output.
+    """
+
+    def test_violation_fields_not_swapped(self):
+        """Ensure 'Weakest pre-condition' shows the WP, not the reason, and vice versa."""
+        from unittest.mock import patch, MagicMock
+        from src.reasoner import wp_reasoner
+
+        spec = "[SPEC]\nPre: input >= 0\nPost: result >= 0"
+        func_body = "int x = input + 1; return x;"
+
+        with patch("src.reasoner._parse_spec_conditions", return_value=("spec_pre", "spec_post")), \
+             patch("src.reasoner._split_into_blocks_braced", return_value=[func_body]), \
+             patch("src.reasoner._generate_block_wp", return_value="WP_AT_ENTRY"), \
+             patch("src.reasoner._has_terminating_statement", return_value=False), \
+             patch("src.reasoner._check_pre_implies_wp",
+                   return_value=(False, "OFFENDING_LINE_42", "WP_AT_ENTRY", "CALLER_GUARANTEE_INSUFFICIENT")):
+            result, entry_wp = wp_reasoner(func_body, spec, "", "C")
+
+        # entry_wp should be the WP computed at block 0
+        assert entry_wp == "WP_AT_ENTRY"
+
+        # The error message must map fields correctly (NOT swapped):
+        # - "Statements triggering" → OFFENDING_LINE_42
+        # - "Weakest pre-condition" → WP_AT_ENTRY
+        # - "Reason for violation" → CALLER_GUARANTEE_INSUFFICIENT
+        assert "OFFENDING_LINE_42" in result
+        assert "Weakest pre-condition:\nWP_AT_ENTRY" in result
+        assert "Reason for violation:\nCALLER_GUARANTEE_INSUFFICIENT" in result
+
+        # Negative assertions: the values must NOT appear in the wrong sections
+        assert "Weakest pre-condition:\nCALLER_GUARANTEE_INSUFFICIENT" not in result
+        assert "Reason for violation:\nWP_AT_ENTRY" not in result
+
+    def test_success_returns_entry_wp(self):
+        """On success, wp_reasoner returns (message, entry_wp) where entry_wp is the WP at block 0."""
+        from unittest.mock import patch
+        from src.reasoner import wp_reasoner
+
+        spec = "[SPEC]\nPre: input >= 0\nPost: result >= 0"
+        func_body = "int x = input + 1; return x;"
+
+        with patch("src.reasoner._parse_spec_conditions", return_value=("spec_pre", "spec_post")), \
+             patch("src.reasoner._split_into_blocks_braced", return_value=[func_body]), \
+             patch("src.reasoner._generate_block_wp", return_value="THE_WP_VALUE"), \
+             patch("src.reasoner._has_terminating_statement", return_value=False), \
+             patch("src.reasoner._check_pre_implies_wp",
+                   return_value=(True, None, None, None)):
+            result, entry_wp = wp_reasoner(func_body, spec, "", "C")
+
+        assert "passes the WP verification" in result
+        assert entry_wp == "THE_WP_VALUE"
+
+    def test_parse_failure_returns_none_wp(self):
+        """On spec parse failure, wp_reasoner returns (error_msg, None)."""
+        from unittest.mock import patch
+        from src.reasoner import wp_reasoner
+
+        with patch("src.reasoner._parse_spec_conditions", return_value=(None, None)):
+            result, entry_wp = wp_reasoner("func body", "bad spec", "", "C")
+
+        assert "Failed to parse" in result
+        assert entry_wp is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
# feat: add WP (weakest precondition) bottom-up reasoning

## Summary

This PR adds a symmetric backward-reasoning mode (Weakest Precondition / bottom-up) alongside the existing SP (Strongest Postcondition / top-down) forward reasoning.

WP derives the minimal pre-condition from the spec's post-condition and checks `spec_pre ⊨ wp` at function entry, finding complementary bug classes to SP.

## Motivation

Hoare logic supports two dual reasoning directions:
- **SP (forward/top-down)**: `pre → block₁ → post₁ → ... → postₙ`; checks `postₙ ⊨ spec_post` at exit → finds "code did wrong" (forward contradiction)
- **WP (backward/bottom-up)**: `spec_post ← blockₙ ← wpₙ ← ... ← wp₁`; checks `spec_pre ⊨ wp₁` at entry → finds "code failed to guarantee" (backward gap / pre-condition too weak)

Some bugs that SP misses (e.g., missing upper-bound check, unhandled zero-case branch, caller not guaranteeing callee pre-condition) are naturally caught by WP, and vice versa.

## Changes

**9 source files (+699 lines), 1 design doc, 41 unit tests, 5 demo examples:**

### Core
- `config.py`: `REASONING_DIRECTION` config + `REASONER_WP_MODEL` constant
- `fm-agent.toml`: `reasoning_direction = "topdown"` (default, opt-in)
- `src/prompts.py`: `_generate_block_wp()`, `_check_pre_implies_wp()`, `_parse_wp_json()` — mirror SP prompt functions, backward direction
- `src/reasoner.py`: `wp_reasoner()` — backward chain derivation; `_collect_callee_wps()`, `_format_callee_wps()` — WP propagation

### Integration
- `src/generate_topdown_layers.py`: `_compute_bottomup_layers()`, `generate_bottomup_layers()` — leaf-first topological sort with Tarjan SCC on `callees_map`
- `src/verification.py`: direction routing in `_verify_single_file()` and `streaming_reasoner()`; `_load_callees_from_layers()` for WP propagation; regex handles both SP/WP result formats
- `main.py`: `--reasoning-direction` CLI arg; direction-aware Stage 5/6
- `src/entry_reasoning_pipeline.py`: pass-through `reasoning_direction`
- `src/incremental_reasoner.py`: direction-aware layer generation and `_verify_incremental_functions()` passthrough

### Tests & Examples
- `tests/test_wp_reasoner.py`: 41 unit tests (all passing) — JSON parsing, bottom-up layering, callee WP propagation, spec parsing, result format handling, integration
- `examples/wp_demo/`: 5 C files demonstrating SP/WP complementarity + README
- `docs/wp_reasoning_design.md`: Full design document

## Design Principles

- **Non-invasive**: Default remains `topdown` (SP), fully backward compatible
- **Architecture symmetry**: WP reasoner, prompts, and layering algorithm mirror existing SP implementation
- **Callee WP propagation**: Core advantage of bottom-up — callee WPs are computed first and injected into caller's reasoning context via `wp_cache`

## Usage

```bash
# Existing SP mode (default, unchanged)
python main.py /path/to/project

# New WP mode
python main.py /path/to/project --reasoning-direction bottomup
```

## Test Results

```
41 passed in 0.42s
```

## Checklist

- [x] All code follows existing project conventions and style
- [x] Default behavior is unchanged (backward compatible)
- [x] Unit tests added and passing (41 tests)
- [x] Demo examples added showing SP/WP complementarity
- [x] Design document included
- [x] All modified Python files pass `py_compile` syntax check
