### PR TITLE
fix(spec): preserve source extension in sidecar namesfix

### DIFF
--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -334,7 +334,10 @@ def build_prompt(
     lines.append("")
     lines.append(
         "For each function file `<function-file>`, "
-        "write TWO JSON files in the SAME directory:"
+        "write TWO JSON files in the SAME directory. "
+        "`<function-file>` includes its original extension "
+        "(for example, `foo.py` must produce `foo.py.spec.json` "
+        "and `foo.py.info.json`):"
     )
     lines.append("")
     lines.append("`<function-file>.spec.json`:")


### PR DESCRIPTION
## Summary

Clarify the spec-generation prompt so sidecar filenames preserve the source file extension.

For example, `foo.py` must produce:

- `foo.py.spec.json`
- `foo.py.info.json`

This prevents agents from incorrectly generating `foo.spec.json` and `foo.info.json`.

