### PR TITLE
chore(codegraph): bump pinned build to v1.5.0-fmagent.2

### DIFF
--- a/config.py
+++ b/config.py
@@ -157,7 +157,7 @@ class CodegraphCfg(_Section):
     repo: str = "fmagent-project/codegraph"
     # fm-agent.toml is the authoritative source; this default is only the fallback
     # when the toml is absent. Keep it in sync when bumping the pinned version.
-    version: str = "v1.5.0-fmagent.1"
+    version: str = "v1.5.0-fmagent.2"
     bin_dir: str = "~/.local/bin"  # launcher location; install and run must agree
 
 

--- a/fm-agent.toml
+++ b/fm-agent.toml
@@ -35,10 +35,12 @@ timeout_s = 180     # ELP_TIMEOUT_SECONDS
 # The pinned codegraph build. install.sh reads these to install it, and the
 # runtime invokes that pinned binary — so this is the single place that decides
 # "which codegraph": bump `version` (and `repo`), then re-run ./install.sh to
-# switch. This is a maintenance-fork release that re-hosts upstream v1.5.0, which
-# carries the C macro-attribute extraction fix natively. The fork build's updater
-# points back at the fork, so `codegraph upgrade` won't self-replace it with the
-# upstream build.
+# switch. This maintenance-fork build is based on upstream main at c6aaa20 (past
+# v1.5.0, which is why the marker still reads 1.5.0-fmagent.N) and carries one
+# patch of its own: FM-Agent's work directory is excluded from the index by
+# default, so an analysed project is not indexed with a second copy of every
+# function this tool extracted from it. The fork build's updater points back at
+# the fork, so `codegraph upgrade` won't self-replace it with the upstream build.
 repo    = "fmagent-project/codegraph"   # CODEGRAPH_REPO
-version = "v1.5.0-fmagent.1"            # CODEGRAPH_VERSION
+version = "v1.5.0-fmagent.2"            # CODEGRAPH_VERSION
 bin_dir = "~/.local/bin"                # CODEGRAPH_BIN_DIR — where the codegraph launcher is installed and invoked from


### PR DESCRIPTION
Bumps the pinned codegraph from `v1.5.0-fmagent.1` to `v1.5.0-fmagent.2`, and
rewrites the comment to say what that build actually is. Upgrade by re-running
`./install.sh`.

The build follows upstream (based on upstream main at `c6aaa20`, 107 commits)
and carries one fork-only patch: `fm_agent` is in codegraph's default ignore
list, so an analysed project is no longer indexed with a second copy of every
function this tool extracted from it (#195).

## Verification

- codegraph's own test suite passes in full
- a complete pipeline run over a real C kernel corpus, matching the historical baseline
- one complete fmagent run in each execution mode — plain full run (C++ and
  Python), `--incremental`, and `--entry-func`: with the project carrying
  neither a `codegraph.json` nor a `.gitignore`, no fm_agent artifact reaches
  the index, and the index left behind matches a full rebuild
