### PR TITLE
Retry errored reasoning and bug validation results on resume

### DIFF
--- a/src/cli_backend.py
+++ b/src/cli_backend.py
@@ -169,7 +169,7 @@ def run_agent_for_messages(model, messages):
         input=command.stdin,
         cwd=cwd,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         text=True,
         encoding="utf-8",
         errors="replace",
@@ -177,7 +177,9 @@ def run_agent_for_messages(model, messages):
         check=False,
     )
     if result.returncode != 0:
-        output = (result.stdout or "")[-4000:]
+        output = "\n".join(
+            part for part in (result.stdout, result.stderr) if part
+        ).strip()[-4000:]
         raise RuntimeError(
             f"{command.backend} exited with code {result.returncode}: {output}"
         )

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -313,14 +313,22 @@ def _terminal_validation_record_is_valid(validation, expected_bug_id):
     )
 
 
-def _terminal_validation_is_valid(validation_path, expected_bug_id):
+def _terminal_validation_is_valid(
+    validation_path, expected_bug_id, retry_errors=False
+):
     """Return whether a candidate's validation artifact is complete and terminal."""
     try:
         with open(validation_path, "r", encoding="utf-8") as f:
             validation = json.load(f)
     except (OSError, json.JSONDecodeError):
         return False
-    return _terminal_validation_record_is_valid(validation, expected_bug_id)
+    return (
+        _terminal_validation_record_is_valid(validation, expected_bug_id)
+        and not (
+            retry_errors
+            and validation.get("confirmation_status") == "error"
+        )
+    )
 
 
 def _get_incomplete_verification_files(
@@ -342,6 +350,10 @@ def _get_incomplete_verification_files(
             incomplete.append(rel)
             continue
 
+        if result.get("verdict") == "ERROR":
+            incomplete.append(rel)
+            continue
+
         if all_bugs:
             candidates = _all_bugs_candidate_paths(result_path, result)
             if candidates is None:
@@ -356,7 +368,9 @@ def _get_incomplete_verification_files(
                 validation_path = os.path.join(
                     work_dir, "bug_validation", f"{bug_id}.result.json"
                 )
-                if not _terminal_validation_is_valid(validation_path, bug_id):
+                if not _terminal_validation_is_valid(
+                    validation_path, bug_id, retry_errors=True
+                ):
                     missing_validation = True
                     break
             if missing_validation:
@@ -370,16 +384,20 @@ def _get_incomplete_verification_files(
 
         bug_id = os.path.splitext(rel)[0].replace(os.sep, "--").replace("/", "--")
         validation_path = os.path.join(work_dir, "bug_validation", f"{bug_id}.result.json")
-        if not _json_file_is_valid(validation_path):
+        if not _json_file_is_valid(validation_path, retry_errors=True):
             incomplete.append(rel)
     return incomplete
 
 
-def _json_file_is_valid(path):
+def _json_file_is_valid(path, retry_errors=False):
     try:
         with open(path, "r") as f:
-            json.load(f)
-        return True
+            data = json.load(f)
+        return not (
+            retry_errors
+            and isinstance(data, dict)
+            and data.get("confirmation_status") == "error"
+        )
     except (OSError, json.JSONDecodeError):
         return False
 

--- a/src/verification.py
+++ b/src/verification.py
@@ -477,13 +477,16 @@ def _verify_single_file(file_path, input_dir, output_dir, language, work_dir=Non
                 if all_bugs
                 else None
             )
-            reusable = not all_bugs or (
-                candidates is not None
-                and _rebind_all_bugs_function_paths(
-                    output_path,
-                    existing,
-                    candidates,
-                    artifact_function,
+            reusable = verdict != "ERROR" and (
+                not all_bugs
+                or (
+                    candidates is not None
+                    and _rebind_all_bugs_function_paths(
+                        output_path,
+                        existing,
+                        candidates,
+                        artifact_function,
+                    )
                 )
             )
             if reusable:
@@ -721,10 +724,23 @@ def _validate_single_bug(
     # finishes this validation stage. Candidate identity is fixed by the
     # completed reasoning artifacts, so no content hash is needed here.
     if is_candidate and resume and os.path.exists(result_path):
-        if _terminal_validation_is_valid(result_path, bug_id):
+        if _terminal_validation_is_valid(
+            result_path, bug_id, retry_errors=True
+        ):
             logging.info(f"Bug validation already done, skipping: {bug_id}")
             return
         _clear_bug_validation_artifacts(work_dir, bug_id)
+
+    if not is_candidate and resume and os.path.exists(result_path):
+        try:
+            with open(result_path) as result_file:
+                existing_validation = json.load(result_file)
+            if existing_validation.get("confirmation_status") != "error":
+                logging.info(f"Bug validation already done, skipping: {bug_id}")
+                return
+            _clear_bug_validation_artifacts(work_dir, bug_id)
+        except (json.JSONDecodeError, OSError):
+            pass  # corrupted result — re-validate
 
     # Read either the user-selected validator or the built-in default.
     base_md_path = (
@@ -782,16 +798,6 @@ def _validate_single_bug(
         cwd=proj_dir,
         files=[prompt_path],
     )
-    # Preserve the legacy resume path exactly: a readable result is reusable
-    # without candidate-specific schema or content checks.
-    if not is_candidate and resume and os.path.exists(result_path):
-        try:
-            with open(result_path) as _f:
-                json.load(_f)
-            logging.info(f"Bug validation already done, skipping: {bug_id}")
-            return
-        except (json.JSONDecodeError, OSError):
-            pass  # corrupted result — re-validate
     try:
         max_attempts = config.BUG_VALIDATION_MAX_RETRIES
         for attempt in range(1, max_attempts + 1):


### PR DESCRIPTION
## Summary

- Treat reasoning results with `verdict: ERROR` as incomplete during resume.
- Retry bug validations with `confirmation_status: error`.
- Continue reusing successful `MATCH`, `MISMATCH`, `confirmed`, and
  `not_confirmed` results.
- Reuse the existing `--resume` workflow without introducing new CLI options.

## Motivation

Reasoning and validation may fail because of transient external conditions,
including network failures, rate limits, excessive concurrency, or unavailable
model credits. Previously, the presence of a readable result file caused these
failed results to be skipped permanently during resume.

## Validation

- Python compilation passed.
- `git diff --check` passed.
- Verified that `ERROR/error` results are selected for retry.
- Verified that completed results remain reusable.