### PR TITLE
feat(reasoner): add syntax-aware block splitting for brace-delimited languages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "tree-sitter-c>=0.24,<0.25",
     "tree-sitter-cpp>=0.23.4,<0.24",
     "tree-sitter-java>=0.23.5,<0.24",
+    "tree-sitter-javascript>=0.23,<0.26",
+    "tree-sitter-typescript>=0.23,<0.24",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "tree-sitter-cpp>=0.23.4,<0.24",
     "tree-sitter-java>=0.23.5,<0.24",
     "tree-sitter-javascript>=0.23,<0.26",
+    "tree-sitter-rust>=0.24,<0.25",
     "tree-sitter-typescript>=0.23,<0.24",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ dependencies = [
     "socksio>=1.0.0",
     "pydantic-settings>=2.2",
     "tree-sitter>=0.25,<0.27",
+    "tree-sitter-c>=0.24,<0.25",
     "tree-sitter-cpp>=0.23.4,<0.24",
+    "tree-sitter-java>=0.23.5,<0.24",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "litellm>=1.50.0",
     "socksio>=1.0.0",
     "pydantic-settings>=2.2",
+    "tree-sitter>=0.25,<0.27",
+    "tree-sitter-cpp>=0.23.4,<0.24",
 ]
 
 [project.scripts]

--- a/src/languages/c.py
+++ b/src/languages/c.py
@@ -1,4 +1,80 @@
+import re
+
 from src.languages.codegraph import CodeGraphExtractor
+
+
+_LINE_PREFIX = re.compile(r"^Line \d+: ?")
+
+
+def _line_end(node) -> int:
+    """Return the inclusive source line containing ``node``'s end."""
+    row, column = node.end_point
+    return row - 1 if column == 0 and row > node.start_point[0] else row
+
+
+def _function_block_nodes(root):
+    """Return safe top-level C block boundaries for one function."""
+    stack = list(reversed(root.named_children))
+    while stack:
+        node = stack.pop()
+        if node.type == "function_definition":
+            body = node.child_by_field_name("body")
+            if body is None or body.type != "compound_statement":
+                return None
+            return [child for child in body.named_children if child.type != "comment"]
+        stack.extend(reversed(node.named_children))
+    return None
+
+
+def split_blocks(func: str, granularity: int) -> list[str] | None:
+    """Split a C function at complete top-level syntax nodes.
+
+    ``func`` may carry the ``Line N:`` prefixes added by ``parser.py``. They are
+    removed only for parsing; returned chunks retain the original prompt text.
+    Returning ``None`` asks the caller to use its regex/brace-depth fallback.
+    """
+    try:
+        import tree_sitter_c as ts_c
+        from tree_sitter import Language, Parser
+    except (ImportError, OSError):
+        return None
+
+    prompt_lines = func.strip().split("\n")
+    if len(prompt_lines) <= granularity:
+        return [func.strip()]
+
+    source = "\n".join(_LINE_PREFIX.sub("", line) for line in prompt_lines)
+    try:
+        parser = Parser(Language(ts_c.language()))
+        tree = parser.parse(source.encode("utf-8"))
+    except (TypeError, UnicodeError, ValueError):
+        return None
+
+    if tree.root_node.has_error:
+        return None
+
+    block_nodes = _function_block_nodes(tree.root_node)
+    if not block_nodes:
+        return None
+
+    boundaries = sorted({_line_end(node) for node in block_nodes})
+    blocks = []
+    start = 0
+    total = len(prompt_lines)
+    while start < total:
+        if total - start <= granularity * 2:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        split_at = next((end for end in boundaries if end >= start + granularity), None)
+        if split_at is None or split_at >= total - 1:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        blocks.append("\n".join(prompt_lines[start : split_at + 1]))
+        start = split_at + 1
+
+    return blocks
 
 
 def batch_extract(proj_dir: str) -> dict:

--- a/src/languages/cpp.py
+++ b/src/languages/cpp.py
@@ -1,4 +1,88 @@
+import re
+
 from src.languages.codegraph import CodeGraphExtractor
+
+
+_LINE_PREFIX = re.compile(r"^Line \d+: ?")
+
+
+def _line_end(node) -> int:
+    """Return the inclusive source line containing ``node``'s end."""
+    row, column = node.end_point
+    return row - 1 if column == 0 and row > node.start_point[0] else row
+
+
+def _function_block_nodes(root):
+    """Return safe top-level C++ block boundaries for one function."""
+    stack = list(reversed(root.named_children))
+    while stack:
+        node = stack.pop()
+        if node.type == "function_definition":
+            body = node.child_by_field_name("body")
+            if body is not None and body.type == "compound_statement":
+                return [child for child in body.named_children if child.type != "comment"]
+            if body is not None and body.type == "try_statement":
+                return [body]
+            function_try = next(
+                (child for child in node.named_children if child.type == "try_statement"),
+                None,
+            )
+            if function_try is not None:
+                return [function_try]
+            return None
+        stack.extend(reversed(node.named_children))
+    return None
+
+
+def split_blocks(func: str, granularity: int) -> list[str] | None:
+    """Split a C++ function at complete top-level syntax nodes.
+
+    ``func`` may carry the ``Line N:`` prefixes added by ``parser.py``. They are
+    removed only for parsing; returned chunks retain the original prompt text.
+    Returning ``None`` asks the caller to use its regex/brace-depth fallback.
+    """
+    try:
+        import tree_sitter_cpp as ts_cpp
+        from tree_sitter import Language, Parser
+    except (ImportError, OSError):
+        return None
+
+    prompt_lines = func.strip().split("\n")
+    if len(prompt_lines) <= granularity:
+        return [func.strip()]
+
+    source = "\n".join(_LINE_PREFIX.sub("", line) for line in prompt_lines)
+    try:
+        parser = Parser(Language(ts_cpp.language()))
+        tree = parser.parse(source.encode("utf-8"))
+    except (TypeError, UnicodeError, ValueError):
+        return None
+
+    if tree.root_node.has_error:
+        return None
+
+    block_nodes = _function_block_nodes(tree.root_node)
+    if not block_nodes:
+        return None
+
+    boundaries = sorted({_line_end(node) for node in block_nodes})
+    blocks = []
+    start = 0
+    total = len(prompt_lines)
+    while start < total:
+        if total - start <= granularity * 2:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        split_at = next((end for end in boundaries if end >= start + granularity), None)
+        if split_at is None or split_at >= total - 1:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        blocks.append("\n".join(prompt_lines[start : split_at + 1]))
+        start = split_at + 1
+
+    return blocks
 
 
 def batch_extract(proj_dir: str) -> dict:

--- a/src/languages/java.py
+++ b/src/languages/java.py
@@ -1,4 +1,112 @@
+import re
+
 from src.languages.codegraph import CodeGraphExtractor
+
+
+_LINE_PREFIX = re.compile(r"^Line \d+: ?")
+_FUNCTION_TYPES = {
+    "method_declaration",
+    "constructor_declaration",
+    "compact_constructor_declaration",
+}
+_CONSTRUCTOR_START = re.compile(
+    r"""^\s*
+    (?:(?:@[A-Za-z_$][A-Za-z0-9_$.]*(?:\s*\([^()]*\))?
+        |public|protected|private|static|final|synchronized|native|strictfp|abstract)\s+)*
+    (?:<[^{}()]*>\s*)?
+    ([A-Za-z_$][A-Za-z0-9_$]*)\s*(?:\(|\{)""",
+    re.VERBOSE,
+)
+
+
+def _line_end(node) -> int:
+    """Return the inclusive source line containing ``node``'s end."""
+    row, column = node.end_point
+    return row - 1 if column == 0 and row > node.start_point[0] else row
+
+
+def _function_block_nodes(root):
+    """Return safe top-level Java block boundaries for one callable."""
+    stack = list(reversed(root.named_children))
+    while stack:
+        node = stack.pop()
+        if node.type in _FUNCTION_TYPES:
+            body = node.child_by_field_name("body")
+            if body is None:
+                return None
+            return [child for child in body.named_children if child.type != "comment"]
+        stack.extend(reversed(node.named_children))
+    return None
+
+
+def _constructor_name(source: str) -> str | None:
+    """Return a standalone constructor's name, if it can be wrapped safely."""
+    match = _CONSTRUCTOR_START.match(source)
+    return match.group(1) if match is not None else None
+
+
+def split_blocks(func: str, granularity: int) -> list[str] | None:
+    """Split a Java callable at complete top-level syntax nodes.
+
+    ``func`` may carry the ``Line N:`` prefixes added by ``parser.py``. They are
+    removed only for parsing; returned chunks retain the original prompt text.
+    Returning ``None`` asks the caller to use its regex/brace-depth fallback.
+    """
+    try:
+        import tree_sitter_java as ts_java
+        from tree_sitter import Language, Parser
+    except (ImportError, OSError):
+        return None
+
+    prompt_lines = func.strip().split("\n")
+    if len(prompt_lines) <= granularity:
+        return [func.strip()]
+
+    source = "\n".join(_LINE_PREFIX.sub("", line) for line in prompt_lines)
+    try:
+        parser = Parser(Language(ts_java.language()))
+        tree = parser.parse(source.encode("utf-8"))
+    except (TypeError, UnicodeError, ValueError):
+        return None
+
+    if tree.root_node.has_error:
+        constructor_name = _constructor_name(source)
+        if constructor_name is None:
+            return None
+        try:
+            tree = parser.parse(
+                f"class {constructor_name} {{\n{source}\n}}".encode("utf-8")
+            )
+        except UnicodeError:
+            return None
+        if tree.root_node.has_error:
+            return None
+        line_offset = 1
+    else:
+        line_offset = 0
+
+    block_nodes = _function_block_nodes(tree.root_node)
+    if not block_nodes:
+        return None
+
+    boundaries = sorted({_line_end(node) - line_offset for node in block_nodes})
+    blocks = []
+    start = 0
+    total = len(prompt_lines)
+    while start < total:
+        if total - start <= granularity * 2:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        split_at = next((end for end in boundaries if end >= start + granularity), None)
+        if split_at is None or split_at >= total - 1:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        blocks.append("\n".join(prompt_lines[start : split_at + 1]))
+        start = split_at + 1
+
+    return blocks
 
 
 def batch_extract(proj_dir: str) -> dict:

--- a/src/languages/javascript.py
+++ b/src/languages/javascript.py
@@ -1,4 +1,96 @@
+import re
+
 from src.languages.codegraph import CodeGraphExtractor
+
+
+_LINE_PREFIX = re.compile(r"^Line \d+: ?")
+_FUNCTION_TYPES = {
+    "function_declaration",
+    "generator_function_declaration",
+    "function_expression",
+    "generator_function",
+    "arrow_function",
+    "method_definition",
+}
+
+
+def _line_end(node) -> int:
+    """Return the inclusive source line containing ``node``'s end."""
+    row, column = node.end_point
+    return row - 1 if column == 0 and row > node.start_point[0] else row
+
+
+def _function_block_nodes(root):
+    """Return safe top-level JavaScript block boundaries for one callable."""
+    stack = list(reversed(root.named_children))
+    while stack:
+        node = stack.pop()
+        if node.type in _FUNCTION_TYPES:
+            body = node.child_by_field_name("body")
+            if body is None or body.type != "statement_block":
+                return None
+            return [child for child in body.named_children if child.type != "comment"]
+        stack.extend(reversed(node.named_children))
+    return None
+
+
+def split_blocks(func: str, granularity: int) -> list[str] | None:
+    """Split a JavaScript callable at complete top-level syntax nodes.
+
+    ``func`` may carry the ``Line N:`` prefixes added by ``parser.py``. They are
+    removed only for parsing; returned chunks retain the original prompt text.
+    Returning ``None`` asks the caller to use its regex/brace-depth fallback.
+    """
+    try:
+        import tree_sitter_javascript as ts_javascript
+        from tree_sitter import Language, Parser
+    except (ImportError, OSError):
+        return None
+
+    prompt_lines = func.strip().split("\n")
+    if len(prompt_lines) <= granularity:
+        return [func.strip()]
+
+    source = "\n".join(_LINE_PREFIX.sub("", line) for line in prompt_lines)
+    try:
+        parser = Parser(Language(ts_javascript.language()))
+        tree = parser.parse(source.encode("utf-8"))
+    except (TypeError, UnicodeError, ValueError):
+        return None
+
+    if tree.root_node.has_error:
+        try:
+            tree = parser.parse(f"class _ {{\n{source}\n}}".encode("utf-8"))
+        except UnicodeError:
+            return None
+        if tree.root_node.has_error:
+            return None
+        line_offset = 1
+    else:
+        line_offset = 0
+
+    block_nodes = _function_block_nodes(tree.root_node)
+    if not block_nodes:
+        return None
+
+    boundaries = sorted({_line_end(node) - line_offset for node in block_nodes})
+    blocks = []
+    start = 0
+    total = len(prompt_lines)
+    while start < total:
+        if total - start <= granularity * 2:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        split_at = next((end for end in boundaries if end >= start + granularity), None)
+        if split_at is None or split_at >= total - 1:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        blocks.append("\n".join(prompt_lines[start : split_at + 1]))
+        start = split_at + 1
+
+    return blocks
 
 
 def batch_extract(proj_dir: str) -> dict:

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -49,7 +49,7 @@ REGISTRY: dict = {
     "c":          LanguageHandler(batch_extract=_c.batch_extract,          call_edges=_c.call_edges,          function_spans=_c.function_spans, split_blocks=_c.split_blocks),
     "cpp":        LanguageHandler(batch_extract=_cpp.batch_extract,        call_edges=_cpp.call_edges,        function_spans=_cpp.function_spans, split_blocks=_cpp.split_blocks),
     "java":       LanguageHandler(batch_extract=_java.batch_extract,       call_edges=_java.call_edges,       function_spans=_java.function_spans, split_blocks=_java.split_blocks),
-    "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges,       function_spans=_rust.function_spans),
+    "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges,       function_spans=_rust.function_spans, split_blocks=_rust.split_blocks),
     "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges, function_spans=_javascript.function_spans, split_blocks=_javascript.split_blocks),
     "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges, function_spans=_typescript.function_spans, split_blocks=_typescript.split_blocks),
     "erlang":     LanguageHandler(batch_extract=_erlang.batch_extract,     call_edges=_erlang.call_edges,     function_spans=_erlang.function_spans, incremental_source_extract=_erlang.extract_functions_from_sources),

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -50,8 +50,8 @@ REGISTRY: dict = {
     "cpp":        LanguageHandler(batch_extract=_cpp.batch_extract,        call_edges=_cpp.call_edges,        function_spans=_cpp.function_spans, split_blocks=_cpp.split_blocks),
     "java":       LanguageHandler(batch_extract=_java.batch_extract,       call_edges=_java.call_edges,       function_spans=_java.function_spans, split_blocks=_java.split_blocks),
     "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges,       function_spans=_rust.function_spans),
-    "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges, function_spans=_javascript.function_spans),
-    "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges, function_spans=_typescript.function_spans),
+    "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges, function_spans=_javascript.function_spans, split_blocks=_javascript.split_blocks),
+    "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges, function_spans=_typescript.function_spans, split_blocks=_typescript.split_blocks),
     "erlang":     LanguageHandler(batch_extract=_erlang.batch_extract,     call_edges=_erlang.call_edges,     function_spans=_erlang.function_spans, incremental_source_extract=_erlang.extract_functions_from_sources),
 }
 

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -46,9 +46,9 @@ class LanguageHandler:
 REGISTRY: dict = {
     "python":     LanguageHandler(batch_extract=_python.batch_extract,     call_edges=_python.call_edges,     function_spans=_python.function_spans),
     "go":         LanguageHandler(batch_extract=_go.batch_extract,         call_edges=_go.call_edges,         function_spans=_go.function_spans),
-    "c":          LanguageHandler(batch_extract=_c.batch_extract,          call_edges=_c.call_edges,          function_spans=_c.function_spans),
+    "c":          LanguageHandler(batch_extract=_c.batch_extract,          call_edges=_c.call_edges,          function_spans=_c.function_spans, split_blocks=_c.split_blocks),
     "cpp":        LanguageHandler(batch_extract=_cpp.batch_extract,        call_edges=_cpp.call_edges,        function_spans=_cpp.function_spans, split_blocks=_cpp.split_blocks),
-    "java":       LanguageHandler(batch_extract=_java.batch_extract,       call_edges=_java.call_edges,       function_spans=_java.function_spans),
+    "java":       LanguageHandler(batch_extract=_java.batch_extract,       call_edges=_java.call_edges,       function_spans=_java.function_spans, split_blocks=_java.split_blocks),
     "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges,       function_spans=_rust.function_spans),
     "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges, function_spans=_javascript.function_spans),
     "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges, function_spans=_typescript.function_spans),

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -21,6 +21,7 @@ class LanguageHandler:
     function_spans(proj_dir, filepath)  -> [(func_name, start_idx, end_idx)] | None
     incremental_source_extract(proj_dir, sources)
         -> {abs_filepath: [(func_name, body)]} | None
+    split_blocks(func, granularity)      -> [chunk, ...] | None
 
     Each function handles its own backend (e.g. codegraph) internally.
     batch_extract returns ``None`` when a semantic backend cannot safely
@@ -31,7 +32,7 @@ class LanguageHandler:
 
     To add a new language:
       1. Create src/languages/<lang>.py implementing batch_extract, call_edges,
-         function_spans, and optionally incremental_source_extract
+         function_spans, and optionally incremental_source_extract / split_blocks
       2. Import it here and add one entry to REGISTRY
     No other files need to change.
     """
@@ -39,13 +40,14 @@ class LanguageHandler:
     call_edges: Callable
     function_spans: Callable
     incremental_source_extract: Callable | None = None
+    split_blocks: Callable | None = None
 
 
 REGISTRY: dict = {
     "python":     LanguageHandler(batch_extract=_python.batch_extract,     call_edges=_python.call_edges,     function_spans=_python.function_spans),
     "go":         LanguageHandler(batch_extract=_go.batch_extract,         call_edges=_go.call_edges,         function_spans=_go.function_spans),
     "c":          LanguageHandler(batch_extract=_c.batch_extract,          call_edges=_c.call_edges,          function_spans=_c.function_spans),
-    "cpp":        LanguageHandler(batch_extract=_cpp.batch_extract,        call_edges=_cpp.call_edges,        function_spans=_cpp.function_spans),
+    "cpp":        LanguageHandler(batch_extract=_cpp.batch_extract,        call_edges=_cpp.call_edges,        function_spans=_cpp.function_spans, split_blocks=_cpp.split_blocks),
     "java":       LanguageHandler(batch_extract=_java.batch_extract,       call_edges=_java.call_edges,       function_spans=_java.function_spans),
     "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges,       function_spans=_rust.function_spans),
     "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges, function_spans=_javascript.function_spans),
@@ -91,6 +93,15 @@ def function_spans_for_file(proj_dir: str, filepath: str, lang_key: str):
     if handler is None:
         return None
     return handler.function_spans(proj_dir, filepath)
+
+
+def split_blocks_for_function(func: str, lang_key: str, granularity: int):
+    """Return syntax-aware blocks for ``lang_key``, or ``None`` for fallback."""
+    normalized_key = {"c++": "cpp"}.get(lang_key.lower(), lang_key.lower())
+    handler = REGISTRY.get(normalized_key)
+    if handler is None or handler.split_blocks is None:
+        return None
+    return handler.split_blocks(func, granularity)
 
 
 def supports_incremental_source_extraction(lang_key: str) -> bool:

--- a/src/languages/rust.py
+++ b/src/languages/rust.py
@@ -1,4 +1,80 @@
+import re
+
 from src.languages.codegraph import CodeGraphExtractor
+
+
+_LINE_PREFIX = re.compile(r"^Line \d+: ?")
+
+
+def _line_end(node) -> int:
+    """Return the inclusive source line containing ``node``'s end."""
+    row, column = node.end_point
+    return row - 1 if column == 0 and row > node.start_point[0] else row
+
+
+def _function_block_nodes(root):
+    """Return safe top-level Rust block boundaries for one function."""
+    stack = list(reversed(root.named_children))
+    while stack:
+        node = stack.pop()
+        if node.type == "function_item":
+            body = node.child_by_field_name("body")
+            if body is None or body.type != "block":
+                return None
+            return [child for child in body.named_children if child.type != "comment"]
+        stack.extend(reversed(node.named_children))
+    return None
+
+
+def split_blocks(func: str, granularity: int) -> list[str] | None:
+    """Split a Rust function at complete top-level syntax nodes.
+
+    ``func`` may carry the ``Line N:`` prefixes added by ``parser.py``. They are
+    removed only for parsing; returned chunks retain the original prompt text.
+    Returning ``None`` asks the caller to use its regex/brace-depth fallback.
+    """
+    try:
+        import tree_sitter_rust as ts_rust
+        from tree_sitter import Language, Parser
+    except (ImportError, OSError):
+        return None
+
+    prompt_lines = func.strip().split("\n")
+    if len(prompt_lines) <= granularity:
+        return [func.strip()]
+
+    source = "\n".join(_LINE_PREFIX.sub("", line) for line in prompt_lines)
+    try:
+        parser = Parser(Language(ts_rust.language()))
+        tree = parser.parse(source.encode("utf-8"))
+    except (TypeError, UnicodeError, ValueError):
+        return None
+
+    if tree.root_node.has_error:
+        return None
+
+    block_nodes = _function_block_nodes(tree.root_node)
+    if not block_nodes:
+        return None
+
+    boundaries = sorted({_line_end(node) for node in block_nodes})
+    blocks = []
+    start = 0
+    total = len(prompt_lines)
+    while start < total:
+        if total - start <= granularity * 2:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        split_at = next((end for end in boundaries if end >= start + granularity), None)
+        if split_at is None or split_at >= total - 1:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        blocks.append("\n".join(prompt_lines[start : split_at + 1]))
+        start = split_at + 1
+
+    return blocks
 
 
 def batch_extract(proj_dir: str) -> dict:

--- a/src/languages/typescript.py
+++ b/src/languages/typescript.py
@@ -1,4 +1,111 @@
+import re
+
 from src.languages.codegraph import CodeGraphExtractor
+
+
+_LINE_PREFIX = re.compile(r"^Line \d+: ?")
+_FUNCTION_TYPES = {
+    "function_declaration",
+    "generator_function_declaration",
+    "function_expression",
+    "generator_function",
+    "arrow_function",
+    "method_definition",
+}
+
+
+def _line_end(node) -> int:
+    """Return the inclusive source line containing ``node``'s end."""
+    row, column = node.end_point
+    return row - 1 if column == 0 and row > node.start_point[0] else row
+
+
+def _function_block_nodes(root):
+    """Return safe top-level TypeScript block boundaries for one callable."""
+    stack = list(reversed(root.named_children))
+    while stack:
+        node = stack.pop()
+        if node.type in _FUNCTION_TYPES:
+            body = node.child_by_field_name("body")
+            if body is None or body.type != "statement_block":
+                return None
+            return [child for child in body.named_children if child.type != "comment"]
+        stack.extend(reversed(node.named_children))
+    return None
+
+
+def _parse_callable(source: str, typescript, tsx, parser_type):
+    """Parse TypeScript or TSX source, adding class context for methods."""
+    for language in (typescript, tsx):
+        parser = parser_type(language)
+        tree = parser.parse(source.encode("utf-8"))
+        if not tree.root_node.has_error:
+            return tree, 0
+
+    for language in (typescript, tsx):
+        parser = parser_type(language)
+        tree = parser.parse(f"class _ {{\n{source}\n}}".encode("utf-8"))
+        if not tree.root_node.has_error:
+            return tree, 1
+
+    return None
+
+
+def split_blocks(func: str, granularity: int) -> list[str] | None:
+    """Split a TypeScript callable at complete top-level syntax nodes.
+
+    The TypeScript parser is preferred; TSX is retried for JSX-bearing source.
+    ``func`` may carry the ``Line N:`` prefixes added by ``parser.py``. They are
+    removed only for parsing; returned chunks retain the original prompt text.
+    Returning ``None`` asks the caller to use its regex/brace-depth fallback.
+    """
+    try:
+        import tree_sitter_typescript as ts_typescript
+        from tree_sitter import Language, Parser
+    except (ImportError, OSError):
+        return None
+
+    prompt_lines = func.strip().split("\n")
+    if len(prompt_lines) <= granularity:
+        return [func.strip()]
+
+    source = "\n".join(_LINE_PREFIX.sub("", line) for line in prompt_lines)
+    try:
+        parsed = _parse_callable(
+            source,
+            Language(ts_typescript.language_typescript()),
+            Language(ts_typescript.language_tsx()),
+            Parser,
+        )
+    except (TypeError, UnicodeError, ValueError):
+        return None
+
+    if parsed is None:
+        return None
+    tree, line_offset = parsed
+
+    block_nodes = _function_block_nodes(tree.root_node)
+    if not block_nodes:
+        return None
+
+    boundaries = sorted({_line_end(node) - line_offset for node in block_nodes})
+    blocks = []
+    start = 0
+    total = len(prompt_lines)
+    while start < total:
+        if total - start <= granularity * 2:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        split_at = next((end for end in boundaries if end >= start + granularity), None)
+        if split_at is None or split_at >= total - 1:
+            blocks.append("\n".join(prompt_lines[start:]))
+            break
+
+        blocks.append("\n".join(prompt_lines[start : split_at + 1]))
+        start = split_at + 1
+
+    return blocks
 
 
 def batch_extract(proj_dir: str) -> dict:

--- a/src/parser.py
+++ b/src/parser.py
@@ -64,8 +64,6 @@ def _remove_func_comments(code):
     in_block_comment = False
     in_string = False
     string_delimiter = ""
-    in_raw_string = False
-    raw_string_hashes = 0
     line_start = True
 
     while index < len(code):
@@ -82,41 +80,6 @@ def _remove_func_comments(code):
                 line_start = True
             index += 1
             continue
-
-        if in_raw_string:
-            closing_delimiter = '"' + '#' * raw_string_hashes
-            if code.startswith(closing_delimiter, index):
-                result.append(closing_delimiter)
-                index += len(closing_delimiter)
-                in_raw_string = False
-                line_start = False
-            else:
-                result.append(char)
-                line_start = char == '\n'
-                index += 1
-            continue
-
-        # Rust raw strings use r"...", r#"..."#, etc.; byte raw strings add b.
-        raw_prefix_length = (
-            2 if char == 'b' and next_char == 'r' else 1 if char == 'r' else 0
-        )
-        if raw_prefix_length and (
-            index == 0 or not (code[index - 1].isalnum() or code[index - 1] == '_')
-        ):
-            delimiter_index = index + raw_prefix_length
-            while delimiter_index < len(code) and code[delimiter_index] == '#':
-                delimiter_index += 1
-            if (
-                delimiter_index < len(code)
-                and delimiter_index - index - raw_prefix_length < 256
-                and code[delimiter_index] == '"'
-            ):
-                raw_string_hashes = delimiter_index - index - raw_prefix_length
-                result.append(code[index : delimiter_index + 1])
-                index = delimiter_index + 1
-                in_raw_string = True
-                line_start = False
-                continue
 
         if in_string:
             result.append(char)

--- a/src/parser.py
+++ b/src/parser.py
@@ -64,6 +64,8 @@ def _remove_func_comments(code):
     in_block_comment = False
     in_string = False
     string_delimiter = ""
+    in_raw_string = False
+    raw_string_hashes = 0
     line_start = True
 
     while index < len(code):
@@ -80,6 +82,41 @@ def _remove_func_comments(code):
                 line_start = True
             index += 1
             continue
+
+        if in_raw_string:
+            closing_delimiter = '"' + '#' * raw_string_hashes
+            if code.startswith(closing_delimiter, index):
+                result.append(closing_delimiter)
+                index += len(closing_delimiter)
+                in_raw_string = False
+                line_start = False
+            else:
+                result.append(char)
+                line_start = char == '\n'
+                index += 1
+            continue
+
+        # Rust raw strings use r"...", r#"..."#, etc.; byte raw strings add b.
+        raw_prefix_length = (
+            2 if char == 'b' and next_char == 'r' else 1 if char == 'r' else 0
+        )
+        if raw_prefix_length and (
+            index == 0 or not (code[index - 1].isalnum() or code[index - 1] == '_')
+        ):
+            delimiter_index = index + raw_prefix_length
+            while delimiter_index < len(code) and code[delimiter_index] == '#':
+                delimiter_index += 1
+            if (
+                delimiter_index < len(code)
+                and delimiter_index - index - raw_prefix_length < 256
+                and code[delimiter_index] == '"'
+            ):
+                raw_string_hashes = delimiter_index - index - raw_prefix_length
+                result.append(code[index : delimiter_index + 1])
+                index = delimiter_index + 1
+                in_raw_string = True
+                line_start = False
+                continue
 
         if in_string:
             result.append(char)

--- a/src/reasoner.py
+++ b/src/reasoner.py
@@ -30,10 +30,20 @@ def _compute_brace_depth_per_line(lines):
     """
     depths = []
     depth = 0
+    in_block_comment = False
     for line in lines:
         i = 0
         while i < len(line):
             ch = line[i]
+            # A block comment may span lines. While inside one, only its closing
+            # delimiter is syntax; every other character, including braces, is text.
+            if in_block_comment:
+                if ch == '*' and i + 1 < len(line) and line[i + 1] == '/':
+                    in_block_comment = False
+                    i += 2
+                else:
+                    i += 1
+                continue
             # Skip string literals
             if ch == '"':
                 i += 1
@@ -63,13 +73,8 @@ def _compute_brace_depth_per_line(lines):
                 break
             # Block comment
             if ch == '/' and i + 1 < len(line) and line[i + 1] == '*':
+                in_block_comment = True
                 i += 2
-                while i < len(line):
-                    if line[i] == '*' and i + 1 < len(line) and line[i + 1] == '/':
-                        i += 2
-                        break
-                    i += 1
-                # If block comment spans lines, we ignore braces inside it (simplified)
                 continue
             if ch == '{':
                 depth += 1

--- a/src/reasoner.py
+++ b/src/reasoner.py
@@ -1,5 +1,6 @@
 import re
 from config import *
+from .languages.registry import split_blocks_for_function
 from .prompts import _generate_block_post_condition, _check_post_implies_spec
 
 
@@ -83,6 +84,10 @@ def _split_into_blocks_braced(func, language):
     """
     Split function body into blocks respecting syntactic boundaries.
     """
+
+    syntax_blocks = split_blocks_for_function(func, language, GRANULARITY)
+    if syntax_blocks is not None:
+        return syntax_blocks
 
     python_like = {"python"}
 

--- a/uv.lock
+++ b/uv.lock
@@ -322,6 +322,8 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "socksio" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-cpp" },
 ]
 
 [package.metadata]
@@ -332,6 +334,8 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "socksio", specifier = ">=1.0.0" },
+    { name = "tree-sitter", specifier = ">=0.25,<0.27" },
+    { name = "tree-sitter-cpp", specifier = ">=0.23.4,<0.24" },
 ]
 
 [[package]]
@@ -1471,6 +1475,53 @@ dependencies = [
 sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/03/5600b84aff2e6c4fe80cfebb4063fe2f50299521befe5f6092ab8c082f4a/tree_sitter-0.26.0.tar.gz", hash = "sha256:b40c219edccc4564530c96f8f1556f6202b37cda964d1cbd7bd2b7e68b40a245", size = 191423, upload-time = "2026-06-30T12:14:27.933Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/87/ca/565702c44815393e3a973552ad546db4e5ca081ca8698640b4e93d809f51/tree_sitter-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6cb2bd20efb2544c19ac54486ab7cb8ec7b36f913bbe1ce95df84acb96743d9c", size = 148934, upload-time = "2026-06-30T12:14:01.188Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/54/6f/8bb61957f16ec1b1d92410a006cdc84a952b6352a7313b2ad299f2d21484/tree_sitter-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:918d89529786873f0982a0f59c2a303cd065fbfd1b903d71a8e4e1584f67b42e", size = 140820, upload-time = "2026-06-30T12:14:02.087Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/78/0a/8a6f08559182643a814a4ab559948ae817b2851890fd9b995a4fff6541ce/tree_sitter-0.26.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30a88be89ff1f2755297f81e8080d88b795dd98720c3f9fa2acf93873182cc95", size = 638844, upload-time = "2026-06-30T12:14:03.428Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8a/2f/6e6781b31677231366cb3cf27bc8269157f6d4b03c9032865a4f5f2bbe7e/tree_sitter-0.26.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a6b333b0282d8bb0af741f9b018bd2523d4eecb2686bf6717066a625fecfaa4", size = 667487, upload-time = "2026-06-30T12:14:04.669Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/02/0b/0483078c8567445557a7015b0e5b187f6d7d4fda73464df9c4bdea7f7f3c/tree_sitter-0.26.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3f3c44339dd34fe8eb2b8d5aa7610660499a795f70376b130bbee7a437337280", size = 647975, upload-time = "2026-06-30T12:14:05.797Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/27/68/da83ca72c984e96ab4eb3bee0db1a6ffb5de1c8c455f92bd9f420cde7f0e/tree_sitter-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:94550e13b6ae576969da40246f4c4abb206380b5375ad43f26dd9151d55438e3", size = 665018, upload-time = "2026-06-30T12:14:07.278Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/36/4d67927fd47b89af4a00f65f55a7370e28778cd50e972c2430487e3ecc27/tree_sitter-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:ca89e361a276dbc934b28a43dd881199e25d34ff5493ee0ce45f3c52a6124a37", size = 129619, upload-time = "2026-06-30T12:14:08.373Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ed/72/cdefad523eb78710679c6da6a79e3d90f5afd32b1c6aa5a17bac7eef99f6/tree_sitter-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:bc6cb01d5ee75c85424aa1f1c72a82d8f07fd52539a0f3c4a6ed3e8721079b84", size = 116545, upload-time = "2026-06-30T12:14:09.273Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cb/b0/465257cf8f972ad9f9812ec1cbaa8ec210ebebb601ade9a15881aa2436b4/tree_sitter-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ed0889dbed843ce45ede9f5169c0b2dea2222f12685844a03fadb81f12705867", size = 148893, upload-time = "2026-06-30T12:14:10.541Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a1/ec/19d093e854b45e807fecfdd26105c266f43aeecc39c4dc97992a7074ad5a/tree_sitter-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6189c6c340c7384357711e3d92645e96bfb79f7a502f86de1ebdb23eb43f7dab", size = 140829, upload-time = "2026-06-30T12:14:11.626Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9b/ee/87e74671ed63a837e7a1f17ab94aa3913871e033b27523d8e7b83d6f7ad0/tree_sitter-0.26.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ff2e0750b7daa722302838356d7b65e303829b7eb73c915df127ddba115e1d1", size = 639334, upload-time = "2026-06-30T12:14:12.836Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/66/e7/f7e04cd9dff6b6ac0adf23922796fbc76accd4cf4bcda50542748d485679/tree_sitter-0.26.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7075ef857ef86f327dbb72d1e2574dda78db5754b3a1fca6506acd7fe5d561a7", size = 668102, upload-time = "2026-06-30T12:14:14.035Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d3/90/0bfb16b7894fea728c774a89d5af421a9368a2f913bbd4e8dcab7caaecfb/tree_sitter-0.26.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:26c996c1edfee86e977bb3f5462e74fcec0d0b0db1e85a3c475875763caa03be", size = 648560, upload-time = "2026-06-30T12:14:15.302Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/cd/e6/0fe05ba396e9623b0ae40ccf34171336b8701ec8d7bd0ee9f5224d638665/tree_sitter-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00289bfe7978f3e0dc0ce69813a20fa9f44ea4c100b3ec62043e5eb74ccfc3a2", size = 665121, upload-time = "2026-06-30T12:14:16.403Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/d2/a944b1ca35bed6068dc84a9967aaf3049d8cc0b7a36179eea8787270a6ab/tree_sitter-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:93e220cab7e6a823efeb2046c49171427de92ef71c7c681c01820d14d8d3721f", size = 129615, upload-time = "2026-06-30T12:14:17.463Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/ef/c7ca48293580d2249f36940c4eed5b4ddeb9ce75baf9a4ef30621987e0c7/tree_sitter-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:b31a8195d2f224224c530ac814632d98c1dcc123d227442c07c736e86b70d564", size = 116525, upload-time = "2026-06-30T12:14:18.53Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/7a/4d84e6f6ae2c3e757490dd84de251712c31e293dfe31f28da1ec019cefa2/tree_sitter-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5a3c93a352b7e6f70f73e121bbfa2d0117ba7478bd51114ed35c91b0b78814fa", size = 148901, upload-time = "2026-06-30T12:14:19.452Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b0/d9/efe62ec65dc9d096e834d27b8c058127e2146e42ff3380b822a233f016a6/tree_sitter-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5fc2f41bf246ff2f70a9cc3690be35ec7580a4923151873d898c8bcb1a4503d3", size = 140805, upload-time = "2026-06-30T12:14:20.478Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c4/2c/c82326b7b97e3c485c18679883b16f89e5e913c639d3b219d3da70c9e67e/tree_sitter-0.26.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8ea92a255c91671a7ec4625aba3ab7bb5220c423630ffbf83c45d7312abe084", size = 640586, upload-time = "2026-06-30T12:14:21.527Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e2/7a/f56e7d8282859452611024c7cbc623bfba5b24b8cb9b8f8bc88c5219fe9a/tree_sitter-0.26.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f665510f0fcf4636fb9696f1f7853bed7a3bd764b7bb0cb8494e619c14ed5a0c", size = 668300, upload-time = "2026-06-30T12:14:22.728Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/91/51/240ee81b9d5e9ca0a6cb1528e8605ffa70ab58c89ce126631be96d3e4bae/tree_sitter-0.26.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:253df7ab82cc0a9d311cd65f06e9f99fb3eac55996ae9fc94da22f123a861b90", size = 649627, upload-time = "2026-06-30T12:14:23.819Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6a/54/760035cefedf9eb44f0f84c4ac22f1322e73155853e272576ee876336312/tree_sitter-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ff80d4833d330a73184a3ac5132abe93c575d2dea31975c6f15c0d21fef238aa", size = 664885, upload-time = "2026-06-30T12:14:25.064Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/1b/0b36fe2a984ecedc4ce6aefd5d56447a6626a8e9b595c4e48658510ce8f8/tree_sitter-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:a4033fecc8f606c7f2e8b8014d0057b74668a7f0152763606f7bc25c5f9ec64c", size = 132688, upload-time = "2026-06-30T12:14:26.106Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4d/74/ebc041a13fbf40144afdb0d4b447e48e0b4012ca866c63de8b48f801f0c1/tree_sitter-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:823251c4b6725a7c03ed497a339135ede7ae4bdde75bb8be7ef5e305aeb4ff52", size = 120287, upload-time = "2026-06-30T12:14:26.991Z" },
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/20/2c/4dd63d705a8933543cad9b92ff31be849b164fec91a6eb63475ebc9ce668/tree_sitter_cpp-0.23.4.tar.gz", hash = "sha256:6a59c4cebb1ad1dc2e8d586cf8a72b39d21b8108b7b139d089719e81a339e41d", size = 940358, upload-time = "2024-11-11T06:59:24.934Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b6/ac/11d56670f7b048362db872ca866fd00ba2002a322ab179f047b7c0fb2910/tree_sitter_cpp-0.23.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aacb1759f0efd9dbc25bd8ee88184a340483018869f75412d9c3bc32c039a520", size = 287861, upload-time = "2024-11-11T06:59:15.005Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/12/1c/0337c016bdc00a77a3326d12f10ee836401dd28f27db6fd5b7734bfb21ed/tree_sitter_cpp-0.23.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc3c404d9f0cbd87951213a85440afbf4c31e718f8d907fa9ee12bea4b8d276f", size = 315513, upload-time = "2024-11-11T06:59:16.679Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/7b/dd38c049b10ed7fda118b903a1d28a8b55a36b98c30606ef90e8f374c6de/tree_sitter_cpp-0.23.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ccc43ddf1279d5d5a4ef190373f4cb16522801bec4492bcd4754edf2aeba2b7b", size = 334813, upload-time = "2024-11-11T06:59:18.253Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6a/4d/23e390234d2acd351f5563b1079c515d7c1fe13ddb7392cee543be74dda3/tree_sitter_cpp-0.23.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:773d2cafc08bbc0f998687fa33f42f378c1a371cdb582870c4d13abb06092706", size = 316110, upload-time = "2024-11-11T06:59:19.823Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/32/c7/b94a7e0e803af9d3bd4608fb4f0cfb2e9e233abaf0a38c928bfb0b1a025d/tree_sitter_cpp-0.23.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:247d127f0eb6574b0f6b30c0151e0bd0774e2e7acf9c558bdf9fbb8adc2e80c0", size = 308242, upload-time = "2024-11-11T06:59:21.466Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/7e/909e52b3dec09c475140b0e175511e275d0d00ba2dbd7c68102d377ae0f6/tree_sitter_cpp-0.23.4-cp39-abi3-win_amd64.whl", hash = "sha256:68606a45bea92669d155399e1239f771a7767d8683cd8f8e30e7d813107030ca", size = 290997, upload-time = "2024-11-11T06:59:22.432Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d4/6a/65435d4d1f4c735be7ffe52d7c2e7b8a7f7c2790343a2719c60c548611c8/tree_sitter_cpp-0.23.4-cp39-abi3-win_arm64.whl", hash = "sha256:712f84f18be94cbe2a148fa4fdf40fcf4a8c25a8f7670efb9f8a47ddec2fc281", size = 288203, upload-time = "2024-11-11T06:59:23.404Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -326,6 +326,8 @@ dependencies = [
     { name = "tree-sitter-c" },
     { name = "tree-sitter-cpp" },
     { name = "tree-sitter-java" },
+    { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-typescript" },
 ]
 
 [package.metadata]
@@ -340,6 +342,8 @@ requires-dist = [
     { name = "tree-sitter-c", specifier = ">=0.24,<0.25" },
     { name = "tree-sitter-cpp", specifier = ">=0.23.4,<0.24" },
     { name = "tree-sitter-java", specifier = ">=0.23.5,<0.24" },
+    { name = "tree-sitter-javascript", specifier = ">=0.23,<0.26" },
+    { name = "tree-sitter-typescript", specifier = ">=0.23,<0.24" },
 ]
 
 [[package]]
@@ -1557,6 +1561,37 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/43/56/7d06b23ddd09bde816a131aa504ee11a1bbe87c6b62ab9b2ed23849a3382/tree_sitter_java-0.23.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aae84449e330363b55b14a2af0585e4e0dae75eb64ea509b7e5b0e1de536846a", size = 82564, upload-time = "2024-12-21T18:24:20.493Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/d6/0528c7e1e88a18221dbd8ccee3825bf274b1fa300f745fd74eb343878043/tree_sitter_java-0.23.5-cp39-abi3-win_amd64.whl", hash = "sha256:1ee45e790f8d31d416bc84a09dac2e2c6bc343e89b8a2e1d550513498eedfde7", size = 60650, upload-time = "2024-12-21T18:24:22.902Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/57/5bab54d23179350356515526fff3cc0f3ac23bfbc1a1d518a15978d4880e/tree_sitter_java-0.23.5-cp39-abi3-win_arm64.whl", hash = "sha256:402efe136104c5603b429dc26c7e75ae14faaca54cfd319ecc41c8f2534750f4", size = 59059, upload-time = "2024-12-21T18:24:24.934Z" },
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/59/e0/e63103c72a9d3dfd89a31e02e660263ad84b7438e5f44ee82e443e65bbde/tree_sitter_javascript-0.25.0.tar.gz", hash = "sha256:329b5414874f0588a98f1c291f1b28138286617aa907746ffe55adfdcf963f38", size = 132338, upload-time = "2025-09-01T07:13:44.792Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2c/df/5106ac250cd03661ebc3cc75da6b3d9f6800a3606393a0122eca58038104/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b70f887fb269d6e58c349d683f59fa647140c410cfe2bee44a883b20ec92e3dc", size = 64052, upload-time = "2025-09-01T07:13:36.865Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/8f/6b4b2bc90d8ab3955856ce852cc9d1e82c81d7ab9646385f0e75ffd5b5d3/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8264a996b8845cfce06965152a013b5d9cbb7d199bc3503e12b5682e62bb1de1", size = 66440, upload-time = "2025-09-01T07:13:37.962Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5f/c4/7da74ecdcd8a398f88bd003a87c65403b5fe0e958cdd43fbd5fd4a398fcf/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dc04ba91fc8583344e57c1f1ed5b2c97ecaaf47480011b92fbeab8dda96db75", size = 99728, upload-time = "2025-09-01T07:13:38.755Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/c8/97da3af4796495e46421e9344738addb3602fa6426ea695be3fcbadbee37/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:199d09985190852e0912da2b8d26c932159be314bc04952cf917ed0e4c633e6b", size = 106072, upload-time = "2025-09-01T07:13:39.798Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/13/be/c964e8130be08cc9bd6627d845f0e4460945b158429d39510953bbcb8fcc/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dfcf789064c58dc13c0a4edb550acacfc6f0f280577f1e7a00de3e89fc7f8ddc", size = 104388, upload-time = "2025-09-01T07:13:40.866Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1e/fc/bb52958f7e399250aee093751e9373a6311cadbe76b6e0d109b853757f35/tree_sitter_typescript-0.23.2.tar.gz", hash = "sha256:7b167b5827c882261cb7a50dfa0fb567975f9b315e87ed87ad0a0a3aedb3834d", size = 773053, upload-time = "2024-11-11T02:36:11.396Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/95/4c00680866280e008e81dd621fd4d3f54aa3dad1b76b857a19da1b2cc426/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3cd752d70d8e5371fdac6a9a4df9d8924b63b6998d268586f7d374c9fba2a478", size = 286677, upload-time = "2024-11-11T02:35:58.839Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8f/2f/1f36fda564518d84593f2740d5905ac127d590baf5c5753cef2a88a89c15/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c7cc1b0ff5d91bac863b0e38b1578d5505e718156c9db577c8baea2557f66de8", size = 302008, upload-time = "2024-11-11T02:36:00.733Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/96/2d/975c2dad292aa9994f982eb0b69cc6fda0223e4b6c4ea714550477d8ec3a/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b1eed5b0b3a8134e86126b00b743d667ec27c63fc9de1b7bb23168803879e31", size = 351987, upload-time = "2024-11-11T02:36:02.669Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/d1/a71c36da6e2b8a4ed5e2970819b86ef13ba77ac40d9e333cb17df6a2c5db/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e96d36b85bcacdeb8ff5c2618d75593ef12ebaf1b4eace3477e2bdb2abb1752c", size = 344960, upload-time = "2024-11-11T02:36:04.443Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/cb/f57b149d7beed1a85b8266d0c60ebe4c46e79c9ba56bc17b898e17daf88e/tree_sitter_typescript-0.23.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8d4f0f9bcb61ad7b7509d49a1565ff2cc363863644a234e1e0fe10960e55aea0", size = 340245, upload-time = "2024-11-11T02:36:06.473Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8b/ab/dd84f0e2337296a5f09749f7b5483215d75c8fa9e33738522e5ed81f7254/tree_sitter_typescript-0.23.2-cp39-abi3-win_amd64.whl", hash = "sha256:3f730b66396bc3e11811e4465c41ee45d9e9edd6de355a58bbbc49fa770da8f9", size = 278015, upload-time = "2024-11-11T02:36:07.631Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9f/e4/81f9a935789233cf412a0ed5fe04c883841d2c8fb0b7e075958a35c65032/tree_sitter_typescript-0.23.2-cp39-abi3-win_arm64.whl", hash = "sha256:05db58f70b95ef0ea126db5560f3775692f609589ed6f8dd0af84b7f19f1cbb7", size = 274052, upload-time = "2024-11-11T02:36:09.514Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,9 @@ dependencies = [
     { name = "rich" },
     { name = "socksio" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-c" },
     { name = "tree-sitter-cpp" },
+    { name = "tree-sitter-java" },
 ]
 
 [package.metadata]
@@ -335,7 +337,9 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7.0" },
     { name = "socksio", specifier = ">=1.0.0" },
     { name = "tree-sitter", specifier = ">=0.25,<0.27" },
+    { name = "tree-sitter-c", specifier = ">=0.24,<0.25" },
     { name = "tree-sitter-cpp", specifier = ">=0.23.4,<0.24" },
+    { name = "tree-sitter-java", specifier = ">=0.23.5,<0.24" },
 ]
 
 [[package]]
@@ -1510,6 +1514,22 @@ wheels = [
 ]
 
 [[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a6/c9/3834f3d9278251aea7312274971bc4c45b17aec2490fd4b884d93bd7019a/tree_sitter_c-0.24.2.tar.gz", hash = "sha256:1628584df0299b5a340aa63f8e67b6c97c91517f52fa7e7a4c557e40adb330a9", size = 228397, upload-time = "2026-04-22T08:06:14.491Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/28/c1/26ed17730ec2c17bedc1b673349e5e0a466c578e3eb0327c3b73cf52bf97/tree_sitter_c-0.24.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4d4579a8b54f0a442f903d88d3304cab77cd5c2031d4015baa4f2f8e15d6dcb7", size = 81016, upload-time = "2026-04-22T08:06:07.208Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c1/1c/1140db75e7e375cda3c68792a33826c4fd40b5b98c3259d93c75f6c8368f/tree_sitter_c-0.24.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:97bc80a224d48215d4e6e6376bf30d114f4c317b8145ff1b02afe785d4ba7bdd", size = 86213, upload-time = "2026-04-22T08:06:08.136Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/8c/0dfb88d726f8821d1c4c36042f092be974a800afd734307a595b8604190c/tree_sitter_c-0.24.2-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5041ef67eb68ce6bc8bb0b1f8ef3a5585ce523dae0c7eec109ab0627dd75aede", size = 94264, upload-time = "2026-04-22T08:06:08.918Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/87/78/47dc570e7aee6b0a1ecc2520b30639cc2b06003154c9ab0672d86bf720d5/tree_sitter_c-0.24.2-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c098bedcd5ac86ff93fa734d51d1dd86aed40fd5ed7d634c7af11380a0469969", size = 94560, upload-time = "2026-04-22T08:06:09.852Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/37/75d59d3f74f4cfc00f04472917e933d8a9c9fdc6eff980ef9552e010e6aa/tree_sitter_c-0.24.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:82842c5a5f2acd93f4de10038c33ac179c8979defc39376f990348d6289e933b", size = 94023, upload-time = "2026-04-22T08:06:10.682Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/64/57/8fc655d5a446a70a637e92b98bd2fdaab88bf5bb5b36076ac4add544808d/tree_sitter_c-0.24.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e2b42e8e22202c251f8629306f9321233542e07a6e01611b5fe83489272143eb", size = 94160, upload-time = "2026-04-22T08:06:11.497Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c1/f7/72a1d6b42dd31fd37e03ff67e7dc5ee572301499e6b216002b8dd42a1714/tree_sitter_c-0.24.2-cp310-abi3-win_amd64.whl", hash = "sha256:abb549225091f7b25df2dd3a0143ece6e208f7055d8bcb4700b41ee79b9ef1e1", size = 84669, upload-time = "2026-04-22T08:06:12.347Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e2/9d/7475d9ae8ef679aa36c7dfe6c903ab78e573651c68b6ef9862d6a3f994db/tree_sitter_c-0.24.2-cp310-abi3-win_arm64.whl", hash = "sha256:4a2f4371cd816cc3153458f69062135ebb2ea5f275ddd90494e5c823d778204a", size = 82956, upload-time = "2026-04-22T08:06:13.364Z" },
+]
+
+[[package]]
 name = "tree-sitter-cpp"
 version = "0.23.4"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
@@ -1522,6 +1542,21 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/32/c7/b94a7e0e803af9d3bd4608fb4f0cfb2e9e233abaf0a38c928bfb0b1a025d/tree_sitter_cpp-0.23.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:247d127f0eb6574b0f6b30c0151e0bd0774e2e7acf9c558bdf9fbb8adc2e80c0", size = 308242, upload-time = "2024-11-11T06:59:21.466Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/37/7e/909e52b3dec09c475140b0e175511e275d0d00ba2dbd7c68102d377ae0f6/tree_sitter_cpp-0.23.4-cp39-abi3-win_amd64.whl", hash = "sha256:68606a45bea92669d155399e1239f771a7767d8683cd8f8e30e7d813107030ca", size = 290997, upload-time = "2024-11-11T06:59:22.432Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d4/6a/65435d4d1f4c735be7ffe52d7c2e7b8a7f7c2790343a2719c60c548611c8/tree_sitter_cpp-0.23.4-cp39-abi3-win_arm64.whl", hash = "sha256:712f84f18be94cbe2a148fa4fdf40fcf4a8c25a8f7670efb9f8a47ddec2fc281", size = 288203, upload-time = "2024-11-11T06:59:23.404Z" },
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fa/dc/eb9c8f96304e5d8ae1663126d89967a622a80937ad2909903569ccb7ec8f/tree_sitter_java-0.23.5.tar.gz", hash = "sha256:f5cd57b8f1270a7f0438878750d02ccc79421d45cca65ff284f1527e9ef02e38", size = 138121, upload-time = "2024-12-21T18:24:26.936Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/67/21/b3399780b440e1567a11d384d0ebb1aea9b642d0d98becf30fa55c0e3a3b/tree_sitter_java-0.23.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:355ce0308672d6f7013ec913dee4a0613666f4cda9044a7824240d17f38209df", size = 58926, upload-time = "2024-12-21T18:24:12.53Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/57/ef/6406b444e2a93bc72a04e802f4107e9ecf04b8de4a5528830726d210599c/tree_sitter_java-0.23.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:24acd59c4720dedad80d548fe4237e43ef2b7a4e94c8549b0ca6e4c4d7bf6e69", size = 62288, upload-time = "2024-12-21T18:24:14.634Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4e/6c/74b1c150d4f69c291ab0b78d5dd1b59712559bbe7e7daf6d8466d483463f/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9401e7271f0b333df39fc8a8336a0caf1b891d9a2b89ddee99fae66b794fc5b7", size = 85533, upload-time = "2024-12-21T18:24:16.695Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/29/09/e0d08f5c212062fd046db35c1015a2621c2631bc8b4aae5740d7adb276ad/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:370b204b9500b847f6d0c5ad584045831cee69e9a3e4d878535d39e4a7e4c4f1", size = 84033, upload-time = "2024-12-21T18:24:18.758Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/43/56/7d06b23ddd09bde816a131aa504ee11a1bbe87c6b62ab9b2ed23849a3382/tree_sitter_java-0.23.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aae84449e330363b55b14a2af0585e4e0dae75eb64ea509b7e5b0e1de536846a", size = 82564, upload-time = "2024-12-21T18:24:20.493Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/d6/0528c7e1e88a18221dbd8ccee3825bf274b1fa300f745fd74eb343878043/tree_sitter_java-0.23.5-cp39-abi3-win_amd64.whl", hash = "sha256:1ee45e790f8d31d416bc84a09dac2e2c6bc343e89b8a2e1d550513498eedfde7", size = 60650, upload-time = "2024-12-21T18:24:22.902Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/57/5bab54d23179350356515526fff3cc0f3ac23bfbc1a1d518a15978d4880e/tree_sitter_java-0.23.5-cp39-abi3-win_arm64.whl", hash = "sha256:402efe136104c5603b429dc26c7e75ae14faaca54cfd319ecc41c8f2534750f4", size = 59059, upload-time = "2024-12-21T18:24:24.934Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -327,6 +327,7 @@ dependencies = [
     { name = "tree-sitter-cpp" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-rust" },
     { name = "tree-sitter-typescript" },
 ]
 
@@ -343,6 +344,7 @@ requires-dist = [
     { name = "tree-sitter-cpp", specifier = ">=0.23.4,<0.24" },
     { name = "tree-sitter-java", specifier = ">=0.23.5,<0.24" },
     { name = "tree-sitter-javascript", specifier = ">=0.23,<0.26" },
+    { name = "tree-sitter-rust", specifier = ">=0.24,<0.25" },
     { name = "tree-sitter-typescript", specifier = ">=0.23,<0.24" },
 ]
 
@@ -1577,6 +1579,22 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b7/87/75cbd22b927267d310f76cca1ab3c1d9d41035dfa3eb9cc95f96ee199440/tree_sitter_rust-0.24.2.tar.gz", hash = "sha256:54fb02a5911e345308b405174465112479f56dc39e3f1e7744d7568595f00db9", size = 339341, upload-time = "2026-03-27T21:08:55.629Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/24/2b2d33af5e27c84a4fde4e8cd2594bb4ab1e1cf48756a9f40dadc84956cc/tree_sitter_rust-0.24.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3620cfd12340efa43082d45df76349ff511893a9c361da2f8d6d51e307020a59", size = 129507, upload-time = "2026-03-27T21:08:47.585Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/78/2a/cf39f881a545360b5a86bb1accba1f4acc713daab01fb9edd35b6e84f473/tree_sitter_rust-0.24.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:01a46622735498493f29f3e628a90de95c96a07bfbeb88996243eb986b1cee36", size = 136812, upload-time = "2026-03-27T21:08:48.761Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ca/45/a051bbd3045a61182dde25b93ae9a33d2677c935b16952283e12eaf46051/tree_sitter_rust-0.24.2-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e033c5a93b57c88e0a835880de39fc802909ff69f57aaff6000211c196ea5190", size = 164706, upload-time = "2026-03-27T21:08:49.605Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b5/f6/a5a146df5c0a5daea3ffcd5d7245775fe7f084357770d5a313dd6245ae78/tree_sitter_rust-0.24.2-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d76d1208c3638b871236090759dfc13d478921320653a6c9da5336e7c58f65a", size = 170310, upload-time = "2026-03-27T21:08:50.424Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/95/a8/f85b1ca75e01361ca5f92d226593ca4857cea49551b9f6c8fa6fc08ea917/tree_sitter_rust-0.24.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87930163a462408c49ab62c667e74029bc26b4cc7123dd1bdc7352215786c64a", size = 168668, upload-time = "2026-03-27T21:08:51.404Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a2/e1/3519f866a4679ca36acd9f5a06a779ecb8a92b18887c5546458d521df557/tree_sitter_rust-0.24.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:da2b86099028fd42c6cd32878b7b16b01f8aac0f7b0e98742b7fa6bc3cf09b89", size = 162403, upload-time = "2026-03-27T21:08:52.588Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/34/71/7ef609894dbfe5699eb16f7471f9b8af1d958d8ba3e29c238d7607e8cb47/tree_sitter_rust-0.24.2-cp39-abi3-win_amd64.whl", hash = "sha256:4529c125d928882ddfb879fdc6bc0704913261ecc078b6fa7902559e0daf200d", size = 129422, upload-time = "2026-03-27T21:08:54.031Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b9/d8/050a781172745bc345f98abb7c56e72022ea0790f8e793de981c83c2ef15/tree_sitter_rust-0.24.2-cp39-abi3-win_arm64.whl", hash = "sha256:66ba90f61bd54f4c4f5d30434957daf64507c16b0313df76becb37d63f70a227", size = 128245, upload-time = "2026-03-27T21:08:54.803Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR introduces a modular Tree-sitter-first block-splitting path for brace-delimited languages, with C++ currently implemented and C, Java, JavaScript/TypeScript, Rust, and similar languages still pending. No review needed yet.