### PR TITLE
Fix spec sidecar filename normalization for source extensions

### DIFF
--- a/md/system_prompt.md
+++ b/md/system_prompt.md
@@ -61,9 +61,23 @@ Do not name specific members of a set — not even as examples. Describe the gov
 
 ### Spec Format
 
-For each extracted function file (for example, `calculate_average.py`), write TWO
-separate JSON files in the SAME directory. Do NOT modify the original function
-source file.
+For each extracted function file, write TWO separate JSON files in the SAME
+directory. Do NOT modify the original function source file.
+
+**CRITICAL — filename rule:** The output filename MUST be **exactly** the
+function file name **including its source extension**, with `.spec.json` or
+`.info.json` appended. The source extension (.rs, .cpp, .py, .c, etc.) is
+part of the filename and MUST NOT be removed, changed, or normalized. The
+same naming rule applies to both `.spec.json` and `.info.json`.
+
+**Examples:**
+
+| Function file | Spec output | Info output |
+|---|---|---|
+| `Preprocessor::preprocess_source.rs` | `Preprocessor::preprocess_source.rs.spec.json` | `Preprocessor::preprocess_source.rs.info.json` |
+| `calculate_average.py` | `calculate_average.py.spec.json` | `calculate_average.py.info.json` |
+| `LocalStorage::Flush.cpp` | `LocalStorage::Flush.cpp.spec.json` | `LocalStorage::Flush.cpp.info.json` |
+| `src/lib/parser.c` | `src/lib/parser.c.spec.json` | `src/lib/parser.c.info.json` |
 
 **`<function-file>.spec.json`** — the function's own behavioral specification:
 

--- a/md/workflow_spec_step4_batch.md
+++ b/md/workflow_spec_step4_batch.md
@@ -12,17 +12,31 @@ You are given a single batch prompt file path in the prompt. Your ONLY job is to
 4. For EACH function listed in the batch prompt:
    a. Read the extracted function file
    b. If layer > 0, read earlier-layer caller specs mentioned in the batch prompt
-   c. Generate a behavioral spec and write it to `<function-file>.spec.json` in the same directory
-   d. Generate callee expectations and write them to `<function-file>.info.json` in the same directory
+    c. Generate a behavioral spec and write it to `<function-file>.spec.json` — the filename MUST include the source extension (see Spec Format below)
+    d. Generate callee expectations and write them to `<function-file>.info.json` — the filename MUST include the source extension (see Spec Format below)
    e. Do NOT modify the original function source file
 
 ---
 
 ## Spec Format
 
-For each extracted function file (for example, `calculate_average.py`), write TWO
-separate JSON files in the SAME directory. Do NOT modify the original function
-source file.
+For each extracted function file, write TWO separate JSON files in the SAME
+directory. Do NOT modify the original function source file.
+
+**CRITICAL — filename rule:** The output filename MUST be **exactly** the
+function file name **including its source extension**, with `.spec.json` or
+`.info.json` appended. The source extension (.rs, .cpp, .py, .c, etc.) is
+part of the filename and MUST NOT be removed, changed, or normalized. The
+same naming rule applies to both `.spec.json` and `.info.json`.
+
+**Examples:**
+
+| Function file | Spec output | Info output |
+|---|---|---|
+| `Preprocessor::preprocess_source.rs` | `Preprocessor::preprocess_source.rs.spec.json` | `Preprocessor::preprocess_source.rs.info.json` |
+| `calculate_average.py` | `calculate_average.py.spec.json` | `calculate_average.py.info.json` |
+| `LocalStorage::Flush.cpp` | `LocalStorage::Flush.cpp.spec.json` | `LocalStorage::Flush.cpp.info.json` |
+| `src/lib/parser.c` | `src/lib/parser.c.spec.json` | `src/lib/parser.c.info.json` |
 
 **`<function-file>.spec.json`** — the function's own behavioral specification:
 

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import json
 import re
@@ -94,6 +95,83 @@ def is_file_ready(file_path):
         return False
 
     return _is_valid_spec_json(spec) and _is_valid_info_json(info)
+
+
+def _is_valid_sidecar_file(path):
+    """Return True if *path* is a sidecar JSON file with valid FM-Agent schema."""
+    if not os.path.isfile(path):
+        return False
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if path.endswith(".spec.json"):
+        return _is_valid_spec_json(data)
+    if path.endswith(".info.json"):
+        return _is_valid_info_json(data)
+    return False
+
+
+def normalize_spec_filenames(function_files):
+    """Fix sidecar filenames where the LLM dropped the source extension.
+
+    For each function file ``foo.rs`` the pipeline expects sidecars
+    ``foo.rs.spec.json`` and ``foo.rs.info.json``. Some LLMs instead
+    produce ``foo.spec.json`` and ``foo.info.json``.
+
+    When the mapping is unambiguous, this function renames or replaces
+    those files so they match the expected filenames.
+
+    Raises:
+        RuntimeError: If a bare sidecar could belong to multiple source files.
+
+    Returns:
+        bool: True if any sidecar filename was renamed or replaced.
+    """
+    if not function_files:
+        return False
+
+    changed = False
+
+    base_map = {}
+    for func_path in function_files:
+        base = os.path.splitext(func_path)[0]
+        base_map.setdefault(base, []).append(func_path)
+
+    for func_path in function_files:
+        base = os.path.splitext(func_path)[0]
+        candidates = base_map[base]
+
+        if len(candidates) > 1:
+            for suffix in (".spec.json", ".info.json"):
+                alt = f"{base}{suffix}"
+                expected = f"{func_path}{suffix}"
+                if os.path.isfile(alt) and not _is_valid_sidecar_file(expected):
+                    raise RuntimeError(
+                        f"Ambiguous sidecar filename: {alt} could belong to "
+                        f"multiple source files: {candidates}"
+                    )
+
+    for func_path in function_files:
+        base = os.path.splitext(func_path)[0]
+
+        for suffix, expected in (
+            (".spec.json", f"{func_path}.spec.json"),
+            (".info.json", f"{func_path}.info.json"),
+        ):
+            if _is_valid_sidecar_file(expected):
+                continue
+
+            alt = f"{base}{suffix}"
+            if not os.path.isfile(alt):
+                continue
+
+            logging.info("Normalized sidecar filename: %s -> %s", alt, expected)
+            os.replace(alt, expected)
+            changed = True
+
+    return changed
 
 
 # Directories that typically contain test code

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -333,9 +333,23 @@ def build_prompt(
     lines.append("## SPEC FORMAT (write JSON files; do NOT modify source files)")
     lines.append("")
     lines.append(
-        "For each function file `<function-file>`, "
-        "write TWO JSON files in the SAME directory:"
+        "For each function file, write TWO JSON files in the SAME directory."
     )
+    lines.append("")
+    lines.append(
+        "CRITICAL: The output filename MUST be exactly the function file name "
+        "INCLUDING its source extension (.rs, .cpp, .py, .c, etc.), with "
+        ".spec.json or .info.json appended. Do NOT remove, change, or "
+        "normalize the source file extension."
+    )
+    lines.append("")
+    lines.append("Examples:")
+    lines.append("  Preprocessor::preprocess_source.rs -> Preprocessor::preprocess_source.rs.spec.json")
+    lines.append("                                        Preprocessor::preprocess_source.rs.info.json")
+    lines.append("  calculate_average.py               -> calculate_average.py.spec.json")
+    lines.append("                                        calculate_average.py.info.json")
+    lines.append("  LocalStorage::Flush.cpp            -> LocalStorage::Flush.cpp.spec.json")
+    lines.append("                                        LocalStorage::Flush.cpp.info.json")
     lines.append("")
     lines.append("`<function-file>.spec.json`:")
     lines.append("```json")

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -11,7 +11,7 @@ import time
 
 from config import MAX_WORKERS, OPENCODE_MAX_RETRIES, OPENCODE_SPEC_MODEL
 from src.domain_knowledge import list_staged_domain_knowledge_relpaths
-from src.file_utils import _get_incomplete_verification_files, _get_phase_files, is_file_ready
+from src.file_utils import _get_incomplete_verification_files, _get_phase_files, is_file_ready, normalize_spec_filenames
 from src.generate_topdown_layers import generate_topdown_layers
 from src.llm_client import build_llm_cli_command
 from src.opencode_trace import function_id_from_extracted_path, run_opencode_traced
@@ -253,6 +253,50 @@ def run_spec_generation_and_verification(
                             future.result()
                         except Exception as exc:
                             logging.error(f"Spec generation task failed unexpectedly: {exc}")
+
+                changed = normalize_spec_filenames(
+                    [os.path.join(input_dir, rel) for rel in layer_files]
+                )
+
+                if changed and not only_spec:
+                    incomplete = _get_incomplete_verification_files(
+                        layer_files,
+                        input_dir,
+                        output_dir,
+                        work_dir,
+                    )
+
+                    ready_to_verify = [
+                        rel
+                        for rel in incomplete
+                        if is_file_ready(os.path.join(input_dir, rel))
+                    ]
+
+                    unready_count = len(incomplete) - len(ready_to_verify)
+                    if unready_count:
+                        logging.warning(
+                            "Skipping verification for %d file(s) that are not ready; they will be retried.",
+                            unready_count,
+                        )
+
+                    if ready_to_verify:
+                        logging.info(
+                            "Running verification for %d normalized file(s).",
+                            len(ready_to_verify),
+                        )
+
+                        newly_processed = streaming_reasoner(
+                            input_dir,
+                            output_dir,
+                            file_list=ready_to_verify,
+                            proj_dir=proj_dir,
+                            work_dir=work_dir,
+                            spec_procs=None,
+                            already_processed=all_processed | layer_processed,
+                            resume=resume,
+                            bug_validator_path=bug_validator_path,
+                        )
+                        layer_processed.update(newly_processed)
 
                 # Check if any files in this layer received specs
                 specs_generated = sum(


### PR DESCRIPTION
Closes #167

### Motivation

Stage 6 expects spec sidecar files to follow the exact naming convention:

    {function_file}.spec.json
    {function_file}.info.json

including the original source file extension (for example, `.rs` or `.cpp`).

Some LLMs occasionally omit the source extension and generate filenames such as foo.spec.json，instead of foo.rs.spec.json.

This causes artifact validation to fail even though the generated content is otherwise correct.

### Changes

- Clarify the required sidecar filename format in the spec generation prompts.
- Explicitly document that the source extension is part of the filename.
- Add a normalization step after spec generation to rename sidecar files that omitted the source extension when the mapping is unambiguous.
- Preserve strict artifact validation and report an error for ambiguous filename mappings rather than guessing.

### Validation

The change was manually verified against the reported filename mismatch scenario, as well as normal and ambiguous naming cases.
