### PR TITLE
Normalize call-graph edge representation across language backends

### DIFF
--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -315,9 +315,14 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None, extra_cal
     phase_langs = {_detect_lang_from_ext(fp) for fp, _ in phase_files if _detect_lang_from_ext(fp)}
     registry_edges_list, registry_langs = call_edges_all(proj_dir, phase_langs)
     # codegraph edges are [{"caller": fqn, "callee": fqn, "kind": k}, ...]
-    registry_edges: dict = {}
+    # normalize_call_edges guarantees caller/callee are present, but use .get()
+    # defensively in case an edge bypasses the normalization layer.
+    registry_edges = defaultdict(set)
     for edge in registry_edges_list:
-        registry_edges.setdefault(edge["caller"], set()).add(edge["callee"])
+        caller = edge.get("caller")
+        callee = edge.get("callee")
+        if caller and callee:
+            registry_edges[caller].add(callee)
 
     for filepath, module_name in phase_files:
         fqn = fqn_map[filepath]

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -313,7 +313,11 @@ def _build_call_graph(phase_files, proj_dir, global_stem_to_fqns=None, extra_cal
     edge_aliases_map = defaultdict(lambda: defaultdict(set))  # callee -> caller -> aliases
 
     phase_langs = {_detect_lang_from_ext(fp) for fp, _ in phase_files if _detect_lang_from_ext(fp)}
-    registry_edges, registry_langs = call_edges_all(proj_dir, phase_langs)
+    registry_edges_list, registry_langs = call_edges_all(proj_dir, phase_langs)
+    # codegraph edges are [{"caller": fqn, "callee": fqn, "kind": k}, ...]
+    registry_edges: dict = {}
+    for edge in registry_edges_list:
+        registry_edges.setdefault(edge["caller"], set()).add(edge["callee"])
 
     for filepath, module_name in phase_files:
         fqn = fqn_map[filepath]

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -379,29 +379,19 @@ class CodeGraphExtractor:
             for name, qualified_name, start, end in rows
         ]
 
-    def get_call_edges(self, lang_key: str) -> dict:
-        """Return {caller_fqn: {callee_fqn, ...}} for the given language.
+    def get_call_edges(self, lang_key: str) -> list:
+        """Return precisely resolved call edges for the given language.
 
-        Each FQN matches generate_topdown_layers._file_to_fqn for the
-        corresponding extracted function (``dir::file-ext::dedup_name``). Edges
-        are resolved by codegraph NODE ID (not by bare name), so the precise
-        caller/callee identity codegraph computed — which file, which same-named
-        sibling — is preserved end-to-end. This lets the call-graph builder use
-        the edges directly instead of re-resolving bare names against every
-        same-named function (which collapsed siblings and over-approximated
-        across files).
+        Each edge preserves exact codegraph node identity through the extracted-
+        function FQN. No bare-name resolution is performed here.
 
-        Constructor calls are synthesised from `instantiates` edges: when a
-        function instantiates a class, the corresponding constructor method is
-        added as a callee.  See _CONSTRUCTOR_FILTER for per-language details.
-
-        NOTE: codegraph itself collapses calls to same-named classes in different
-        files onto the first definition (a codegraph resolver limitation for C++,
-        not addressable here — see issues/codegraph-samename-class-resolution).
+        Returns a list of ``{"caller": fqn, "callee": fqn, "kind": str,
+        "span": {...}}`` dicts, ordered by source location so call-site order
+        aligns with the source appearance order.
         """
         cg_langs = _CG_LANG.get(lang_key)
         if not cg_langs:
-            return {}
+            return []
 
         conn = sqlite3.connect(self._db)
         cur = conn.cursor()
@@ -411,23 +401,37 @@ class CodeGraphExtractor:
         # dedup as get_functions_by_file, then resolve edges by node id.
         fqn_of = _node_fqn_map(cur, cg_langs)
 
-        result = defaultdict(set)
+        result = []
+        seen = set()
 
         # Query 1: regular function/method calls, kept as (source_id, target_id)
         # so each endpoint resolves to its exact node's FQN.
+        # ORDER BY is required so that multiple call sites of the same callee are
+        # returned in source order (aligns with AST/regex arg-list extraction).
         cur.execute(
             f"""
-            SELECT e.source, e.target
+            SELECT e.source, e.target, s.start_line, s.start_column
             FROM edges e
             JOIN nodes s ON e.source = s.id
             WHERE e.kind = 'calls' AND s.language IN ({placeholders})
+            ORDER BY s.file_path, s.start_line, s.start_column
             """,
             cg_langs,
         )
-        for src_id, tgt_id in cur.fetchall():
+        for src_id, tgt_id, start_line, start_col in cur.fetchall():
             caller, callee = fqn_of.get(src_id), fqn_of.get(tgt_id)
-            if caller and callee:
-                result[caller].add(callee)
+            if not caller or not callee:
+                continue
+            key = (caller, callee, "calls")
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append({
+                "caller": caller,
+                "callee": callee,
+                "kind": "calls",
+                "span": {"start_line": start_line, "start_column": start_col},
+            })
 
         # Query 2: constructor calls synthesised from instantiates edges.
         # For each `caller instantiates ClassName` edge, find the constructor
@@ -436,7 +440,7 @@ class CodeGraphExtractor:
         if ctor_filter:
             cur.execute(
                 f"""
-                SELECT e.source, ctor.id
+                SELECT e.source, ctor.id, s.start_line, s.start_column
                 FROM edges e
                 JOIN nodes s   ON e.source = s.id
                 JOIN nodes cls ON e.target = cls.id AND cls.kind = 'class'
@@ -445,16 +449,27 @@ class CodeGraphExtractor:
                                AND ctor.kind IN ('method', 'function')
                 WHERE e.kind = 'instantiates' AND s.language IN ({placeholders})
                 AND {ctor_filter}
+                ORDER BY s.file_path, s.start_line, s.start_column
                 """,
                 cg_langs,
             )
-            for src_id, ctor_id in cur.fetchall():
+            for src_id, ctor_id, start_line, start_col in cur.fetchall():
                 caller, callee = fqn_of.get(src_id), fqn_of.get(ctor_id)
-                if caller and callee:
-                    result[caller].add(callee)
+                if not caller or not callee:
+                    continue
+                key = (caller, callee, "constructor")
+                if key in seen:
+                    continue
+                seen.add(key)
+                result.append({
+                    "caller": caller,
+                    "callee": callee,
+                    "kind": "constructor",
+                    "span": {"start_line": start_line, "start_column": start_col},
+                })
 
         conn.close()
-        return dict(result)
+        return result
 
 
 def _codegraph_cmd() -> str:

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -430,10 +430,11 @@ class CodeGraphExtractor:
             # of the same callee within one function are all preserved; without
             # them, the 2nd and later calls would be dropped (breaking
             # order_index / arg_bindings).
-            key = (caller, callee, "call", file_path, start_line, start_col)
-            if key in seen:
-                continue
-            seen.add(key)
+            if start_line and start_line > 0:
+                key = (caller, callee, "call", file_path, start_line, start_col)
+                if key in seen:
+                    continue
+                seen.add(key)
             result.append({
                 "caller": caller,
                 "callee": callee,
@@ -456,7 +457,8 @@ class CodeGraphExtractor:
                 f"""
                 SELECT e.source, ctor.id, s.file_path,
                        COALESCE(e.line, s.start_line),
-                       COALESCE(e.col, s.start_column)
+                       COALESCE(e.col, s.start_column),
+                       e.line IS NULL AS coord_fallback
                 FROM edges e
                 JOIN nodes s   ON e.source = s.id
                 JOIN nodes cls ON e.target = cls.id AND cls.kind = 'class'
@@ -470,16 +472,28 @@ class CodeGraphExtractor:
                 """,
                 cg_langs,
             )
-            for src_id, ctor_id, file_path, start_line, start_col in cur.fetchall():
+            ctor_seq = 0
+            for src_id, ctor_id, file_path, start_line, start_col, coord_fallback \
+                    in cur.fetchall():
                 caller, callee = fqn_of.get(src_id), fqn_of.get(ctor_id)
                 if not caller or not callee:
                     continue
                 # Dedup key includes call-site coordinates so multiple
                 # constructor call sites within one function are preserved.
-                key = (caller, callee, "constructor", file_path, start_line, start_col)
-                if key in seen:
-                    continue
-                seen.add(key)
+                # When the edge has no real coordinates (coord_fallback=True),
+                # the COALESCE fallback gives every call site the same value;
+                # use a sequence so distinct no-coordinate call sites are NOT
+                # merged away (keeping all edges is safer than dropping calls).
+                if not coord_fallback:
+                    key = (caller, callee, "constructor", file_path,
+                           start_line, start_col)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                else:
+                    key = (caller, callee, "constructor", file_path,
+                           "no-coord", ctor_seq)
+                    ctor_seq += 1
                 result.append({
                     "caller": caller,
                     "callee": callee,
@@ -492,6 +506,17 @@ class CodeGraphExtractor:
                 })
 
         conn.close()
+
+        # Sort the merged result by source location so call sites of different
+        # kinds (call vs constructor) are interleaved in true source order.
+        # Query 1 and Query 2 each ORDER BY independently, but appending them
+        # in sequence would put all calls before all constructors regardless of
+        # line number, breaking consumers that align call sites with source.
+        result.sort(key=lambda e: (
+            e["span"].get("file", ""),
+            e["span"].get("start_line") or 0,
+            e["span"].get("start_column") or 0,
+        ))
         return result
 
 

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -426,16 +426,18 @@ class CodeGraphExtractor:
             caller, callee = fqn_of.get(src_id), fqn_of.get(tgt_id)
             if not caller or not callee:
                 continue
-            # key 包含调用点坐标，区分同一函数内对同一 callee 的多次不同调用点，
-            # 否则第 2 次及以后的调用会被误判为重复而丢弃（order_index/arg_bindings 失效）
-            key = (caller, callee, "calls", file_path, start_line, start_col)
+            # Dedup key includes call-site coordinates so multiple call sites
+            # of the same callee within one function are all preserved; without
+            # them, the 2nd and later calls would be dropped (breaking
+            # order_index / arg_bindings).
+            key = (caller, callee, "call", file_path, start_line, start_col)
             if key in seen:
                 continue
             seen.add(key)
             result.append({
                 "caller": caller,
                 "callee": callee,
-                "kind": "calls",
+                "kind": "call",
                 "span": {
                     "file": file_path,
                     "start_line": start_line,
@@ -472,7 +474,8 @@ class CodeGraphExtractor:
                 caller, callee = fqn_of.get(src_id), fqn_of.get(ctor_id)
                 if not caller or not callee:
                     continue
-                # key 含调用点坐标，区分同一函数内对同一构造器的多次调用点
+                # Dedup key includes call-site coordinates so multiple
+                # constructor call sites within one function are preserved.
                 key = (caller, callee, "constructor", file_path, start_line, start_col)
                 if key in seen:
                     continue

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -410,7 +410,7 @@ class CodeGraphExtractor:
         # returned in source order (aligns with AST/regex arg-list extraction).
         cur.execute(
             f"""
-            SELECT e.source, e.target, s.start_line, s.start_column
+            SELECT e.source, e.target, s.file_path, s.start_line, s.start_column
             FROM edges e
             JOIN nodes s ON e.source = s.id
             WHERE e.kind = 'calls' AND s.language IN ({placeholders})
@@ -418,11 +418,13 @@ class CodeGraphExtractor:
             """,
             cg_langs,
         )
-        for src_id, tgt_id, start_line, start_col in cur.fetchall():
+        for src_id, tgt_id, file_path, start_line, start_col in cur.fetchall():
             caller, callee = fqn_of.get(src_id), fqn_of.get(tgt_id)
             if not caller or not callee:
                 continue
-            key = (caller, callee, "calls")
+            # key 包含行列号，区分同一函数内对同一 callee 的多次不同调用点，
+            # 否则第 2 次及以后的调用会被误判为重复而丢弃（order_index/arg_bindings 失效）
+            key = (caller, callee, "calls", file_path, start_line, start_col)
             if key in seen:
                 continue
             seen.add(key)
@@ -430,7 +432,11 @@ class CodeGraphExtractor:
                 "caller": caller,
                 "callee": callee,
                 "kind": "calls",
-                "span": {"start_line": start_line, "start_column": start_col},
+                "span": {
+                    "file": file_path,
+                    "start_line": start_line,
+                    "start_column": start_col,
+                },
             })
 
         # Query 2: constructor calls synthesised from instantiates edges.
@@ -440,7 +446,7 @@ class CodeGraphExtractor:
         if ctor_filter:
             cur.execute(
                 f"""
-                SELECT e.source, ctor.id, s.start_line, s.start_column
+                SELECT e.source, ctor.id, s.file_path, s.start_line, s.start_column
                 FROM edges e
                 JOIN nodes s   ON e.source = s.id
                 JOIN nodes cls ON e.target = cls.id AND cls.kind = 'class'
@@ -453,11 +459,12 @@ class CodeGraphExtractor:
                 """,
                 cg_langs,
             )
-            for src_id, ctor_id, start_line, start_col in cur.fetchall():
+            for src_id, ctor_id, file_path, start_line, start_col in cur.fetchall():
                 caller, callee = fqn_of.get(src_id), fqn_of.get(ctor_id)
                 if not caller or not callee:
                     continue
-                key = (caller, callee, "constructor")
+                # key 含行列号，区分同一函数内对同一构造器的多次调用点
+                key = (caller, callee, "constructor", file_path, start_line, start_col)
                 if key in seen:
                     continue
                 seen.add(key)
@@ -465,7 +472,11 @@ class CodeGraphExtractor:
                     "caller": caller,
                     "callee": callee,
                     "kind": "constructor",
-                    "span": {"start_line": start_line, "start_column": start_col},
+                    "span": {
+                        "file": file_path,
+                        "start_line": start_line,
+                        "start_column": start_col,
+                    },
                 })
 
         conn.close()

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -406,15 +406,19 @@ class CodeGraphExtractor:
 
         # Query 1: regular function/method calls, kept as (source_id, target_id)
         # so each endpoint resolves to its exact node's FQN.
-        # ORDER BY is required so that multiple call sites of the same callee are
-        # returned in source order (aligns with AST/regex arg-list extraction).
+        # Call-site coordinates come from the EDGE (e.line/e.col), not the caller
+        # function node (s.start_line is the function DEFINITION location). The
+        # caller node provides the source FILE identity (the call site is always
+        # inside the caller's file), while the edge provides the precise
+        # call-site line/column. ORDER BY the edge coordinates so multiple call
+        # sites of the same callee are returned in true source order.
         cur.execute(
             f"""
-            SELECT e.source, e.target, s.file_path, s.start_line, s.start_column
+            SELECT e.source, e.target, s.file_path, e.line, e.col
             FROM edges e
             JOIN nodes s ON e.source = s.id
             WHERE e.kind = 'calls' AND s.language IN ({placeholders})
-            ORDER BY s.file_path, s.start_line, s.start_column
+            ORDER BY s.file_path, e.line, e.col
             """,
             cg_langs,
         )
@@ -422,7 +426,7 @@ class CodeGraphExtractor:
             caller, callee = fqn_of.get(src_id), fqn_of.get(tgt_id)
             if not caller or not callee:
                 continue
-            # key 包含行列号，区分同一函数内对同一 callee 的多次不同调用点，
+            # key 包含调用点坐标，区分同一函数内对同一 callee 的多次不同调用点，
             # 否则第 2 次及以后的调用会被误判为重复而丢弃（order_index/arg_bindings 失效）
             key = (caller, callee, "calls", file_path, start_line, start_col)
             if key in seen:
@@ -442,11 +446,15 @@ class CodeGraphExtractor:
         # Query 2: constructor calls synthesised from instantiates edges.
         # For each `caller instantiates ClassName` edge, find the constructor
         # method inside that class and add it as a synthetic callee.
+        # instantiates edges may lack call-site coordinates, so fall back to the
+        # caller node's definition location when the edge coordinates are NULL.
         ctor_filter = _CONSTRUCTOR_FILTER.get(lang_key)
         if ctor_filter:
             cur.execute(
                 f"""
-                SELECT e.source, ctor.id, s.file_path, s.start_line, s.start_column
+                SELECT e.source, ctor.id, s.file_path,
+                       COALESCE(e.line, s.start_line),
+                       COALESCE(e.col, s.start_column)
                 FROM edges e
                 JOIN nodes s   ON e.source = s.id
                 JOIN nodes cls ON e.target = cls.id AND cls.kind = 'class'
@@ -455,7 +463,8 @@ class CodeGraphExtractor:
                                AND ctor.kind IN ('method', 'function')
                 WHERE e.kind = 'instantiates' AND s.language IN ({placeholders})
                 AND {ctor_filter}
-                ORDER BY s.file_path, s.start_line, s.start_column
+                ORDER BY s.file_path, COALESCE(e.line, s.start_line),
+                          COALESCE(e.col, s.start_column)
                 """,
                 cg_langs,
             )
@@ -463,7 +472,7 @@ class CodeGraphExtractor:
                 caller, callee = fqn_of.get(src_id), fqn_of.get(ctor_id)
                 if not caller or not callee:
                     continue
-                # key 含行列号，区分同一函数内对同一构造器的多次调用点
+                # key 含调用点坐标，区分同一函数内对同一构造器的多次调用点
                 key = (caller, callee, "constructor", file_path, start_line, start_col)
                 if key in seen:
                     continue

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -130,6 +130,43 @@ _ALLOWED_EDGE_FIELDS = {
     "span", "arg_bindings", "order_index",
 }
 
+# span 内部的标准字段名（不同后端可能叫 file/path/source_file，统一到 file）
+_SPAN_FIELD_ALIASES = {
+    "file": ("file", "path", "source_file", "filename"),
+    "start_line": ("start_line", "line"),
+    "start_column": ("start_column", "col", "column"),
+}
+
+
+def _normalize_span(span) -> dict:
+    """Unify span field names: {file, start_line, start_column}."""
+    if not isinstance(span, dict):
+        return span
+    out = {}
+    for canonical, aliases in _SPAN_FIELD_ALIASES.items():
+        for a in aliases:
+            if a in span and span[a] is not None:
+                out[canonical] = span[a]
+                break
+    # 保留未识别字段（向后兼容）
+    for k, v in span.items():
+        if k not in {x for aliases in _SPAN_FIELD_ALIASES.values() for x in aliases}:
+            out[k] = v
+    return out
+
+
+def _edge_dedup_key(d: dict) -> tuple:
+    """Dedup key at call-site granularity (mirrors codegraph.py)."""
+    span = d.get("span") if isinstance(d.get("span"), dict) else {}
+    return (
+        d.get("caller"),
+        d.get("callee"),
+        d.get("kind", "call"),
+        span.get("file"),
+        span.get("start_line"),
+        span.get("start_column"),
+    )
+
 
 def normalize_call_edges(edges, language=None) -> list:
     """Normalize language-backend call edges into FM-Agent standard format.
@@ -141,9 +178,25 @@ def normalize_call_edges(edges, language=None) -> list:
 
     Returns a list of normalized edge dicts. Malformed edges are skipped with
     a warning (never silently dropped — this is shared infrastructure).
+    Dedup is applied at call-site granularity so the function is idempotent.
     """
     if edges is None:
         return []
+
+    seen = set()
+
+    def _append(d: dict) -> None:
+        # span 字段名统一
+        if "span" in d and isinstance(d["span"], dict):
+            d["span"] = _normalize_span(d["span"])
+        # language 空字符串规范化：非空 language 参数覆盖空值
+        if not d.get("language") and language:
+            d["language"] = language
+        key = _edge_dedup_key(d)
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(d)
 
     # dict form: {caller: {callee, ...}} / {caller: "callee_str"}
     if isinstance(edges, dict):
@@ -155,7 +208,7 @@ def normalize_call_edges(edges, language=None) -> list:
                 _logger.warning("Skipping malformed call edge (unknown container): %r", callees)
                 continue
             for callee in callees:
-                out.append({
+                _append({
                     "caller": caller,
                     "callee": callee,
                     "kind": "call",
@@ -174,28 +227,18 @@ def normalize_call_edges(edges, language=None) -> list:
                     _logger.warning("Skipping malformed call edge: %s", d)
                     continue
                 d.setdefault("kind", "call")
-                if language:
-                    d.setdefault("language", language)
-                out.append(d)
+                _append(d)
             else:
-                # custom object: 优先 __dict__ 且按白名单过滤内部字段
-                if hasattr(e, "__dict__"):
-                    d = {
-                        k: v
-                        for k, v in e.__dict__.items()
-                        if k in _ALLOWED_EDGE_FIELDS
-                    }
-                else:
-                    d = {}
-                    for key in _ALLOWED_EDGE_FIELDS:
+                # custom object: 统一走 getattr（兼容 __dict__ / __slots__ / @property）
+                d = {}
+                for key in _ALLOWED_EDGE_FIELDS:
+                    if hasattr(e, key):
                         val = getattr(e, key, None)
                         if val is not None:
                             d[key] = val
                 if "caller" in d and "callee" in d:
                     d.setdefault("kind", "call")
-                    if language:
-                        d.setdefault("language", language)
-                    out.append(d)
+                    _append(d)
         return out
 
     return []
@@ -205,10 +248,12 @@ def call_edges_all(proj_dir: str, lang_keys) -> tuple:
     """Call call_edges for each language in lang_keys and merge results.
 
     Returns (edges, langs) where edges is a list of normalized edge dicts and
-    langs is the set of language keys codegraph handled.
+    langs is the set of language keys codegraph handled. Edges are deduped
+    across language backends at call-site granularity.
     """
     edges = []
     langs = set()
+    seen = set()
     for lang in lang_keys:
         if lang not in REGISTRY:
             continue
@@ -216,5 +261,10 @@ def call_edges_all(proj_dir: str, lang_keys) -> tuple:
         if result is None:
             continue
         langs.add(lang)
-        edges.extend(normalize_call_edges(result, language=lang))
+        for edge in normalize_call_edges(result, language=lang):
+            key = _edge_dedup_key(edge)
+            if key in seen:
+                continue
+            seen.add(key)
+            edges.append(edge)
     return edges, langs

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -124,13 +124,15 @@ def extract_incremental_sources(proj_dir: str, lang_key: str, sources: dict):
 
 _logger = logging.getLogger(__name__)
 
-# 允许透传的 edge 字段（内部缓存字段如 _internal_cache 会被过滤）
+# Edge fields allowed to pass through (internal cache fields like
+# _internal_cache are filtered out).
 _ALLOWED_EDGE_FIELDS = {
     "caller", "callee", "kind", "language",
     "span", "arg_bindings", "order_index",
 }
 
-# span 内部的标准字段名（不同后端可能叫 file/path/source_file，统一到 file）
+# Standard field names inside a span (backends may use file/path/source_file;
+# all are unified to "file").
 _SPAN_FIELD_ALIASES = {
     "file": ("file", "path", "source_file", "filename"),
     "start_line": ("start_line", "line"),
@@ -148,7 +150,7 @@ def _normalize_span(span) -> dict:
             if a in span and span[a] is not None:
                 out[canonical] = span[a]
                 break
-    # 保留未识别字段（向后兼容）
+    # Keep unrecognized fields for backward compatibility.
     for k, v in span.items():
         if k not in {x for aliases in _SPAN_FIELD_ALIASES.values() for x in aliases}:
             out[k] = v
@@ -179,11 +181,15 @@ def normalize_call_edges(edges, language=None) -> list:
     Accepts:
       - dict form:      {caller: {callee, ...}} / {caller: "callee_str"}
       - list form:      [{"caller": ..., "callee": ..., "kind": ...}]
-      - custom objects: 可转换为 dict 的 edge object（保留额外字段）
+      - custom objects: edge objects convertible to a dict (extra fields kept)
 
     Returns a list of normalized edge dicts. Malformed edges are skipped with
     a warning (never silently dropped — this is shared infrastructure).
     Dedup is applied at call-site granularity so the function is idempotent.
+
+    ``kind`` is unified to the canonical values "call" / "constructor"
+    (see issue #204). Codegraph directly emits "call"; legacy edge objects
+    emitting "calls" are mapped here for backward compatibility.
     """
     if edges is None:
         return []
@@ -192,10 +198,14 @@ def normalize_call_edges(edges, language=None) -> list:
     seen = set()
 
     def _append(d: dict) -> None:
-        # span 字段名统一
+        # Unify span field names.
         if "span" in d and isinstance(d["span"], dict):
             d["span"] = _normalize_span(d["span"])
-        # language 空字符串规范化：非空 language 参数覆盖空值
+        # Unify kind: map deprecated "calls" to "call", default missing to "call".
+        kind = d.get("kind")
+        if kind == "calls" or not kind:
+            d["kind"] = "call"
+        # Overwrite an empty language with the caller-provided one.
         if not d.get("language") and language:
             d["language"] = language
         key = _edge_dedup_key(d)
@@ -208,17 +218,12 @@ def normalize_call_edges(edges, language=None) -> list:
     if isinstance(edges, dict):
         for caller, callees in edges.items():
             if isinstance(callees, str):
-                callees = [callees]          # 兼容 {caller: "callee_str"}
+                callees = [callees]          # support {caller: "callee_str"}
             elif not isinstance(callees, (list, set, tuple)):
                 _logger.warning("Skipping malformed call edge (unknown container): %r", callees)
                 continue
             for callee in callees:
-                _append({
-                    "caller": caller,
-                    "callee": callee,
-                    "kind": "call",
-                    "language": language,
-                })
+                _append({"caller": caller, "callee": callee})
         return out
 
     # list form: normalized dicts or edge objects
@@ -226,14 +231,14 @@ def normalize_call_edges(edges, language=None) -> list:
         for e in edges:
             if isinstance(e, dict):
                 d = dict(e)
-                # schema 校验：缺 caller/callee 跳过（不静默——基础设施层要留日志）
+                # Schema validation: skip edges missing caller/callee (with a log).
                 if "caller" not in d or "callee" not in d:
                     _logger.warning("Skipping malformed call edge: %s", d)
                     continue
-                d.setdefault("kind", "call")
                 _append(d)
             else:
-                # custom object: 统一走 getattr（兼容 __dict__ / __slots__ / @property）
+                # Custom object: extract via getattr (works with __dict__,
+                # __slots__, and @property).
                 d = {}
                 for key in _ALLOWED_EDGE_FIELDS:
                     if hasattr(e, key):
@@ -241,8 +246,9 @@ def normalize_call_edges(edges, language=None) -> list:
                         if val is not None:
                             d[key] = val
                 if "caller" in d and "callee" in d:
-                    d.setdefault("kind", "call")
                     _append(d)
+                else:
+                    _logger.warning("Skipping malformed call edge object: %r", e)
         return out
 
     return []

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -162,16 +162,41 @@ def _edge_dedup_key(d: dict) -> tuple:
 
     Includes language so edges from different backends (e.g. C and C++)
     with the same caller/callee/span are not merged away.
+
+    When call-site coordinates are absent (start_line missing or 0), the key
+    falls back to ``id(d)`` so distinct no-coordinate edges are all kept
+    instead of being collapsed (safety over false dedup). This mirrors the
+    coord_fallback handling in codegraph.get_call_edges().
     """
     span = d.get("span") if isinstance(d.get("span"), dict) else {}
+    file_path = span.get("file")
+    start_line = span.get("start_line")
+    # Compatible with both start_column and start_col aliases.
+    start_col = (
+        span.get("start_column")
+        if span.get("start_column") is not None
+        else span.get("start_col")
+    )
+
+    # Valid coordinates: dedup at call-site granularity.
+    if start_line and start_line > 0:
+        return (
+            d.get("language"),
+            d.get("caller"),
+            d.get("callee"),
+            d.get("kind", "call"),
+            file_path,
+            start_line,
+            start_col,
+        )
+
+    # No valid coordinates: keep every edge (id() guarantees uniqueness).
     return (
         d.get("language"),
         d.get("caller"),
         d.get("callee"),
         d.get("kind", "call"),
-        span.get("file"),
-        span.get("start_line"),
-        span.get("start_column"),
+        id(d),
     )
 
 

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Callable
 
+import logging
+
 from src.languages import python as _python
 from src.languages import go as _go
 from src.languages import c as _c
@@ -120,27 +122,99 @@ def extract_incremental_sources(proj_dir: str, lang_key: str, sources: dict):
     return handler.incremental_source_extract(proj_dir, sources)
 
 
+_logger = logging.getLogger(__name__)
+
+# 允许透传的 edge 字段（内部缓存字段如 _internal_cache 会被过滤）
+_ALLOWED_EDGE_FIELDS = {
+    "caller", "callee", "kind", "language",
+    "span", "arg_bindings", "order_index",
+}
+
+
+def normalize_call_edges(edges, language=None) -> list:
+    """Normalize language-backend call edges into FM-Agent standard format.
+
+    Accepts:
+      - dict form:      {caller: {callee, ...}} / {caller: "callee_str"}
+      - list form:      [{"caller": ..., "callee": ..., "kind": ...}]
+      - custom objects: 可转换为 dict 的 edge object（保留额外字段）
+
+    Returns a list of normalized edge dicts. Malformed edges are skipped with
+    a warning (never silently dropped — this is shared infrastructure).
+    """
+    if edges is None:
+        return []
+
+    # dict form: {caller: {callee, ...}} / {caller: "callee_str"}
+    if isinstance(edges, dict):
+        out = []
+        for caller, callees in edges.items():
+            if isinstance(callees, str):
+                callees = [callees]          # 兼容 {caller: "callee_str"}
+            elif not isinstance(callees, (list, set, tuple)):
+                _logger.warning("Skipping malformed call edge (unknown container): %r", callees)
+                continue
+            for callee in callees:
+                out.append({
+                    "caller": caller,
+                    "callee": callee,
+                    "kind": "call",
+                    "language": language,
+                })
+        return out
+
+    # list form: normalized dicts or edge objects
+    if isinstance(edges, list):
+        out = []
+        for e in edges:
+            if isinstance(e, dict):
+                d = dict(e)
+                # schema 校验：缺 caller/callee 跳过（不静默——基础设施层要留日志）
+                if "caller" not in d or "callee" not in d:
+                    _logger.warning("Skipping malformed call edge: %s", d)
+                    continue
+                d.setdefault("kind", "call")
+                if language:
+                    d.setdefault("language", language)
+                out.append(d)
+            else:
+                # custom object: 优先 __dict__ 且按白名单过滤内部字段
+                if hasattr(e, "__dict__"):
+                    d = {
+                        k: v
+                        for k, v in e.__dict__.items()
+                        if k in _ALLOWED_EDGE_FIELDS
+                    }
+                else:
+                    d = {}
+                    for key in _ALLOWED_EDGE_FIELDS:
+                        val = getattr(e, key, None)
+                        if val is not None:
+                            d[key] = val
+                if "caller" in d and "callee" in d:
+                    d.setdefault("kind", "call")
+                    if language:
+                        d.setdefault("language", language)
+                    out.append(d)
+        return out
+
+    return []
+
+
 def call_edges_all(proj_dir: str, lang_keys) -> tuple:
     """Call call_edges for each language in lang_keys and merge results.
 
-    Returns (edges, langs) where edges is {caller_fqn: {callee_fqns}} and langs is
-    the set of language keys codegraph handled (it returned a dict, even if empty
-    — None means the backend was unavailable and the caller should use regex).
+    Returns (edges, langs) where edges is a list of normalized edge dicts and
+    langs is the set of language keys codegraph handled.
     """
-    edges = {}
+    edges = []
     langs = set()
     for lang in lang_keys:
         if lang not in REGISTRY:
             continue
         result = REGISTRY[lang].call_edges(proj_dir)
-        # A handler returns None when its backend (codegraph) is unavailable, and
-        # a dict (possibly empty) when it handled the language. Treat "handled but
-        # no edges" as codegraph-authoritative — add the language to `langs` so the
-        # caller uses the codegraph path — instead of falling back to regex, which
-        # would otherwise invent edges (e.g. match a function's own signature) for
-        # a genuinely call-free project.
-        if result is not None:
-            langs.add(lang)
-            for key, callees in result.items():
-                edges.setdefault(key, set()).update(callees)
+        if result is None:
+            continue
+        langs.add(lang)
+        edges.extend(normalize_call_edges(result, language=lang))
     return edges, langs

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -188,6 +188,7 @@ def normalize_call_edges(edges, language=None) -> list:
     if edges is None:
         return []
 
+    out = []
     seen = set()
 
     def _append(d: dict) -> None:
@@ -205,7 +206,6 @@ def normalize_call_edges(edges, language=None) -> list:
 
     # dict form: {caller: {callee, ...}} / {caller: "callee_str"}
     if isinstance(edges, dict):
-        out = []
         for caller, callees in edges.items():
             if isinstance(callees, str):
                 callees = [callees]          # 兼容 {caller: "callee_str"}
@@ -223,7 +223,6 @@ def normalize_call_edges(edges, language=None) -> list:
 
     # list form: normalized dicts or edge objects
     if isinstance(edges, list):
-        out = []
         for e in edges:
             if isinstance(e, dict):
                 d = dict(e)

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -156,9 +156,14 @@ def _normalize_span(span) -> dict:
 
 
 def _edge_dedup_key(d: dict) -> tuple:
-    """Dedup key at call-site granularity (mirrors codegraph.py)."""
+    """Dedup key at call-site granularity (mirrors codegraph.py).
+
+    Includes language so edges from different backends (e.g. C and C++)
+    with the same caller/callee/span are not merged away.
+    """
     span = d.get("span") if isinstance(d.get("span"), dict) else {}
     return (
+        d.get("language"),
         d.get("caller"),
         d.get("callee"),
         d.get("kind", "call"),


### PR DESCRIPTION
Fixes#204

## Motivation

FM-Agent is integrating security analysis plugins (IFC, taint, crypto, resource) that perform cross-function data-flow analysis and need a precise call graph — distinguishing same-named functions, preserving edge kind, and carrying call-site location. The current `get_call_edges()` output (FQN-set dict) cannot provide these.

## What changed

### src/languages/codegraph.py
- `get_call_edges()` returns a list of edge dicts `[{caller, callee, kind, span}]` instead of `{caller: {callee}}`.
- Edge kind (`calls` vs `constructor`) preserved.
- Each edge carries call-site location `{file, start_line, start_column}`.
- Results `ORDER BY` source location so call-site order aligns with source appearance.
- Dedup key includes file/line/col so multiple call sites of the same callee are all preserved.

### src/languages/registry.py
- `normalize_call_edges()` unifies dict (incl. single-string callee), list, and custom-object edge formats into one schema.
- Schema validation skips malformed edges with a warning (shared infrastructure, never silent).
- Dedup at call-site granularity (idempotent); includes language so C/C++ backends don't merge away.
- Span field-name aliases normalized to `{file, start_line, start_column}`.
- Empty language overwritten by caller language; custom objects extracted via getattr (`__slots__`/`@property` compatible).

### src/generate_topdown_layers.py
- Adapts the main pipeline consumer to the new list format by converting back to the legacy `{caller: {callee}}` shape at the boundary, preserving existing behavior exactly.

## Design

codegraph → list{caller, callee, kind, span}
              → registry.normalize_call_edges()
              → main pipeline  and  → ProgramIndex for plugins

This is the first step toward a shared ProgramIndex contract; edge kind and call-site metadata are preserved end-to-end for future plugin consumption.
