### PR TITLE
Add pre-run scope and cost estimates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,5 +218,6 @@ docs/superpowers/
 
 .opencode/
 .codegraph/
+fm_agent_estimate/
 CLAUDE.md
 AGENTS.md

--- a/README.md
+++ b/README.md
@@ -217,8 +217,30 @@ uv run python main.py <proj_dir> [--resume] [--domain-knowledge FILE ...] [--bug
 | `--submodule PATH [PATH ...]` | Only process source code under one or more subdirectories of `proj_dir`. |
 | `--extra-edge FILE`         | Add supplemental caller-to-callee edges to the static call graph from a JSON file or directory. |
 | `--only-spec`               | Only generate behavioral specs; skip the reasoning and bug validation stages. Cannot be combined with `--incremental`. |
+| `--estimate`                | Scan scope and print a history-based time, LLM-call, token, and cost estimate without making LLM calls. |
 
 `proj_dir` must be a git repository.
+
+### Pre-run estimate
+
+Inspect the planned source scope before spending any model tokens:
+
+```bash
+uv run python main.py <proj_dir> --estimate
+uv run python main.py <proj_dir> --estimate --submodule src/core src/runtime
+```
+
+The preflight lists included and excluded directories, included/excluded source
+file counts, an approximate function count from local extraction, and the six
+analysis stages. When completed runs are available, it scales their actual
+duration, LLM-call count, token usage, and cost by the current function count
+(falling back to file count) and reports a range. Every projected value is
+labelled **ESTIMATE**; with no completed history it reports that the estimate is
+unavailable instead of inventing a number.
+
+Successful-run summaries are retained in `fm_agent/history.jsonl` across fresh
+runs. A normal run also generates `fm_agent/estimate.json` before its first LLM
+stage, so the live dashboard can show the same preflight alongside actual usage.
 
 To provide project-specific domain knowledge without editing FM-Agent's built-in prompts, pass one or more Markdown files:
 
@@ -297,10 +319,18 @@ If `fm_agent/version.log` does not exist (no previous run to compare against), F
 
 ### Live Dashboard
 
-FM-Agent ships a standalone real-time TUI dashboard ([dashboard.py](dashboard.py)) that visualizes a run as it progresses: per-stage progress, token usage and cost, prompt-cache hit rate, and bug-validation verdicts. It reads the trace files FM-Agent writes under `fm_agent/`, so run it in a second terminal while `main.py` is going:
+FM-Agent ships a standalone real-time TUI dashboard ([dashboard.py](dashboard.py)) that visualizes a run as it progresses: pre-run scope and estimates, per-stage progress, token usage and cost, prompt-cache hit rate, and bug-validation verdicts. It reads the trace files FM-Agent writes under `fm_agent/`, so run it in a second terminal while `main.py` is going:
 
 ```bash
 uv run python dashboard.py <proj_dir>
+```
+
+To generate and display only the pre-run estimate, without starting the
+pipeline or making LLM calls:
+
+```bash
+uv run python dashboard.py <proj_dir> --estimate
+uv run python dashboard.py <proj_dir> --estimate --submodule src/core src/runtime
 ```
 
 | Argument    | Description                                                  |

--- a/README_zh.md
+++ b/README_zh.md
@@ -166,8 +166,22 @@ uv run python main.py <proj_dir> [--resume] [--domain-knowledge FILE ...] [--bug
 | `--submodule PATH [PATH ...]` | 只处理 `proj_dir` 中一个或多个子目录下的源代码。 |
 | `--extra-edge FILE` | 从 JSON 文件或目录向静态调用图补充 caller 到 callee 的边。 |
 | `--only-spec` | 只生成行为规约，跳过推理与 Bug 验证阶段。不能与 `--incremental` 一起使用。 |
+| `--estimate` | 不调用 LLM，仅扫描范围并输出基于历史数据的时间、LLM 调用次数、Token 与费用预估。 |
 
 `proj_dir` 必须是一个 git 仓库。
+
+### 运行前预估
+
+在消耗任何模型 Token 前检查计划分析的代码范围：
+
+```bash
+uv run python main.py <proj_dir> --estimate
+uv run python main.py <proj_dir> --estimate --submodule src/core src/runtime
+```
+
+预检会展示纳入和排除的目录、纳入/排除的源文件数量、通过本地抽取得到的近似函数数量，以及六个分析阶段。当存在已完成的历史运行时，FM-Agent 会按本次函数数量（缺失时退化为文件数量）缩放历史运行的实际耗时、LLM 调用次数、Token 用量和费用，并给出区间。所有预测值都会明确标注为 **ESTIMATE（估算）**；没有完整历史样本时会显示无法估算，而不会编造数值。
+
+成功运行的摘要会保存在 `fm_agent/history.jsonl`，并在全新运行清理工作目录时继续保留。正常运行也会在第一次 LLM 调用前生成 `fm_agent/estimate.json`，实时 Dashboard 会同时展示该预检和实际用量。
 
 如需在不修改 FM-Agent 内置提示词的情况下提供项目特定领域知识，可传入一个或多个 Markdown 文件：
 
@@ -242,10 +256,17 @@ python3 main.py <proj_dir> --incremental <intent_file>
 
 ### 实时监控面板
 
-FM-Agent 自带一个独立的实时 TUI 监控面板（[dashboard.py](dashboard.py)），用于在运行过程中可视化展示：各阶段进度、Token 用量与花费、prompt 缓存命中率，以及 Bug 验证结果。它读取 FM-Agent 写入 `fm_agent/` 目录下的 trace 文件，因此可在 `main.py` 运行期间于另一个终端中启动：
+FM-Agent 自带一个独立的实时 TUI 监控面板（[dashboard.py](dashboard.py)），用于在运行过程中可视化展示：运行前范围与估算、各阶段进度、Token 用量与花费、prompt 缓存命中率，以及 Bug 验证结果。它读取 FM-Agent 写入 `fm_agent/` 目录下的 trace 文件，因此可在 `main.py` 运行期间于另一个终端中启动：
 
 ```bash
 uv run python dashboard.py <proj_dir>
+```
+
+如需在不启动流水线、不调用 LLM 的情况下生成并展示一次运行前估算：
+
+```bash
+uv run python dashboard.py <proj_dir> --estimate
+uv run python dashboard.py <proj_dir> --estimate --submodule src/core src/runtime
 ```
 
 | 参数 | 描述 |

--- a/dashboard.py
+++ b/dashboard.py
@@ -5,8 +5,10 @@ Usage:
     uv run python dashboard.py <proj_dir>                        # live: <proj_dir>/fm_agent/
     uv run python dashboard.py <proj_dir>/fm_agent.archived_xx   # any workspace dir (auto-detected by trace/ subdir)
     uv run python dashboard.py <proj_dir> --refresh 1.0          # refresh every 1.0s
+    uv run python dashboard.py <proj_dir> --estimate             # one-shot pre-run estimate
 
 Reads:
+    <workdir>/estimate.json              (scope and history-based estimates)
     <workdir>/trace/events.jsonl          (FM-Agent native events)
     <workdir>/trace/opencode/*.jsonl      (lucentia opencode-trace records)
     <workdir>/bug_validation/*.result.json (bug validation verdicts)
@@ -38,6 +40,8 @@ from rich.table import Table
 from rich.text import Text
 from rich.progress_bar import ProgressBar
 from rich.align import Align
+
+from src.run_estimate import write_preflight_estimate
 
 
 STAGES = ["init", "generate_phases_json", "generate_domain_context", "spec_generation", "verification", "bug_validation"]
@@ -183,7 +187,7 @@ def _locate_workdir(proj_dir):
         by the presence of a `trace/` subdir, used as-is.
     """
     p = Path(proj_dir).resolve()
-    if (p / "trace").is_dir():
+    if (p / "trace").is_dir() or (p / "estimate.json").is_file():
         return p
     return p / "fm_agent"
 
@@ -191,17 +195,23 @@ def _locate_workdir(proj_dir):
 class State:
     """Aggregated trace state. Mutated by tail_* methods on each refresh."""
 
-    def __init__(self, proj_dir):
+    def __init__(self, proj_dir, workdir=None):
         self.proj_dir = Path(proj_dir).resolve()
-        self.workdir = _locate_workdir(self.proj_dir)
+        self.workdir = (
+            Path(workdir).resolve()
+            if workdir is not None
+            else _locate_workdir(self.proj_dir)
+        )
         self.trace_dir = self.workdir / "trace"
         self.events_path = self.trace_dir / "events.jsonl"
         self.opencode_dir = self.trace_dir / "opencode"
         self.bug_dir = self.workdir / "bug_validation"
+        self.estimate_path = self.workdir / "estimate.json"
 
         # Tail offsets
         self._events_offset = 0
         self._opencode_offsets = {}      # filename → byte offset
+        self._estimate_mtime_ns = None
 
         # Aggregates
         self.first_event_time = None
@@ -228,6 +238,26 @@ class State:
         self.bugs_confirmed = 0
         self.bugs_not_confirmed = 0
         self.bugs_pending = 0     # opencode call done but no result.json yet
+        self.estimate = None
+        self.load_estimate()
+
+    def load_estimate(self):
+        """Load a newly created or refreshed pre-run estimate manifest."""
+        try:
+            mtime_ns = self.estimate_path.stat().st_mtime_ns
+        except OSError:
+            return
+        if mtime_ns == self._estimate_mtime_ns:
+            return
+        try:
+            with open(self.estimate_path, "r", encoding="utf-8") as f:
+                estimate = json.load(f)
+        except (OSError, ValueError):
+            return
+        if not isinstance(estimate, dict):
+            return
+        self.estimate = estimate
+        self._estimate_mtime_ns = mtime_ns
 
     # ---------- events.jsonl tail ----------
     def tail_events(self):
@@ -521,6 +551,106 @@ def render_header(state):
     return Panel(Text.from_markup("  •  ".join(parts)), border_style="cyan")
 
 
+def _fmt_range(value, formatter):
+    if not isinstance(value, dict):
+        return "history unavailable"
+    return f"{formatter(value.get('low'))} – {formatter(value.get('high'))}"
+
+
+def _directory_summary(directories, limit=3):
+    values = []
+    for item in directories or []:
+        values.append(item.get("path", "") if isinstance(item, dict) else str(item))
+    values = [value for value in values if value]
+    if not values:
+        return "(none)"
+    shown = ", ".join(values[:limit])
+    if len(values) > limit:
+        shown += f", … +{len(values) - limit}"
+    return shown
+
+
+def render_preflight(state):
+    estimate = state.estimate
+    if not estimate:
+        return Panel(
+            Align.center(
+                Text.from_markup(
+                    "[dim](no pre-run estimate; run main.py <proj> --estimate)[/]"
+                ),
+                vertical="middle",
+            ),
+            title="Pre-run Scope & ESTIMATE",
+            border_style="magenta",
+        )
+
+    scope = estimate.get("scope") or {}
+    prediction = estimate.get("estimate") or {}
+    scope_table = Table(show_header=False, expand=True, pad_edge=False, box=None)
+    scope_table.add_column("item", style="cyan", no_wrap=True)
+    scope_table.add_column("value", overflow="ellipsis")
+    scope_table.add_row(
+        "included dirs",
+        _directory_summary(scope.get("included_directories")),
+    )
+    scope_table.add_row(
+        "excluded dirs",
+        _directory_summary(scope.get("excluded_directories")),
+    )
+    scope_table.add_row(
+        "source files",
+        f"[green]{scope.get('included_file_count', 0)} included[/] / "
+        f"[dim]{scope.get('excluded_file_count', 0)} excluded[/]",
+    )
+    function_suffix = " [dim](local estimate)[/]" if scope.get(
+        "function_count_is_estimate"
+    ) else ""
+    scope_table.add_row(
+        "functions",
+        f"[bold]~{scope.get('function_count', 0)}[/]{function_suffix}",
+    )
+    stage_labels = [
+        f"{stage.get('number')}. {stage.get('name')} ({stage.get('kind')})"
+        for stage in estimate.get("analysis_stages") or []
+    ]
+    scope_table.add_row("analysis stages", " → ".join(stage_labels))
+
+    prediction_table = Table(show_header=False, expand=True, pad_edge=False, box=None)
+    prediction_table.add_column("metric", style="magenta", no_wrap=True)
+    prediction_table.add_column("ESTIMATE", justify="right", style="bold")
+    prediction_table.add_row(
+        "time",
+        _fmt_range(prediction.get("duration_seconds"), _fmt_duration),
+    )
+    prediction_table.add_row(
+        "LLM calls",
+        _fmt_range(prediction.get("llm_calls"), lambda value: str(int(value))),
+    )
+    prediction_table.add_row(
+        "tokens",
+        _fmt_range(prediction.get("tokens"), _fmt_tokens),
+    )
+    prediction_table.add_row(
+        "cost",
+        _fmt_range(prediction.get("cost_usd"), _fmt_cost),
+    )
+    prediction_table.add_row(
+        "basis",
+        f"{prediction.get('based_on_runs', 0)} completed historical run(s)",
+    )
+
+    content = Table.grid(expand=True, padding=(0, 2))
+    content.add_column(ratio=3)
+    content.add_column(ratio=2)
+    content.add_row(scope_table, prediction_table)
+    return Panel(
+        content,
+        title="[bold magenta]Pre-run Scope & ESTIMATE[/]",
+        subtitle="[dim]ranges are estimates, not quotas[/]",
+        border_style="magenta",
+    )
+
+
 def render_stages(state):
     table = Table(show_header=True, header_style="bold", expand=True, pad_edge=False)
     table.add_column("Stage", style="cyan", no_wrap=True)
@@ -718,6 +848,7 @@ def build_layout(state):
     layout = Layout()
     layout.split_column(
         Layout(render_header(state), name="header", size=3),
+        Layout(render_preflight(state), name="preflight", size=10),
         Layout(name="top", size=stages_h),
         Layout(name="mid", size=tokens_h),
         Layout(render_recent(state), name="footer"),
@@ -743,10 +874,36 @@ def main():
                     help=("Either a target codebase (monitors <proj_dir>/fm_agent/) "
                           "or a workspace directly (any dir containing a trace/ subdir)"))
     ap.add_argument("--refresh", type=float, default=1.5, help="Refresh seconds (default 1.5)")
+    ap.add_argument(
+        "--estimate",
+        action="store_true",
+        help="generate and display a one-shot pre-run estimate without LLM calls",
+    )
+    ap.add_argument(
+        "--submodule",
+        metavar="PATH",
+        nargs="+",
+        default=None,
+        help="limit estimate scope to project-relative subdirectories",
+    )
     args = ap.parse_args()
 
-    state = State(args.proj_dir)
-    if not state.trace_dir.exists():
+    estimate_workdir = None
+    if args.estimate:
+        project_dir = Path(args.proj_dir).resolve()
+        estimate_workdir = project_dir / "fm_agent_estimate"
+        write_preflight_estimate(
+            str(project_dir),
+            estimate_workdir,
+            submodules=args.submodule,
+        )
+
+    state = State(args.proj_dir, workdir=estimate_workdir)
+    if args.estimate:
+        Console().print(render_preflight(state))
+        return
+
+    if not state.trace_dir.exists() and not state.estimate_path.exists():
         print(f"trace dir not found: {state.trace_dir}", file=sys.stderr)
         print("Has the pipeline started yet? (waiting…)", file=sys.stderr)
 
@@ -755,6 +912,7 @@ def main():
               screen=True) as live:
         try:
             while True:
+                state.load_estimate()
                 state.tail_events()
                 state.tail_opencode()
                 state.scan_bugs()

--- a/main.py
+++ b/main.py
@@ -29,6 +29,12 @@ from src.domain_knowledge import (
     collect_domain_knowledge_paths,
     stage_domain_knowledge_files,
 )
+from src.run_estimate import (
+    preserve_history_before_clean,
+    record_completed_run,
+    write_history,
+    write_preflight_estimate,
+)
 import os
 import sys
 import argparse
@@ -43,6 +49,53 @@ def _clean_previous_run(work_dir):
     """Remove the fm_agent working directory from the previous pipeline run."""
     if os.path.isdir(work_dir):
         shutil.rmtree(work_dir)
+
+
+def _print_preflight_summary(estimate, output_path):
+    scope = estimate["scope"]
+    prediction = estimate["estimate"]
+    included = ", ".join(scope["included_directories"]) or "(none)"
+    excluded = ", ".join(
+        item["path"] for item in scope["excluded_directories"][:8]
+    ) or "(none)"
+    if len(scope["excluded_directories"]) > 8:
+        excluded += f", … +{len(scope['excluded_directories']) - 8}"
+    print("[Estimate] ESTIMATE — no LLM calls were made.")
+    print(f"[Estimate] Included directories: {included}")
+    print(f"[Estimate] Excluded directories: {excluded}")
+    print(
+        "[Estimate] "
+        f"{scope['included_file_count']} included source file(s), "
+        f"{scope['excluded_file_count']} excluded source file(s), "
+        f"~{scope['function_count']} function(s)."
+    )
+    print(
+        "[Estimate] Historical samples: "
+        f"{prediction['based_on_runs']}; details: {output_path}"
+    )
+    ranges = (
+        ("time", prediction.get("duration_seconds"), _format_estimate_duration),
+        ("LLM calls", prediction.get("llm_calls"), lambda value: str(int(value))),
+        ("tokens", prediction.get("tokens"), lambda value: f"{int(value):,}"),
+        ("cost", prediction.get("cost_usd"), lambda value: f"${value:.3f}"),
+    )
+    for label, value, formatter in ranges:
+        if isinstance(value, dict):
+            rendered = f"{formatter(value['low'])} – {formatter(value['high'])}"
+        else:
+            rendered = "history unavailable"
+        print(f"[Estimate] {label} (ESTIMATE): {rendered}")
+
+
+def _format_estimate_duration(seconds):
+    seconds = int(seconds)
+    hours, remainder = divmod(seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m"
+    if minutes:
+        return f"{minutes}m {seconds:02d}s"
+    return f"{seconds}s"
 
 
 def _resolve_bug_validator_path(raw_path):
@@ -116,6 +169,7 @@ def run_pipeline(
     only_spec=False,
     bug_validator_path=None,
     plugin_config=None,
+    initial_history=None,
 ):
     if not os.path.isdir(proj_dir):
         print(f"[Pipeline] ERROR: proj_dir does not exist or is not a directory: {proj_dir}")
@@ -135,6 +189,7 @@ def run_pipeline(
     # Clean files from the previous run — unless resuming, where we keep all
     # prior progress (phases.json, generated specs, verification results) and
     # only do the remaining work.
+    preserved_history = list(initial_history or [])
     if resume:
         if os.path.isdir(work_dir):
             print(f"[Pipeline] RESUME: keeping existing {os.path.relpath(work_dir, proj_dir)}/ — only remaining work will run.")
@@ -142,8 +197,19 @@ def run_pipeline(
             print("[Pipeline] RESUME requested but no previous fm_agent/ found — starting fresh.")
             resume = False
     else:
+        if initial_history is None:
+            preserved_history = preserve_history_before_clean(work_dir)
         _clean_previous_run(work_dir)
     os.makedirs(work_dir, exist_ok=True)
+    if preserved_history:
+        write_history(work_dir, preserved_history)
+    estimate_path = os.path.join(work_dir, "estimate.json")
+    estimate = write_preflight_estimate(
+        proj_dir,
+        work_dir,
+        submodules=submodules,
+    )
+    _print_preflight_summary(estimate, estimate_path)
     domain_knowledge_relpaths = stage_domain_knowledge_files(
         proj_dir, work_dir, domain_knowledge_files
     )
@@ -275,7 +341,7 @@ if __name__ == "__main__":
               "[--domain-knowledge FILE ...] [--one-phase] [--isolate] "
               "[--submodule PATH [PATH ...]] [--entry-func PATH] "
               "[--end-func PATH ...] [--extra-edge FILE] "
-              "[--bug-validator FILE] [--only-spec] "
+              "[--bug-validator FILE] [--only-spec] [--estimate] "
               "[--list-plugin] [--plugin NAME]",
         description="Run the FM agent pipeline on a project directory.",
     )
@@ -309,6 +375,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Only generate behavioral specs; skip the reasoning and bug "
         "validation stages.",
+    )
+    parser.add_argument(
+        "--estimate",
+        action="store_true",
+        help="scan source scope and print a history-based run estimate without "
+        "starting the pipeline or making LLM calls",
     )
     parser.add_argument(
         "--domain-knowledge",
@@ -435,6 +507,34 @@ if __name__ == "__main__":
             "(incremental mode is inherently a reasoning/bug-validation flow)."
         )
 
+    if args.estimate:
+        incompatible = any(
+            [
+                resume,
+                args.incremental,
+                args.entry_func,
+                args.end_func,
+                args.isolate,
+                args.only_spec,
+            ]
+        )
+        if incompatible:
+            parser.error(
+                "--estimate is a standalone preflight and cannot be combined "
+                "with resume, incremental, entry/end functions, isolate, or only-spec"
+            )
+        estimate_work_dir = os.path.join(proj_dir, "fm_agent_estimate")
+        estimate = write_preflight_estimate(
+            proj_dir,
+            estimate_work_dir,
+            submodules=submodules,
+        )
+        _print_preflight_summary(
+            estimate,
+            os.path.join(estimate_work_dir, "estimate.json"),
+        )
+        sys.exit(0)
+
     # ---- pre-flight environment check (shared by all pipeline modes) ----
     import config
     from src.env_check import run as env_check_run
@@ -503,6 +603,11 @@ if __name__ == "__main__":
         if args.isolate
         else contextlib.nullcontext(proj_dir)
     )
+    isolated_history = (
+        preserve_history_before_clean(os.path.join(proj_dir, "fm_agent"))
+        if args.isolate
+        else None
+    )
     with run_ctx as run_dir:
         try:
             # Incremental mode requires a recorded commit to diff against; without a
@@ -530,12 +635,17 @@ if __name__ == "__main__":
                     only_spec=args.only_spec,
                     bug_validator_path=bug_validator_path,
                     plugin_config=plugin_config,
+                    initial_history=isolated_history,
                 )
             # Record the commit that was processed. Written after the pipeline since
             # it recreates fm_agent/; with --isolate it lives in the snapshot and is
             # copied back to the real project below. Only recorded on success so a
             # partial run does not advance the version baseline.
             _record_version(new_commit, os.path.join(run_dir, "fm_agent"))
+            record_completed_run(
+                os.path.join(run_dir, "fm_agent"),
+                duration_seconds=time.time() - start_time,
+            )
         finally:
             # With --isolate the pipeline ran against a throwaway snapshot, so its
             # fm_agent/ results live in the snapshot. Copy them back into the real

--- a/src/run_estimate.py
+++ b/src/run_estimate.py
@@ -1,0 +1,583 @@
+"""Pre-run scope inventory and history-based FM-Agent run estimates."""
+
+from __future__ import annotations
+
+import glob
+import json
+import math
+import os
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .extract import EXT_TO_LANG, extract_functions_from_file
+from .file_utils import (
+    _is_test_file,
+    _is_under_submodules,
+    _iter_project_source_files,
+)
+
+try:
+    import litellm
+
+    _MODEL_COST = litellm.model_cost
+except Exception:
+    _MODEL_COST = {}
+
+
+SCHEMA_VERSION = 1
+ESTIMATE_FILENAME = "estimate.json"
+HISTORY_FILENAME = "history.jsonl"
+RUN_SUMMARY_FILENAME = "run_summary.json"
+
+ANALYSIS_STAGES = [
+    {
+        "number": 1,
+        "name": "Code understanding & phase plan",
+        "kind": "LLM",
+    },
+    {
+        "number": 2,
+        "name": "Domain-context generation",
+        "kind": "LLM",
+    },
+    {
+        "number": 3,
+        "name": "Function extraction",
+        "kind": "local",
+    },
+    {
+        "number": 4,
+        "name": "Function inventory",
+        "kind": "local",
+    },
+    {
+        "number": 5,
+        "name": "Call graph & analysis layers",
+        "kind": "local",
+    },
+    {
+        "number": 6,
+        "name": "Specification, verification & bug validation",
+        "kind": "LLM",
+    },
+]
+
+_PRUNED_DIR_NAMES = {"node_modules", "__pycache__", "venv", ".venv", "fm_agent"}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value):
+    if not value:
+        return None
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _source_directory(rel_path: str) -> str:
+    parent = os.path.dirname(rel_path.replace("\\", "/"))
+    return parent or "."
+
+
+def _compress_directories(paths: Iterable[str]) -> list[str]:
+    """Keep the shallowest directories that cover all supplied paths."""
+    result = []
+    for path in sorted(set(paths), key=lambda item: (item.count("/"), item)):
+        if path == "." or not any(
+            root != "." and (path == root or path.startswith(root + "/"))
+            for root in result
+        ):
+            result.append(path)
+    return result
+
+
+def _present_pruned_directories(proj_dir: str) -> list[dict]:
+    """List directories deliberately not traversed by the source scanner."""
+    excluded = []
+    for root, dirs, _files in os.walk(proj_dir):
+        kept = []
+        for dirname in dirs:
+            rel = os.path.relpath(os.path.join(root, dirname), proj_dir).replace(
+                os.sep, "/"
+            )
+            if dirname.startswith(".") or dirname in _PRUNED_DIR_NAMES:
+                excluded.append({"path": rel, "reason": "scanner ignored directory"})
+            else:
+                kept.append(dirname)
+        dirs[:] = kept
+    return excluded
+
+
+def _count_functions(proj_dir: str, files: Iterable[str]) -> tuple[int, list[str]]:
+    """Count functions with the same local fallback extractor used by FM-Agent."""
+    total = 0
+    uncounted = []
+    for rel_path in files:
+        ext = rel_path.rsplit(".", 1)[-1] if "." in rel_path else ""
+        language = EXT_TO_LANG.get(ext)
+        if not language:
+            continue
+        try:
+            functions = extract_functions_from_file(
+                os.path.join(proj_dir, rel_path), language
+            )
+        except OSError:
+            uncounted.append(rel_path)
+            continue
+        if language == "erlang" and not functions:
+            # Erlang extraction is semantic/ELP-only. The fast preflight does not
+            # start ELP, so make the incomplete count explicit in the manifest.
+            uncounted.append(rel_path)
+            continue
+        total += len(functions)
+    return total, uncounted
+
+
+def build_scope_inventory(proj_dir: str, submodules=None) -> dict:
+    """Return the deterministic source scope without invoking an LLM."""
+    proj_dir = os.path.abspath(proj_dir)
+    submodules = list(submodules or [])
+    candidates = sorted(set(_iter_project_source_files(proj_dir)))
+
+    included_files = []
+    excluded_files = []
+    excluded_directory_reasons = {}
+    for rel_path in candidates:
+        reason = None
+        if submodules and not _is_under_submodules(rel_path, submodules):
+            reason = "outside selected submodule"
+        elif _is_test_file(rel_path):
+            reason = "test source"
+
+        if reason is None:
+            included_files.append(rel_path)
+        else:
+            excluded_files.append({"path": rel_path, "reason": reason})
+            excluded_directory_reasons.setdefault(
+                (_source_directory(rel_path), reason), None
+            )
+
+    function_count, uncounted = _count_functions(proj_dir, included_files)
+    included_directories = _compress_directories(
+        _source_directory(path) for path in included_files
+    )
+    excluded_directories = [
+        {"path": path, "reason": reason}
+        for path, reason in excluded_directory_reasons
+    ]
+    excluded_directories.extend(_present_pruned_directories(proj_dir))
+    excluded_directories = sorted(
+        {
+            (item["path"], item["reason"]): item
+            for item in excluded_directories
+        }.values(),
+        key=lambda item: (item["path"].count("/"), item["path"], item["reason"]),
+    )
+
+    return {
+        "submodules": submodules,
+        "included_directories": included_directories,
+        "excluded_directories": excluded_directories,
+        "included_file_count": len(included_files),
+        "excluded_file_count": len(excluded_files),
+        "included_files": included_files,
+        "excluded_files": excluded_files,
+        "function_count": function_count,
+        "function_count_is_estimate": True,
+        "function_count_uncounted_files": uncounted,
+    }
+
+
+def _price_for(model: str | None):
+    if not model:
+        return None
+    if model in _MODEL_COST:
+        return _MODEL_COST[model]
+    if "/" in model:
+        bare = model.split("/", 1)[1]
+        if bare in _MODEL_COST:
+            return _MODEL_COST[bare]
+    return None
+
+
+def _usage_numbers(usage: dict) -> dict:
+    usage = usage or {}
+    prompt = usage.get("input_tokens")
+    if prompt is None:
+        prompt = usage.get("prompt_tokens", 0)
+    output = usage.get("output_tokens")
+    if output is None:
+        output = usage.get("completion_tokens", 0)
+    cache_read = usage.get("cache_read_input_tokens")
+    if cache_read is None:
+        cache_read = usage.get("prompt_cache_hit_tokens")
+    if cache_read is None:
+        cache_read = (
+            (usage.get("prompt_tokens_details") or {}).get("cached_tokens")
+            or (usage.get("input_tokens_details") or {}).get("cached_tokens")
+            or 0
+        )
+    if "prompt_tokens" in usage and cache_read:
+        # OpenAI-compatible usage reports prompt_tokens as total fresh + cached.
+        prompt = usage.get("prompt_cache_miss_tokens", max(0, prompt - cache_read))
+    cache_write = usage.get("cache_creation_input_tokens", 0)
+    return {
+        "input": int(prompt or 0),
+        "output": int(output or 0),
+        "cache_read": int(cache_read or 0),
+        "cache_write": int(cache_write or 0),
+    }
+
+
+def _usage_cost(model: str | None, usage: dict):
+    price = _price_for(model)
+    if not price:
+        return None
+    numbers = _usage_numbers(usage)
+    return (
+        numbers["input"] * (price.get("input_cost_per_token") or 0)
+        + numbers["output"] * (price.get("output_cost_per_token") or 0)
+        + numbers["cache_read"]
+        * (price.get("cache_read_input_token_cost") or 0)
+        + numbers["cache_write"]
+        * (price.get("cache_creation_input_token_cost") or 0)
+    )
+
+
+def _read_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _infer_scope_from_workdir(work_dir: Path) -> dict:
+    estimate = _read_json(work_dir / ESTIMATE_FILENAME) or {}
+    scope = estimate.get("scope")
+    if isinstance(scope, dict):
+        return scope
+
+    functions = 0
+    extracted = work_dir / "extracted_functions"
+    if extracted.is_dir():
+        functions = sum(
+            1
+            for path in extracted.rglob("*")
+            if path.is_file()
+            and not str(path).endswith((".spec.json", ".info.json"))
+        )
+
+    files = set()
+    phases = _read_json(work_dir / "phases.json") or {}
+    for phase in phases.get("phases", []):
+        for module in phase.get("modules", []):
+            files.update(module.get("source_files", []))
+    return {
+        "included_file_count": len(files),
+        "function_count": functions,
+    }
+
+
+def summarize_completed_run(work_dir: str | Path, require_complete=True):
+    """Summarize actual trace usage for one completed workspace."""
+    work_dir = Path(work_dir)
+    existing = _read_json(work_dir / RUN_SUMMARY_FILENAME)
+    if require_complete and not (work_dir / "version.log").is_file():
+        return existing if isinstance(existing, dict) else None
+
+    events_path = work_dir / "trace" / "events.jsonl"
+    if not events_path.is_file():
+        return existing if isinstance(existing, dict) else None
+
+    starts = []
+    ends = []
+    llm_calls = 0
+    tokens = 0
+    total_cost = 0.0
+    cost_known = True
+    model = None
+
+    for line in events_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            event = json.loads(line)
+        except ValueError:
+            continue
+        start = _parse_iso(event.get("start_time"))
+        end = _parse_iso(event.get("end_time"))
+        if start:
+            starts.append(start)
+        if end:
+            ends.append(end)
+        if event.get("type") != "llm_call":
+            continue
+        llm_calls += 1
+        metadata = event.get("metadata") or {}
+        usage = metadata.get("usage") or {}
+        event_model = metadata.get("model")
+        model = model or event_model
+        numbers = _usage_numbers(usage)
+        tokens += sum(numbers.values())
+        cost = _usage_cost(event_model, usage)
+        if cost is None and any(numbers.values()):
+            cost_known = False
+        elif cost is not None:
+            total_cost += cost
+
+    seen_responses = set()
+    requests = {}
+    for trace_path in sorted((work_dir / "trace" / "opencode").glob("*.jsonl")):
+        for line in trace_path.read_text(
+            encoding="utf-8", errors="replace"
+        ).splitlines():
+            try:
+                record = json.loads(line)
+            except ValueError:
+                continue
+            record = {
+                key.removeprefix("*"): value
+                for key, value in record.items()
+            }
+            kind = record.get("_kind")
+            call_id = record.get("_id")
+            key = (trace_path.name, call_id)
+            if kind == "request":
+                requests[key] = record
+                continue
+            if kind != "response" or key in seen_responses:
+                continue
+            usage = record.get("usage")
+            if not isinstance(usage, dict):
+                continue
+            usage = {
+                field.removeprefix("*"): value
+                for field, value in usage.items()
+            }
+            numbers = _usage_numbers(usage)
+            if not any(numbers.values()):
+                continue
+            seen_responses.add(key)
+            llm_calls += 1
+            tokens += sum(numbers.values())
+            event_model = record.get("model") or requests.get(key, {}).get("model")
+            model = model or event_model
+            cost = _usage_cost(event_model, usage)
+            if cost is None:
+                cost_known = False
+            else:
+                total_cost += cost
+
+    if not starts or not ends:
+        return None
+    scope = _infer_scope_from_workdir(work_dir)
+    duration = max(0.0, (max(ends) - min(starts)).total_seconds())
+    version_lines = []
+    version_path = work_dir / "version.log"
+    if version_path.is_file():
+        version_lines = [
+            line.strip()
+            for line in version_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    run_id = f"{version_lines[-1] if version_lines else 'unknown'}:{max(ends).isoformat()}"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "recorded_at": _utc_now_iso(),
+        "included_file_count": int(scope.get("included_file_count") or 0),
+        "function_count": int(scope.get("function_count") or 0),
+        "duration_seconds": duration,
+        "llm_calls": llm_calls,
+        "tokens": tokens,
+        "cost_usd": total_cost if cost_known else None,
+        "model": model,
+    }
+
+
+def read_history(work_dir: str | Path) -> list[dict]:
+    path = Path(work_dir) / HISTORY_FILENAME
+    if not path.is_file():
+        return []
+    records = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            record = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return _dedupe_history(records)
+
+
+def _dedupe_history(records: Iterable[dict]) -> list[dict]:
+    deduped = {}
+    for record in records:
+        run_id = record.get("run_id")
+        if run_id:
+            deduped[run_id] = record
+    return list(deduped.values())
+
+
+def write_history(work_dir: str | Path, records: Iterable[dict]) -> None:
+    records = _dedupe_history(records)
+    if not records:
+        return
+    work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    path = work_dir / HISTORY_FILENAME
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    os.replace(tmp, path)
+
+
+def preserve_history_before_clean(work_dir: str | Path) -> list[dict]:
+    records = read_history(work_dir)
+    summary = summarize_completed_run(work_dir)
+    if summary:
+        records.append(summary)
+    return _dedupe_history(records)
+
+
+def record_completed_run(work_dir: str | Path, duration_seconds=None):
+    summary = summarize_completed_run(work_dir)
+    if not summary:
+        return None
+    if duration_seconds is not None:
+        summary["duration_seconds"] = max(0.0, float(duration_seconds))
+    records = read_history(work_dir)
+    records.append(summary)
+    write_history(work_dir, records)
+    path = Path(work_dir) / RUN_SUMMARY_FILENAME
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, path)
+    return summary
+
+
+def collect_history_samples(proj_dir: str, work_dir: str | Path) -> list[dict]:
+    """Collect persisted history plus completed archived workspaces."""
+    records = read_history(work_dir)
+    for candidate in glob.glob(os.path.join(os.path.abspath(proj_dir), "fm_agent*")):
+        candidate_path = Path(candidate)
+        if not candidate_path.is_dir() or candidate_path.name == "fm_agent_estimate":
+            continue
+        records.extend(read_history(candidate_path))
+        summary = summarize_completed_run(candidate_path)
+        if summary:
+            records.append(summary)
+    return _dedupe_history(records)
+
+
+def _scale_factor(target_scope: dict, sample: dict) -> float:
+    target_functions = int(target_scope.get("function_count") or 0)
+    sample_functions = int(sample.get("function_count") or 0)
+    if target_functions > 0 and sample_functions > 0:
+        return max(0.1, min(10.0, target_functions / sample_functions))
+    target_files = int(target_scope.get("included_file_count") or 0)
+    sample_files = int(sample.get("included_file_count") or 0)
+    if target_files > 0 and sample_files > 0:
+        return max(0.1, min(10.0, target_files / sample_files))
+    return 1.0
+
+
+def _historical_range(values: list[float], integer=False):
+    values = sorted(value for value in values if value is not None and value >= 0)
+    if not values:
+        return None
+    if len(values) == 1:
+        low, high = values[0] * 0.75, values[0] * 1.25
+    else:
+        low, high = values[0] * 0.9, values[-1] * 1.1
+    # Prevent representational noise (e.g. 3000 * 1.1 becoming
+    # 3300.0000000000005) from widening integer ranges by one.
+    low, high = round(low, 9), round(high, 9)
+    if integer:
+        return {"low": max(0, math.floor(low)), "high": max(1, math.ceil(high))}
+    return {"low": max(0.0, low), "high": max(low, high)}
+
+
+def estimate_from_history(scope: dict, samples: Iterable[dict]) -> dict:
+    samples = list(samples)
+    scaled = []
+    for sample in samples:
+        factor = _scale_factor(scope, sample)
+        scaled.append(
+            {
+                "duration_seconds": (
+                    sample.get("duration_seconds") * factor
+                    if sample.get("duration_seconds") is not None
+                    else None
+                ),
+                "llm_calls": (
+                    sample.get("llm_calls") * factor
+                    if sample.get("llm_calls") is not None
+                    else None
+                ),
+                "tokens": (
+                    sample.get("tokens") * factor
+                    if sample.get("tokens") is not None
+                    else None
+                ),
+                "cost_usd": (
+                    sample.get("cost_usd") * factor
+                    if sample.get("cost_usd") is not None
+                    else None
+                ),
+            }
+        )
+
+    return {
+        "label": "estimate",
+        "method": (
+            "historical completed runs scaled by function count "
+            "(file count fallback); range is the observed envelope with 10% margin"
+        ),
+        "based_on_runs": len(samples),
+        "duration_seconds": _historical_range(
+            [item["duration_seconds"] for item in scaled]
+        ),
+        "llm_calls": _historical_range(
+            [item["llm_calls"] for item in scaled], integer=True
+        ),
+        "tokens": _historical_range(
+            [item["tokens"] for item in scaled], integer=True
+        ),
+        "cost_usd": _historical_range(
+            [item["cost_usd"] for item in scaled]
+        ),
+    }
+
+
+def build_preflight_estimate(proj_dir: str, work_dir: str | Path, submodules=None):
+    scope = build_scope_inventory(proj_dir, submodules=submodules)
+    history = collect_history_samples(proj_dir, work_dir)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _utc_now_iso(),
+        "project": os.path.abspath(proj_dir),
+        "scope": scope,
+        "analysis_stages": ANALYSIS_STAGES,
+        "estimate": estimate_from_history(scope, history),
+    }
+
+
+def write_preflight_estimate(
+    proj_dir: str, work_dir: str | Path, submodules=None
+) -> dict:
+    estimate = build_preflight_estimate(proj_dir, work_dir, submodules=submodules)
+    work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    path = work_dir / ESTIMATE_FILENAME
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(estimate, indent=2, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, path)
+    return estimate

--- a/tests/test_run_estimate.py
+++ b/tests/test_run_estimate.py
@@ -1,0 +1,318 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from rich.console import Console
+
+import main as main_module
+from dashboard import State, render_preflight
+from src.run_estimate import (
+    ANALYSIS_STAGES,
+    build_scope_inventory,
+    estimate_from_history,
+    read_history,
+    record_completed_run,
+    summarize_completed_run,
+    write_preflight_estimate,
+)
+
+
+class ScopeInventoryTests(unittest.TestCase):
+    def test_inventory_reports_included_excluded_files_dirs_and_functions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            (project / "src").mkdir()
+            (project / "tests").mkdir()
+            (project / "examples").mkdir()
+            (project / "node_modules").mkdir()
+            (project / "app.py").write_text("def root():\n    return 1\n")
+            (project / "src" / "worker.py").write_text(
+                "def first():\n    return 1\n\n"
+                "def second():\n    return 2\n"
+            )
+            (project / "tests" / "test_worker.py").write_text(
+                "def test_worker():\n    assert True\n"
+            )
+            (project / "examples" / "demo.py").write_text(
+                "def demo():\n    return 3\n"
+            )
+            (project / "node_modules" / "dependency.js").write_text(
+                "function ignored() {}\n"
+            )
+
+            scope = build_scope_inventory(str(project), submodules=["src"])
+
+            self.assertEqual(scope["included_files"], ["src/worker.py"])
+            self.assertEqual(scope["included_directories"], ["src"])
+            self.assertEqual(scope["included_file_count"], 1)
+            self.assertEqual(scope["excluded_file_count"], 3)
+            self.assertEqual(scope["function_count"], 2)
+            reasons = {
+                (item["path"], item["reason"])
+                for item in scope["excluded_directories"]
+            }
+            self.assertIn(("node_modules", "scanner ignored directory"), reasons)
+            self.assertIn((".", "outside selected submodule"), reasons)
+            self.assertIn(("tests", "outside selected submodule"), reasons)
+
+    def test_root_sources_do_not_hide_nested_included_directories(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            (project / "src").mkdir()
+            (project / "app.py").write_text("def root():\n    pass\n")
+            (project / "src" / "worker.py").write_text("def work():\n    pass\n")
+
+            scope = build_scope_inventory(str(project))
+
+            self.assertEqual(scope["included_directories"], [".", "src"])
+
+
+class HistoricalEstimateTests(unittest.TestCase):
+    def test_ranges_scale_completed_runs_by_function_count(self):
+        scope = {"function_count": 20, "included_file_count": 4}
+        samples = [
+            {
+                "function_count": 10,
+                "included_file_count": 2,
+                "duration_seconds": 100,
+                "llm_calls": 10,
+                "tokens": 1_000,
+                "cost_usd": 1.0,
+            },
+            {
+                "function_count": 20,
+                "included_file_count": 4,
+                "duration_seconds": 300,
+                "llm_calls": 30,
+                "tokens": 3_000,
+                "cost_usd": 3.0,
+            },
+        ]
+
+        estimate = estimate_from_history(scope, samples)
+
+        self.assertEqual(estimate["based_on_runs"], 2)
+        self.assertEqual(estimate["duration_seconds"], {"low": 180.0, "high": 330.0})
+        self.assertEqual(estimate["llm_calls"], {"low": 18, "high": 33})
+        self.assertEqual(estimate["tokens"], {"low": 1800, "high": 3300})
+        self.assertEqual(estimate["cost_usd"], {"low": 1.8, "high": 3.3})
+
+    def test_single_sample_has_explicit_uncertainty_band(self):
+        estimate = estimate_from_history(
+            {"function_count": 10},
+            [
+                {
+                    "function_count": 10,
+                    "duration_seconds": 100,
+                    "llm_calls": 20,
+                    "tokens": 1_000,
+                    "cost_usd": 2,
+                }
+            ],
+        )
+        self.assertEqual(estimate["duration_seconds"], {"low": 75.0, "high": 125.0})
+        self.assertEqual(estimate["llm_calls"], {"low": 15, "high": 25})
+
+
+class RunHistoryTests(unittest.TestCase):
+    def test_completed_trace_is_summarized_and_persisted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp)
+            trace_dir = work_dir / "trace"
+            opencode_dir = trace_dir / "opencode"
+            opencode_dir.mkdir(parents=True)
+            (work_dir / "version.log").write_text("abc123\n")
+            (work_dir / "estimate.json").write_text(
+                json.dumps(
+                    {
+                        "scope": {
+                            "included_file_count": 2,
+                            "function_count": 4,
+                        }
+                    }
+                )
+            )
+            events = [
+                {
+                    "type": "llm_call",
+                    "start_time": "2026-01-01T00:00:00Z",
+                    "end_time": "2026-01-01T00:00:10Z",
+                    "metadata": {
+                        "model": "test-model",
+                        "usage": {"input_tokens": 100, "output_tokens": 20},
+                    },
+                },
+                {
+                    "type": "opencode_call",
+                    "start_time": "2026-01-01T00:00:10Z",
+                    "end_time": "2026-01-01T00:00:20Z",
+                    "metadata": {},
+                },
+            ]
+            (trace_dir / "events.jsonl").write_text(
+                "".join(json.dumps(event) + "\n" for event in events)
+            )
+            records = [
+                {
+                    "_kind": "request",
+                    "_id": "call-1",
+                    "model": "test-model",
+                },
+                {
+                    "_kind": "response",
+                    "_id": "call-1",
+                    "usage": {"input_tokens": 50, "output_tokens": 10},
+                },
+            ]
+            (opencode_dir / "one.jsonl").write_text(
+                "".join(json.dumps(record) + "\n" for record in records)
+            )
+            price = {
+                "input_cost_per_token": 0.001,
+                "output_cost_per_token": 0.002,
+            }
+
+            with patch.dict("src.run_estimate._MODEL_COST", {"test-model": price}):
+                summary = summarize_completed_run(work_dir)
+                persisted = record_completed_run(work_dir, duration_seconds=42)
+
+            self.assertEqual(summary["included_file_count"], 2)
+            self.assertEqual(summary["function_count"], 4)
+            self.assertEqual(summary["duration_seconds"], 20)
+            self.assertEqual(summary["llm_calls"], 2)
+            self.assertEqual(summary["tokens"], 180)
+            self.assertAlmostEqual(summary["cost_usd"], 0.21)
+            self.assertEqual(persisted["run_id"], summary["run_id"])
+            self.assertEqual(persisted["duration_seconds"], 42)
+            self.assertEqual(len(read_history(work_dir)), 1)
+
+    def test_incomplete_workspace_is_not_used_as_history(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            work_dir = Path(tmp)
+            (work_dir / "trace").mkdir()
+            (work_dir / "trace" / "events.jsonl").write_text("")
+            self.assertIsNone(summarize_completed_run(work_dir))
+
+
+class DashboardEstimateTests(unittest.TestCase):
+    def test_one_shot_manifest_renders_scope_stages_and_estimate_label(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "src").mkdir()
+            (project / "src" / "app.py").write_text("def main():\n    return 0\n")
+            work_dir = project / "fm_agent_estimate"
+            estimate = write_preflight_estimate(project, work_dir)
+            estimate["estimate"] = {
+                "label": "estimate",
+                "based_on_runs": 2,
+                "duration_seconds": {"low": 60, "high": 120},
+                "llm_calls": {"low": 4, "high": 8},
+                "tokens": {"low": 1_000, "high": 2_000},
+                "cost_usd": {"low": 1.0, "high": 2.0},
+            }
+            (work_dir / "estimate.json").write_text(json.dumps(estimate))
+
+            state = State(project, workdir=work_dir)
+            console = Console(record=True, width=180)
+            console.print(render_preflight(state))
+            rendered = console.export_text()
+
+            self.assertIn("Pre-run Scope & ESTIMATE", rendered)
+            self.assertIn("included dirs", rendered)
+            self.assertIn("excluded dirs", rendered)
+            self.assertIn("functions", rendered)
+            self.assertIn("analysis stages", rendered)
+            self.assertIn("LLM calls", rendered)
+            self.assertIn("2 completed historical run(s)", rendered)
+            self.assertEqual(len(ANALYSIS_STAGES), 6)
+
+
+class MainEstimateCliTests(unittest.TestCase):
+    def test_estimate_mode_needs_neither_git_nor_llm_credentials(self):
+        repository = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            (project / "app.py").write_text("def main():\n    return 0\n")
+            (project / "fm_agent").mkdir()
+            (project / "fm_agent" / "history.jsonl").write_text(
+                json.dumps(
+                    {
+                        "run_id": "previous",
+                        "function_count": 1,
+                        "included_file_count": 1,
+                        "duration_seconds": 60,
+                        "llm_calls": 4,
+                        "tokens": 1_000,
+                        "cost_usd": 1.0,
+                    }
+                )
+                + "\n"
+            )
+            env = os.environ.copy()
+            env.pop("LLM_API_KEY", None)
+
+            result = subprocess.run(
+                [sys.executable, str(repository / "main.py"), str(project), "--estimate"],
+                cwd=repository,
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=30,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("ESTIMATE — no LLM calls were made", result.stdout)
+            self.assertIn("1 included source file(s)", result.stdout)
+            self.assertIn("Historical samples: 1", result.stdout)
+            self.assertIn("time (ESTIMATE): 45s – 1m 15s", result.stdout)
+            self.assertIn("cost (ESTIMATE): $0.750 – $1.250", result.stdout)
+            self.assertTrue((project / "fm_agent_estimate" / "estimate.json").is_file())
+
+
+class NormalPipelinePreflightTests(unittest.TestCase):
+    def test_fresh_run_preserves_history_and_writes_estimate_before_first_llm_stage(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            (project / "app.py").write_text("def main():\n    return 0\n")
+            work_dir = project / "fm_agent"
+            work_dir.mkdir()
+            (work_dir / "stale.txt").write_text("old run")
+            (work_dir / "history.jsonl").write_text(
+                json.dumps(
+                    {
+                        "run_id": "previous",
+                        "function_count": 1,
+                        "included_file_count": 1,
+                        "duration_seconds": 60,
+                        "llm_calls": 4,
+                        "tokens": 1_000,
+                        "cost_usd": 1.0,
+                    }
+                )
+                + "\n"
+            )
+
+            with patch.object(
+                main_module,
+                "_run_generate_phases",
+                side_effect=RuntimeError("stop after preflight"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "stop after preflight"):
+                    main_module.run_pipeline(str(project))
+
+            estimate = json.loads((work_dir / "estimate.json").read_text())
+            self.assertFalse((work_dir / "stale.txt").exists())
+            self.assertTrue((work_dir / "history.jsonl").is_file())
+            self.assertEqual(estimate["estimate"]["based_on_runs"], 1)
+            self.assertEqual(estimate["scope"]["function_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a no-LLM `main.py <proj> --estimate` preflight mode
- add a one-shot `dashboard.py <proj> --estimate` view and keep the estimate panel visible during live runs
- inventory included/excluded directories, included/excluded supported source files, approximate function count, and all six analysis stages
- persist summaries from successful runs and use completed history to estimate duration, LLM calls, token volume, and cost ranges
- generate `fm_agent/estimate.json` before the first LLM stage of every full run and retain `fm_agent/history.jsonl` across fresh runs
- document the workflow in English and Chinese

## Why

Previously FM-Agent did code understanding and extraction only after a run started, while the dashboard reported only usage that had already occurred. Users had no way to inspect scope or understand likely time and cost before committing to a run.

The new preflight performs only local source scanning/extraction. Historical ranges are scaled by function count (file count fallback), use only completed runs, and are explicitly labelled **ESTIMATE**. If no completed history exists, the UI reports that the range is unavailable instead of fabricating a value.

## Validation

- `uv run python -m unittest discover -s tests -v` — 9 tests passed
- `uv run python -m compileall -q main.py dashboard.py src tests`
- `uvx ruff check src/run_estimate.py tests/test_run_estimate.py --select E4,E7,E9,F,I,UP`
- `uvx ruff check main.py dashboard.py --select E9,F63,F7,F82`
- `git diff --check`
- manually exercised `uv run python main.py . --estimate`
- manually rendered `uv run python dashboard.py . --estimate`
