### PR TITLE
refactor(spec): generate batch prompts in process

### DIFF
--- a/main.py
+++ b/main.py
@@ -311,15 +311,6 @@ def run_pipeline(
         os.path.join(script_dir, "md", "system_prompt.md"),
         os.path.join(spec_prompts_dir, "system_prompt.md"),
     )
-    shutil.copy2(
-        os.path.join(script_dir, "src", "generate_batch_prompts.py"),
-        os.path.join(spec_prompts_dir, "generate_batch_prompts.py"),
-    )
-    # generate_batch_prompts.py imports is_file_ready from this module at runtime.
-    shutil.copy2(
-        os.path.join(script_dir, "src", "file_utils.py"),
-        os.path.join(spec_prompts_dir, "file_utils.py"),
-    )
 
     phases_path = os.path.join(work_dir, "phases.json")
     with open(phases_path, "r") as f:

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -6,14 +6,12 @@ import re
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
-# file_utils.py sits beside this script after being copied into fm_agent/spec_prompts/.
 try:
     # When imported as part of the src package (e.g. incremental_reasoner).
     from .file_utils import is_file_ready
     from .domain_knowledge import list_staged_domain_knowledge_relpaths
 except ImportError:
-    # When run standalone after being copied into fm_agent/spec_prompts/,
-    # where file_utils.py sits beside this script.
+    # When run directly from the source tree, file_utils.py sits beside this script.
     from file_utils import is_file_ready
 
     def list_staged_domain_knowledge_relpaths(work_dir, prefix="fm_agent"):
@@ -371,13 +369,21 @@ def build_prompt(
     return "\n".join(lines).rstrip() + "\n"
 
 
-def main() -> int:
-    args = parse_args()
-    if args.batch_size <= 0:
+def generate_batch_prompts(
+    work_dir: Path,
+    phase: int,
+    layers_spec: str,
+    *,
+    batch_size: int = 2,
+    output_dir: Optional[Path] = None,
+    resume: bool = False,
+    dry_run: bool = False,
+) -> dict:
+    """Build, persist, and return the batch manifest for a layer range."""
+    if batch_size <= 0:
         raise ValueError("--batch-size must be > 0")
 
-    # work_dir is the fm_agent/ directory (parent of spec_prompts/ where this script lives)
-    work_dir = Path(__file__).resolve().parent.parent
+    work_dir = Path(work_dir)
     # fm_agent_prefix is the relative path from the project root to work_dir
     repo_root = work_dir.parent
     fm_agent_prefix = str(work_dir.relative_to(repo_root)) + "/"
@@ -388,16 +394,16 @@ def main() -> int:
     exts = phases_json.get("file_extensions", [])
     ext_to_lang = {ext.lower().lstrip("."): lang for ext, lang in zip(exts, languages)}
 
-    topdown_path = work_dir / "spec_prompts" / f"phase_{args.phase:02d}_topdown_layers.json"
+    topdown_path = work_dir / "spec_prompts" / f"phase_{phase:02d}_topdown_layers.json"
     topdown = read_json(topdown_path)
     layers = topdown.get("layers", [])
     total_layers = len(layers)
-    start_layer, end_layer = parse_layers_spec(args.layers)
+    start_layer, end_layer = parse_layers_spec(layers_spec)
     if start_layer < 0 or end_layer >= total_layers:
-        raise ValueError(f"layer range {args.layers} out of bounds [0, {total_layers - 1}]")
+        raise ValueError(f"layer range {layers_spec} out of bounds [0, {total_layers - 1}]")
 
-    output_dir = Path(args.output_dir) if args.output_dir else (
-        work_dir / "spec_prompts" / f"batch_prompts_{project}_phase{args.phase:02d}"
+    output_dir = Path(output_dir) if output_dir is not None else (
+        work_dir / "spec_prompts" / f"batch_prompts_{project}_phase{phase:02d}"
     )
 
     func_to_layer: Dict[str, int] = {}
@@ -424,7 +430,7 @@ def main() -> int:
         layer_functions = layer.get("functions", [])
         is_cycle = bool(layer.get("cycle_resolution", False))
         tag = "cycle" if is_cycle else "extracted"
-        chunks = chunked(layer_functions, args.batch_size)
+        chunks = chunked(layer_functions, batch_size)
         total_functions += len(layer_functions)
 
         for local_idx, fn_batch in enumerate(chunks):
@@ -432,7 +438,7 @@ def main() -> int:
             # On resume, don't ask the LLM to re-spec functions that are already
             # done — but the manifest below still records the full batch.
             prompt_funcs = fn_batch
-            if args.resume:
+            if resume:
                 prompt_funcs = [fn for fn in fn_batch if not is_file_ready(work_dir / fn["file"])]
                 skipped_functions += len(fn_batch) - len(prompt_funcs)
             out_path = output_dir / filename
@@ -443,7 +449,7 @@ def main() -> int:
             # unspecced functions (see _get_pending_batches).
             if prompt_funcs:
                 content = build_prompt(
-                    args.phase,
+                    phase,
                     layer_idx,
                     is_cycle,
                     prompt_funcs,
@@ -472,25 +478,25 @@ def main() -> int:
             batch_index += 1
 
     manifest = {
-        "phase": args.phase,
-        "layers": args.layers,
+        "phase": phase,
+        "layers": layers_spec,
         "total_functions": total_functions,
         "total_batches": len(manifest_batches),
         "batches": manifest_batches,
     }
 
-    if args.dry_run:
+    if dry_run:
         print(
-            f"[dry-run] phase={args.phase} layers={args.layers} "
+            f"[dry-run] phase={phase} layers={layers_spec} "
             f"functions={total_functions} batches={len(manifest_batches)}"
-            + (f" skipped={skipped_functions} (already specced)" if args.resume else "")
+            + (f" skipped={skipped_functions} (already specced)" if resume else "")
         )
         for batch in manifest_batches:
             print(
                 f"- {batch['file']}: layer={batch['layer']} "
                 f"count={batch['num_functions']} cycle={batch['is_cycle']}"
             )
-        return 0
+        return manifest
 
     output_dir.mkdir(parents=True, exist_ok=True)
     current_batch_paths = {out_path for out_path, _ in write_targets}
@@ -504,9 +510,24 @@ def main() -> int:
     (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
 
     print(
-        f"Generated {len(manifest_batches)} batch prompt(s) for phase {args.phase} "
-        f"layers {args.layers} in {output_dir}"
-        + (f" (skipped {skipped_functions} already-specced function(s))" if args.resume else "")
+        f"Generated {len(manifest_batches)} batch prompt(s) for phase {phase} "
+        f"layers {layers_spec} in {output_dir}"
+        + (f" (skipped {skipped_functions} already-specced function(s))" if resume else "")
+    )
+    return manifest
+
+
+def main() -> int:
+    """Run the source-tree command-line adapter."""
+    args = parse_args()
+    generate_batch_prompts(
+        work_dir=Path.cwd() / "fm_agent",
+        phase=args.phase,
+        layers_spec=args.layers,
+        batch_size=args.batch_size,
+        output_dir=Path(args.output_dir) if args.output_dir else None,
+        resume=args.resume,
+        dry_run=args.dry_run,
     )
     return 0
 

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -9,10 +9,12 @@ import shutil
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 from config import MAX_WORKERS, OPENCODE_MAX_RETRIES, OPENCODE_SPEC_MODEL
 from src.domain_knowledge import list_staged_domain_knowledge_relpaths
 from src.file_utils import _get_incomplete_verification_files, _get_phase_files, is_file_ready
+from src.generate_batch_prompts import generate_batch_prompts
 from src.generate_topdown_layers import generate_topdown_layers
 from src.llm_client import build_llm_cli_command
 from src.opencode_trace import function_id_from_extracted_path, run_opencode_traced
@@ -153,16 +155,13 @@ def run_spec_generation_and_verification(
 
             # Generate batch prompts for this layer. On resume, skip functions
             # that were already specced in a previous run.
-            batch_cmd = ["python3", "fm_agent/spec_prompts/generate_batch_prompts.py",
-                         "--phase", str(phase_num), "--layers", str(layer_idx)]
-            if resume:
-                batch_cmd.append("--resume")
-            subprocess.run(batch_cmd, cwd=proj_dir, check=True)
-
-            # Read manifest
-            manifest_path = os.path.join(batch_dir, "manifest.json")
-            with open(manifest_path, "r") as f:
-                manifest = json.load(f)
+            manifest = generate_batch_prompts(
+                work_dir=Path(work_dir),
+                phase=phase_num,
+                layers_spec=str(layer_idx),
+                output_dir=Path(batch_dir),
+                resume=resume,
+            )
             all_batches = manifest.get("batches", [])
 
             if not all_batches:


### PR DESCRIPTION
## Summary

- expose batch prompt generation as an in-process function
- replace the Stage 6 subprocess invocation with a direct function call
- stop copying the prompt generator and `file_utils.py` into project workspaces
- preserve existing prompt, manifest, resume, and CLI behavior

## Validation

- compared generated prompts and manifests against the previous subprocess flow
- verified fresh, resume, cycle, dry-run, and failure scenarios
- ran Python compilation and import checks