### PR TITLE
fix(codegraph): rebuild the index with `codegraph index`

### DIFF
--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -245,9 +245,32 @@ class CodeGraphExtractor:
     def __init__(self, db_path: str):
         self._db = db_path
 
+    @staticmethod
+    def _is_readable_index(db_path: str) -> bool:
+        """True when ``db_path`` is a database this extractor can actually query.
+
+        Existing on disk is not enough. ``codegraph index`` discards the old
+        database before it starts, so an interrupted or failed rebuild leaves a
+        file that is empty or has no schema at all. Reading it raises
+        ``no such table: nodes`` from every query — whereas returning no extractor
+        means "no index", which callers already handle by falling back to the
+        regex extractor. Opened read-only so probing never creates a file.
+        """
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            try:
+                row = conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='nodes'"
+                ).fetchone()
+            finally:
+                conn.close()
+            return row is not None
+        except sqlite3.Error:
+            return False
+
     @classmethod
     def from_proj_dir(cls, proj_dir: str):
-        """Return an extractor if .codegraph/codegraph.db exists, else None.
+        """Return an extractor if a readable .codegraph/codegraph.db exists, else None.
 
         Checks both proj_dir itself and its parent directory, because
         generate_topdown_layers() receives work_dir (fm_agent/) as its
@@ -255,7 +278,7 @@ class CodeGraphExtractor:
         """
         for candidate in [proj_dir, os.path.dirname(os.path.abspath(proj_dir))]:
             db_path = os.path.join(candidate, ".codegraph", "codegraph.db")
-            if os.path.exists(db_path):
+            if os.path.exists(db_path) and cls._is_readable_index(db_path):
                 return cls(db_path)
         return None
 
@@ -543,6 +566,19 @@ def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
     if result.returncode == 0:
         print("[Pipeline] codegraph index built.")
     else:
+        # A failed `index` has already discarded the database it was rebuilding,
+        # leaving an empty or schema-less file behind. Drop it so the fallback
+        # this message promises is the one that happens — an index nobody can read
+        # is worse than no index, because the pipeline would consume it as if it
+        # were complete. Remove the files, not `.codegraph/` itself: that
+        # directory is a symlink into oh-my-openagent's store on any project
+        # opened in an editor session.
+        if action == "index":
+            for path in (db_path, f"{db_path}-wal", f"{db_path}-shm"):
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
         logging.warning(
             "codegraph %s failed (non-fatal, falling back to regex): %s",
             action,

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -12,7 +12,6 @@ import hashlib
 import logging
 import os
 import re
-import shutil
 import sqlite3
 import subprocess
 from collections import defaultdict
@@ -498,16 +497,14 @@ def _warn_on_codegraph_version_mismatch(cmd: str) -> None:
 
 
 def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
-    """Build the codegraph index for proj_dir with `codegraph init`.
+    """Build the codegraph index for proj_dir.
 
-    By default (``force=True``) any existing index is discarded and rebuilt, so
-    the index always reflects the current working tree rather than whatever code
-    was present when it was last built. This is the safe default: callers read
+    By default (``force=True``) an existing index is rebuilt from scratch, so the
+    index always reflects the current working tree rather than whatever code was
+    present when it was last built. This is the safe default: callers read
     function bodies and spans from the index, and a stale one (e.g. after an
     incremental run's tree changed or project sources were edited) would yield
-    boundaries for the wrong code. `codegraph init` on its
-    own no-ops when `.codegraph/` already exists, so a rebuild requires clearing
-    it first.
+    boundaries for the wrong code.
 
     Pass ``force=False`` to keep an existing index and only build when it is
     absent — an opt-in optimization for callers that know the tree is unchanged
@@ -521,17 +518,25 @@ def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
     if os.path.exists(db_path):
         if not force:
             return
-        # Existing index may reflect stale sources; remove it so `codegraph init`
-        # rebuilds against the current tree instead of skipping.
-        shutil.rmtree(codegraph_dir, ignore_errors=True)
+        # `codegraph index` is the full rebuild — "same result as a fresh init",
+        # but it discards codegraph.db itself instead of the directory holding it.
+        # Clearing `.codegraph/` here is what used to make `init` rebuild rather
+        # than no-op, and it silently stopped working once that directory became a
+        # symlink into oh-my-openagent's store: shutil.rmtree refuses to remove a
+        # symlink and ignore_errors=True swallowed the error, so the run reported a
+        # rebuild that never happened.
+        action = "index"
         print("[Pipeline] Rebuilding codegraph index for current working tree...")
     else:
+        # `index` rebuilds an initialized project and errors out otherwise, so the
+        # first build still goes through `init`.
+        action = "init"
         print("[Pipeline] Building codegraph index...")
     cmd = _codegraph_cmd()
     _warn_on_codegraph_version_mismatch(cmd)
     try:
         result = subprocess.run(
-            [cmd, "init"], cwd=proj_dir, capture_output=True, text=True
+            [cmd, action], cwd=proj_dir, capture_output=True, text=True
         )
     except FileNotFoundError:
         return  # codegraph not installed
@@ -539,6 +544,7 @@ def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
         print("[Pipeline] codegraph index built.")
     else:
         logging.warning(
-            "codegraph init failed (non-fatal, falling back to regex): %s",
+            "codegraph %s failed (non-fatal, falling back to regex): %s",
+            action,
             result.stderr[:300],
         )

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -247,24 +247,29 @@ class CodeGraphExtractor:
 
     @staticmethod
     def _is_readable_index(db_path: str) -> bool:
-        """True when ``db_path`` is a database this extractor can actually query.
+        """True when ``db_path`` holds an index that was built to completion.
 
-        Existing on disk is not enough. ``codegraph index`` discards the old
-        database before it starts, so an interrupted or failed rebuild leaves a
-        file that is empty or has no schema at all. Reading it raises
-        ``no such table: nodes`` from every query — whereas returning no extractor
-        means "no index", which callers already handle by falling back to the
-        regex extractor. Opened read-only so probing never creates a file.
+        Existing on disk is not enough: ``codegraph index`` discards the old
+        database before it starts, so a rebuild that fails or is killed leaves an
+        empty or half-written one behind, and reading that yields a truncated
+        graph presented as the whole thing. codegraph stamps its own verdict in
+        ``project_metadata.index_state`` for exactly this purpose, so that
+        decides. No marker means an index predating it — accept those when they
+        actually hold nodes.
         """
         try:
             conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
             try:
                 row = conn.execute(
-                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='nodes'"
+                    "SELECT value FROM project_metadata WHERE key = 'index_state'"
                 ).fetchone()
+                if row is not None:
+                    return row[0] == "complete"
+                return (
+                    conn.execute("SELECT 1 FROM nodes LIMIT 1").fetchone() is not None
+                )
             finally:
                 conn.close()
-            return row is not None
         except sqlite3.Error:
             return False
 
@@ -573,14 +578,25 @@ def try_codegraph_init(proj_dir: str, force: bool = True) -> None:
         # were complete. Remove the files, not `.codegraph/` itself: that
         # directory is a symlink into oh-my-openagent's store on any project
         # opened in an editor session.
+        outcome = "falling back to regex"
         if action == "index":
-            for path in (db_path, f"{db_path}-wal", f"{db_path}-shm"):
-                try:
-                    os.remove(path)
-                except OSError:
-                    pass
+            try:
+                os.remove(db_path)
+            except OSError as exc:
+                # The database survived, so it stays discoverable and the regex
+                # fallback is NOT what happens — say that rather than claiming it.
+                # Leave the sidecars too: dropping a live database's -wal corrupts
+                # it, and half-removed is worse than untouched.
+                outcome = f"existing index left in place, may be stale ({exc})"
+            else:
+                for path in (f"{db_path}-wal", f"{db_path}-shm"):
+                    try:
+                        os.remove(path)
+                    except OSError:
+                        pass
         logging.warning(
-            "codegraph %s failed (non-fatal, falling back to regex): %s",
+            "codegraph %s failed (non-fatal, %s): %s",
             action,
+            outcome,
             result.stderr[:300],
         )


### PR DESCRIPTION
Fixes #200.

Rebuild the index with `codegraph index` instead of clearing `.codegraph/` and
re-running `codegraph init`.

`index` discards `codegraph.db` rather than the directory holding it, so the
symlink oh-my-openagent puts there is irrelevant, and nothing is deleted before
the rebuild is under way. It refuses to run on an uninitialized project, so the
first build still goes through `init` — the two branches now each call the
command that matches their situation, and the warning names whichever one ran.

## Verification

Same setup as the issue: `.codegraph` a symlink, index holding a stale
`['beta']`, source changed to `def gamma()`. Calling `try_codegraph_init` now
leaves the index at `['gamma']`; before this change it stayed `['beta']`.

A project with no index at all still takes the `init` path and indexes normally.

## Note

Based on #199, which touches a different file. Rebasing onto main once that
merges is a no-op.
