### PR TITLE
fix(codegraph): keep FM-Agent's work directory out of the project index

### DIFF
--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -9,6 +9,7 @@ REGISTRY in src/languages/registry.py. No other files need to change.
 """
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -474,6 +475,65 @@ def _codegraph_cmd() -> str:
     return local if os.access(local, os.X_OK) else "codegraph"
 
 
+_CODEGRAPH_CONFIG_FILE = "codegraph.json"
+_WORK_DIR_NAME = "fm_agent"
+
+
+def _ensure_workdir_excluded(proj_dir: str) -> None:
+    """Declare FM-Agent's own work directory as excluded in ``codegraph.json``.
+
+    FM-Agent writes its artifacts to ``<proj>/fm_agent/``, inside the tree
+    codegraph indexes and outside its default skip list, so every extracted
+    function lands in the index a second time next to the source it came from.
+    Ordering the run around it does not help: ``codegraph init`` picks up what a
+    previous run left behind, and the MCP daemon's file watcher syncs artifacts
+    in as they are written. ``codegraph.json`` is codegraph's own exclude
+    mechanism and both paths honour it.
+
+    Only the exclude entry is added; an existing config — or anything unexpected
+    in it — is left as it is, since the project's own config outranks this.
+    """
+    config_path = os.path.join(proj_dir, _CODEGRAPH_CONFIG_FILE)
+    config = {}
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        pass
+    except (OSError, ValueError) as exc:
+        logging.warning("Leaving %s untouched (unreadable): %s", config_path, exc)
+        return
+
+    if not isinstance(config, dict):
+        logging.warning("Leaving %s untouched (not a JSON object).", config_path)
+        return
+
+    pattern = f"{_WORK_DIR_NAME}/"
+    excludes = config.get("exclude", [])
+    if not isinstance(excludes, list):
+        # codegraph ignores a non-array "exclude" too; rewriting it would discard
+        # whatever the project meant to put there.
+        logging.warning('Leaving %s untouched ("exclude" is not an array).', config_path)
+        return
+    if pattern in excludes:
+        return
+
+    config["exclude"] = excludes + [pattern]
+    try:
+        with open(config_path, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2)
+            f.write("\n")
+    except OSError as exc:
+        logging.warning("Could not write %s: %s", config_path, exc)
+        return
+    # Writing into the project under analysis is worth saying out loud — this is
+    # the one file FM-Agent adds outside its own work directory.
+    print(
+        f'[Pipeline] Excluded "{pattern}" in {_CODEGRAPH_CONFIG_FILE} '
+        "so codegraph does not index FM-Agent's own artifacts."
+    )
+
+
 def _warn_on_codegraph_version_mismatch(cmd: str) -> None:
     """Warn (never fail) when the codegraph about to run is not the version pinned
     in ``fm-agent.toml``'s ``[codegraph].version`` — e.g. a stale build shadowing
@@ -528,6 +588,9 @@ def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
     else:
         print("[Pipeline] Building codegraph index...")
     cmd = _codegraph_cmd()
+    if shutil.which(cmd) is None:
+        return  # codegraph not installed; do not leave a stray config behind
+    _ensure_workdir_excluded(proj_dir)
     _warn_on_codegraph_version_mismatch(cmd)
     try:
         result = subprocess.run(


### PR DESCRIPTION
Fixes #195.

FM-Agent writes its artifacts to `<proj>/fm_agent/`, inside the tree codegraph
indexes. Every extracted function ends up in the index a second time next to the
source it was copied from, and the scripts staged under `spec_prompts/` are
indexed as if they were project code — on a 4-function Python project that is 43
of 47 function nodes.

Ordering the run around it does not help, because artifacts get in two ways:
`codegraph init` picks up what a previous run left behind, and the codegraph MCP
daemon's file watcher syncs them in as they are written, seconds after the index
was built. `codegraph.json` is codegraph's own project-scoped exclude and both
paths honour it — its loader runs per index, per sync and per watch event.

## What this does

Before running `codegraph init`, append `"fm_agent/"` to `exclude` in the
project's `codegraph.json`, creating the file when absent.

- **Idempotent** — the entry is added once; later runs read the file and return.
- **Non-destructive** — other keys and existing `exclude` entries are kept. An
  unreadable file, non-object JSON, or a non-array `exclude` is left untouched
  with a warning rather than rewritten, matching how codegraph itself treats a
  config it cannot parse.
- **Announced** — the one run that writes it prints a line saying what changed
  and why; this is the only file FM-Agent adds outside its own work directory.
- **Skipped when codegraph is absent**, so no stray config is left behind.

The call sits in `try_codegraph_init`, the single point all five call sites go
through, so full, `--resume`, `--incremental`, `--entry-func` and `--isolate`
runs are all covered.

## Verification

Two full pipeline runs on a fresh Python fixture, sampling the index throughout:

| | index during the run |
|---|---|
| before | `nodes=6` → `nodes=77` two seconds after Stage 3 |
| after | `nodes=6` for the whole run |

Layering, extraction, specs and verification are unchanged (4 functions, 4
layers, `main → run_all → Engine::start → Engine::warmup`).

Also checked directly: an existing config keeps its other keys and gains only the
new entry; a config with comments or a non-array `exclude` is left byte-for-byte
untouched with a warning; a second call writes nothing and prints nothing.

## Not in scope

`try_codegraph_init` removes `.codegraph/` before rebuilding, without restoring
it if the rebuild does not happen. That is a separate defect with its own fix
(`codegraph index` instead of `rmtree` + `init`) and will be filed on its own.
