### PR TITLE
feat(all-bugs): report multiple violations per checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,11 +263,12 @@ uv run python main.py <proj_dir> --incremental intent.md --all-bugs
 uv run python main.py <proj_dir> --entry-func src::main --all-bugs
 ```
 
-The option is off by default. When enabled, FM-Agent continues through later
-reasoning checkpoints and writes one standard mismatch result per candidate.
-Full and incremental modes validate each candidate independently. Entry-point
-reasoning reports the candidates and their count but intentionally does not run
-bug validation.
+The option is off by default. When enabled, FM-Agent allows each reasoning
+checkpoint to report multiple independently explainable violations, continues
+through later checkpoints, and writes one standard mismatch result per
+candidate. Full and incremental modes validate each candidate independently.
+Entry-point reasoning reports the candidates and their count but intentionally
+does not run bug validation.
 
 For a result such as `path/to/function.json`, all-bugs candidates are written
 beside it as `path/to/function.bug-001.json`, `bug-002.json`, and so on. The

--- a/README_zh.md
+++ b/README_zh.md
@@ -203,7 +203,7 @@ uv run python main.py <proj_dir> --incremental intent.md --all-bugs
 uv run python main.py <proj_dir> --entry-func src::main --all-bugs
 ```
 
-该选项默认关闭。启用后，FM-Agent 会继续检查后续推理检查点，并为每个候选写出一个标准 mismatch 结果。完整和增量模式会分别验证每个候选；入口函数模式只报告候选及其数量，按设计不执行 Bug Validation。
+该选项默认关闭。启用后，每个推理检查点可以报告多个可独立说明的 violation，FM-Agent 会继续检查后续检查点，并为每个候选写出一个标准 mismatch 结果。完整和增量模式会分别验证每个候选；入口函数模式只报告候选及其数量，按设计不执行 Bug Validation。
 
 若主结果为 `path/to/function.json`，all-bugs 候选会写在同一目录下，依次命名为 `path/to/function.bug-001.json`、`bug-002.json` 等。主结果通过 `bug_count` 和 `reasoning_complete` 记录候选数量及推理是否完整。续跑时，完整的主结果就是 reasoning 阶段的检查点，只补跑尚未产生终态结果的候选验证；若 reasoning 中途停止，则只清理并重跑该函数的中间候选和验证，不影响其他已完成函数。
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -9,6 +9,7 @@ Usage:
 Reads:
     <workdir>/trace/events.jsonl          (FM-Agent native events)
     <workdir>/trace/opencode/*.jsonl      (lucentia opencode-trace records)
+    <workdir>/logic_verification_results/ (all-bugs validation targets)
     <workdir>/bug_validation/*.result.json (bug validation verdicts)
 
 Standalone — run in a second terminal while main.py is going.
@@ -38,6 +39,10 @@ from rich.table import Table
 from rich.text import Text
 from rich.progress_bar import ProgressBar
 from rich.align import Align
+from src.verification import (
+    _expected_all_bugs_validation_targets,
+    _validation_status,
+)
 
 
 STAGES = ["init", "generate_phases_json", "generate_domain_context", "spec_generation", "verification", "bug_validation"]
@@ -188,6 +193,21 @@ def _locate_workdir(proj_dir):
     return p / "fm_agent"
 
 
+def _has_all_bugs_results(results_dir):
+    """Return whether current reasoning artifacts use all-bugs mode."""
+    if not results_dir.is_dir():
+        return False
+    for path in results_dir.rglob("*.json"):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                result = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(result, dict) and result.get("all_bugs") is True:
+            return True
+    return False
+
+
 class State:
     """Aggregated trace state. Mutated by tail_* methods on each refresh."""
 
@@ -227,7 +247,7 @@ class State:
         # Bug validation
         self.bugs_confirmed = 0
         self.bugs_not_confirmed = 0
-        self.bugs_pending = 0     # opencode call done but no result.json yet
+        self.bugs_pending = 0     # current target/call without a terminal result
 
     # ---------- events.jsonl tail ----------
     def tail_events(self):
@@ -472,6 +492,25 @@ class State:
     def scan_bugs(self):
         self.bugs_confirmed = 0
         self.bugs_not_confirmed = 0
+        self.bugs_pending = 0
+
+        results_dir = self.workdir / "logic_verification_results"
+        all_bugs_targets = _expected_all_bugs_validation_targets(os.fspath(self.workdir))
+        if all_bugs_targets or _has_all_bugs_results(results_dir):
+            for target_path in all_bugs_targets:
+                target_rel = os.path.relpath(target_path, results_dir)
+                status = _validation_status(
+                    target_rel,
+                    os.fspath(self.workdir),
+                )
+                if status == "confirmed":
+                    self.bugs_confirmed += 1
+                elif status in ("not_confirmed", "error"):
+                    self.bugs_not_confirmed += 1
+                else:
+                    self.bugs_pending += 1
+            return
+
         if not self.bug_dir.exists():
             return
         for path in self.bug_dir.glob("*.result.json"):

--- a/dashboard.py
+++ b/dashboard.py
@@ -19,6 +19,7 @@ import argparse
 import glob
 import json
 import os
+import re
 import sys
 import time
 from collections import deque, defaultdict
@@ -39,10 +40,8 @@ from rich.table import Table
 from rich.text import Text
 from rich.progress_bar import ProgressBar
 from rich.align import Align
-from src.verification import (
-    _expected_all_bugs_validation_targets,
-    _validation_status,
-)
+from src.file_utils import _all_bugs_candidate_paths
+from src.verification import _validation_status
 
 
 STAGES = ["init", "generate_phases_json", "generate_domain_context", "spec_generation", "verification", "bug_validation"]
@@ -193,19 +192,27 @@ def _locate_workdir(proj_dir):
     return p / "fm_agent"
 
 
-def _has_all_bugs_results(results_dir):
-    """Return whether current reasoning artifacts use all-bugs mode."""
+def _discover_all_bugs_targets(results_dir):
+    """Return all-bugs mode and current targets from reasoning artifacts."""
     if not results_dir.is_dir():
-        return False
-    for path in results_dir.rglob("*.json"):
+        return False, []
+
+    all_bugs = False
+    targets = []
+    for path in sorted(results_dir.rglob("*.json")):
+        if re.search(r"\.bug-\d{3}\.json$", path.name):
+            continue
         try:
             with open(path, "r", encoding="utf-8") as f:
                 result = json.load(f)
         except (OSError, json.JSONDecodeError):
             continue
         if isinstance(result, dict) and result.get("all_bugs") is True:
-            return True
-    return False
+            all_bugs = True
+            candidates = _all_bugs_candidate_paths(os.fspath(path), result)
+            if candidates:
+                targets.extend(candidates)
+    return all_bugs, sorted(targets)
 
 
 class State:
@@ -495,8 +502,8 @@ class State:
         self.bugs_pending = 0
 
         results_dir = self.workdir / "logic_verification_results"
-        all_bugs_targets = _expected_all_bugs_validation_targets(os.fspath(self.workdir))
-        if all_bugs_targets or _has_all_bugs_results(results_dir):
+        all_bugs, all_bugs_targets = _discover_all_bugs_targets(results_dir)
+        if all_bugs:
             for target_path in all_bugs_targets:
                 target_rel = os.path.relpath(target_path, results_dir)
                 status = _validation_status(

--- a/main.py
+++ b/main.py
@@ -320,8 +320,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--all-bugs",
         action="store_true",
-        help="continue reasoning after mismatches and report every candidate; "
-        "full and incremental modes validate each candidate.",
+        help="allow each checkpoint to report multiple candidates and continue "
+             "reasoning after mismatches; full and incremental modes validate "
+             "each candidate.",
     )
     parser.add_argument(
         "--only-spec",

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -94,6 +94,83 @@ def _parse_spec_check_json(response):
     return False, None, None, data
 
 
+def _parse_all_bugs_spec_check_json(response):
+    """Parse the multi-violation response used by all-bugs checkpoints."""
+    try:
+        data = _load_spec_check_json(response)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"all-bugs spec-check response is not valid JSON: {exc}") from exc
+
+    required = ("verdict", "violations")
+    missing = [field for field in required if field not in data]
+    if missing:
+        raise ValueError(
+            "all-bugs spec-check JSON missing required field(s): "
+            + ", ".join(missing)
+        )
+
+    verdict = data.get("verdict")
+    if isinstance(verdict, str):
+        verdict = verdict.upper()
+    if verdict not in ("MATCH", "MISMATCH"):
+        raise ValueError(
+            "all-bugs spec-check JSON verdict must be MATCH or MISMATCH"
+        )
+
+    violations = data.get("violations")
+    if not isinstance(violations, list):
+        raise ValueError("all-bugs spec-check JSON violations must be an array")
+    if verdict == "MATCH" and violations:
+        raise ValueError(
+            "all-bugs spec-check MATCH JSON must contain an empty violations array"
+        )
+    if verdict == "MISMATCH" and not violations:
+        raise ValueError(
+            "all-bugs spec-check MISMATCH JSON requires at least one violation"
+        )
+
+    normalized = []
+    required_violation_fields = (
+        "counterexample",
+        "offending_statements",
+        "reason",
+    )
+    for index, violation in enumerate(violations, start=1):
+        if not isinstance(violation, dict):
+            raise ValueError(
+                f"all-bugs violation {index} must be a JSON object"
+            )
+        missing = [
+            field
+            for field in required_violation_fields
+            if field not in violation
+        ]
+        if missing:
+            raise ValueError(
+                f"all-bugs violation {index} missing required field(s): "
+                + ", ".join(missing)
+            )
+        invalid = [
+            field
+            for field in required_violation_fields
+            if not isinstance(violation.get(field), str)
+            or not violation[field].strip()
+        ]
+        if invalid:
+            raise ValueError(
+                f"all-bugs violation {index} requires non-empty string field(s): "
+                + ", ".join(invalid)
+            )
+        normalized.append({
+            field: violation[field].strip()
+            for field in required_violation_fields
+        })
+
+    data["verdict"] = verdict
+    data["violations"] = normalized
+    return verdict == "MISMATCH", normalized, data
+
+
 def _parse_post_condition_json(data):
     """Validate the structured response used to generate one block's post-condition."""
     if not isinstance(data, dict):
@@ -257,7 +334,7 @@ _LANGUAGE_EXPERTISE = {
 
 
 def _check_post_implies_spec(block, post_condition, spec_post_condition, knowledge, language,
-                             trace_dir=None, trace_meta=None):
+                             trace_dir=None, trace_meta=None, all_bugs=False):
     info_str = f"\nAdditional context:\n{knowledge}" if knowledge else ""
     lang_expertise = _LANGUAGE_EXPERTISE.get(language.lower(), f"You are an expert in logic, formal verification, and {language} programming. ")
     messages = [
@@ -273,12 +350,26 @@ def _check_post_implies_spec(block, post_condition, spec_post_condition, knowled
             "  3. The code produces a wrong output value for a valid input.\n"
             "For each potential violation, construct a specific input, trace what the code does (A), and check if the specification (B) is satisfied.\n"
             "Return only a valid JSON object. Do not include markdown, tags, or prose. "
-            "Use exactly this schema: "
-            "{\"verdict\": \"MATCH|MISMATCH\", \"counterexample\": string|null, "
-            "\"offending_statements\": string|null, \"reason\": string}. "
-            "For MISMATCH, counterexample, offending_statements, and reason must be non-empty strings; "
-            "offending_statements must preserve any 'Line N:' prefixes from the code block. "
-            "For MATCH, counterexample and offending_statements must be null or empty, and reason may be empty."
+            + (
+                "Use exactly this schema: "
+                "{\"verdict\": \"MATCH|MISMATCH\", \"violations\": "
+                "[{\"counterexample\": string, \"offending_statements\": string, "
+                "\"reason\": string}]}. For MISMATCH, return every independently "
+                "explainable violation found at this checkpoint, with all three fields "
+                "as non-empty strings. If exactly one violation exists, return a "
+                "one-item array. Do not duplicate the same underlying violation merely "
+                "because multiple concrete inputs trigger it. offending_statements must "
+                "preserve any 'Line N:' prefixes from the code block. For MATCH, return "
+                "an empty violations array."
+                if all_bugs
+                else
+                "Use exactly this schema: "
+                "{\"verdict\": \"MATCH|MISMATCH\", \"counterexample\": string|null, "
+                "\"offending_statements\": string|null, \"reason\": string}. "
+                "For MISMATCH, counterexample, offending_statements, and reason must be non-empty strings; "
+                "offending_statements must preserve any 'Line N:' prefixes from the code block. "
+                "For MATCH, counterexample and offending_statements must be null or empty, and reason may be empty."
+            )
         )},
         {"role": "user", "content": (
             f"Programming language: {language}\n\n"
@@ -288,7 +379,14 @@ def _check_post_implies_spec(block, post_condition, spec_post_condition, knowled
             f"{info_str}\n"
             "Is there a concrete valid input where the code's behavior violates the specification? "
             "Enumerate all cases required by condition B and check if condition A covers each one. "
-            "Provide a specific counterexample if any case is missing. Return only the JSON object."
+            + (
+                "Return every independently explainable mismatch in the violations array. "
+                "If no mismatch exists, return MATCH with an empty violations array. "
+                "Return only the JSON object."
+                if all_bugs
+                else
+                "Provide a specific counterexample if any case is missing. Return only the JSON object."
+            )
         )}
     ]
     trace_meta = trace_meta or {}
@@ -321,7 +419,15 @@ def _check_post_implies_spec(block, post_condition, spec_post_condition, knowled
         parsed_result = None
         parse_error = None
         try:
-            has_violation, stmts, reason, parsed_result = _parse_spec_check_json(response)
+            if all_bugs:
+                (
+                    has_violation,
+                    checkpoint_violations,
+                    parsed_result,
+                ) = _parse_all_bugs_spec_check_json(response)
+                stmts = reason = None
+            else:
+                has_violation, stmts, reason, parsed_result = _parse_spec_check_json(response)
             status = "mismatch" if has_violation else "success"
         except ValueError as exc:
             has_violation = None
@@ -348,6 +454,8 @@ def _check_post_implies_spec(block, post_condition, spec_post_condition, knowled
         }
         record_llm_exchange(trace_dir, event_id, event, messages, response)
         if has_violation is not None:
+            if all_bugs:
+                return checkpoint_violations
             if has_violation:
                 stmts = stmts or "(unable to extract)"
                 reason = reason or "(unable to extract)"
@@ -359,13 +467,23 @@ def _check_post_implies_spec(block, post_condition, spec_post_condition, knowled
             {
                 "role": "user",
                 "content": (
-                    "Return only valid JSON with schema: "
-                    "{\"verdict\": \"MATCH|MISMATCH\", "
-                    "\"counterexample\": string|null, "
-                    "\"offending_statements\": string|null, "
-                    "\"reason\": string}. "
-                    "For MISMATCH, all evidence fields must be non-empty strings. "
-                    "For MATCH, counterexample and offending_statements must be null or empty, and reason may be empty."
+                    (
+                        "Return only valid JSON with schema: "
+                        "{\"verdict\": \"MATCH|MISMATCH\", \"violations\": "
+                        "[{\"counterexample\": string, \"offending_statements\": string, "
+                        "\"reason\": string}]}. For MISMATCH, violations must contain "
+                        "at least one item and every field must be a non-empty string. "
+                        "For MATCH, violations must be an empty array."
+                        if all_bugs
+                        else
+                        "Return only valid JSON with schema: "
+                        "{\"verdict\": \"MATCH|MISMATCH\", "
+                        "\"counterexample\": string|null, "
+                        "\"offending_statements\": string|null, "
+                        "\"reason\": string}. "
+                        "For MISMATCH, all evidence fields must be non-empty strings. "
+                        "For MATCH, counterexample and offending_statements must be null or empty, and reason may be empty."
+                    )
                 ),
             }
         ]

--- a/src/reasoner.py
+++ b/src/reasoner.py
@@ -260,7 +260,7 @@ def reasoner(func, spec, info, language, trace_context=None, all_bugs=False):
         if _has_terminating_statement(block, language) or is_last_block:
             if all_bugs:
                 try:
-                    passed, stmts, post_cond, reason = _check_post_implies_spec(
+                    checkpoint_violations = _check_post_implies_spec(
                         block,
                         post_condition,
                         spec_post_condition,
@@ -268,6 +268,7 @@ def reasoner(func, spec, info, language, trace_context=None, all_bugs=False):
                         language,
                         trace_dir=trace_dir,
                         trace_meta=trace_meta,
+                        all_bugs=True,
                     )
                 except Exception as exc:
                     return {
@@ -279,6 +280,11 @@ def reasoner(func, spec, info, language, trace_context=None, all_bugs=False):
                         ),
                         "reasoning_complete": False,
                     }
+                violations.extend({
+                    "statements": violation["offending_statements"],
+                    "post_condition": post_condition,
+                    "reason": violation["reason"],
+                } for violation in checkpoint_violations)
             else:
                 passed, stmts, post_cond, reason = _check_post_implies_spec(
                     block,
@@ -289,14 +295,7 @@ def reasoner(func, spec, info, language, trace_context=None, all_bugs=False):
                     trace_dir=trace_dir,
                     trace_meta=trace_meta,
                 )
-            if not passed:
-                if all_bugs:
-                    violations.append({
-                        "statements": stmts,
-                        "post_condition": post_cond,
-                        "reason": reason,
-                    })
-                else:
+                if not passed:
                     return (
                         f"Verification FAILED.\n"
                         f"Statements triggering the violation:\n{stmts}\n\n"


### PR DESCRIPTION

Extend `--all-bugs` so that a single reasoning checkpoint can report multiple independently explainable violations, instead of returning at most one candidate per checkpoint.

## Changes

- Add an `--all-bugs`-specific structured response schema using a `violations` array.
- Validate and normalize every returned violation.
- Collect all violations reported by each reasoning checkpoint.
- Preserve the existing single-verdict behavior when `--all-bugs` is disabled.
- Update the CLI help text and English/Chinese documentation.


