### PR TITLE
Fix misleading Erlang diagnostics for projects without Erlang sources (#202)

### DIFF
--- a/src/languages/erlang.py
+++ b/src/languages/erlang.py
@@ -711,14 +711,13 @@ def _analyze_project(proj_dir: str) -> ErlangAnalysis:
         if cached and cached[0] == fingerprint:
             return cached[1]
 
+    _remove_persisted_analysis(root)
     analysis = _analyze_project_uncached(root)
     if files:
         try:
             _persist_analysis(root, fingerprint, analysis)
         except OSError as exc:
             logging.warning("Unable to persist ELP Erlang call graph for %s: %s", root, exc)
-    else:
-        _remove_persisted_analysis(root)
     with _CACHE_LOCK:
         _CACHE[root] = (fingerprint, analysis)
     return analysis

--- a/src/languages/erlang.py
+++ b/src/languages/erlang.py
@@ -433,7 +433,7 @@ def _fingerprint_digest(fingerprint: tuple) -> str:
 def _persist_analysis(proj_dir: str, fingerprint: tuple, analysis: ErlangAnalysis):
     """Persist successful ELP output for diagnostics and reproducible inspection."""
     root = os.path.abspath(proj_dir)
-    output_dir = os.path.join(root, ".codegraph")
+    output_dir = os.path.join(root, "fm_agent")
     output_path = os.path.join(output_dir, "erlang_callgraph.json")
 
     functions = []
@@ -690,6 +690,7 @@ def _analyze_project_uncached(proj_dir: str) -> ErlangAnalysis:
 
 def _analyze_project(proj_dir: str) -> ErlangAnalysis:
     root = os.path.abspath(proj_dir)
+    files = _erlang_files(root)
     fingerprint = _project_fingerprint(root)
     with _CACHE_LOCK:
         cached = _CACHE.get(root)
@@ -697,10 +698,11 @@ def _analyze_project(proj_dir: str) -> ErlangAnalysis:
             return cached[1]
 
     analysis = _analyze_project_uncached(root)
-    try:
-        _persist_analysis(root, fingerprint, analysis)
-    except OSError as exc:
-        logging.warning("Unable to persist ELP Erlang call graph for %s: %s", root, exc)
+    if files:
+        try:
+            _persist_analysis(root, fingerprint, analysis)
+        except OSError as exc:
+            logging.warning("Unable to persist ELP Erlang call graph for %s: %s", root, exc)
     with _CACHE_LOCK:
         _CACHE[root] = (fingerprint, analysis)
     return analysis

--- a/src/languages/erlang.py
+++ b/src/languages/erlang.py
@@ -430,11 +430,15 @@ def _fingerprint_digest(fingerprint: tuple) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def _diagnostic_output_path(proj_dir: str) -> str:
+    return os.path.join(os.path.abspath(proj_dir), "fm_agent", "erlang_callgraph.json")
+
+
 def _persist_analysis(proj_dir: str, fingerprint: tuple, analysis: ErlangAnalysis):
     """Persist successful ELP output for diagnostics and reproducible inspection."""
     root = os.path.abspath(proj_dir)
     output_dir = os.path.join(root, "fm_agent")
-    output_path = os.path.join(output_dir, "erlang_callgraph.json")
+    output_path = _diagnostic_output_path(root)
 
     functions = []
     caller_files = {}
@@ -487,6 +491,16 @@ def _persist_analysis(proj_dir: str, fingerprint: tuple, analysis: ErlangAnalysi
                 os.unlink(temp_path)
             except OSError:
                 pass
+
+
+def _remove_persisted_analysis(proj_dir: str):
+    """Remove a stale ELP diagnostic when the project has no Erlang sources."""
+    try:
+        os.unlink(_diagnostic_output_path(proj_dir))
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logging.warning("Unable to remove ELP Erlang call graph for %s: %s", proj_dir, exc)
 
 
 def _symbol_range(symbol: dict):
@@ -703,6 +717,8 @@ def _analyze_project(proj_dir: str) -> ErlangAnalysis:
             _persist_analysis(root, fingerprint, analysis)
         except OSError as exc:
             logging.warning("Unable to persist ELP Erlang call graph for %s: %s", root, exc)
+    else:
+        _remove_persisted_analysis(root)
     with _CACHE_LOCK:
         _CACHE[root] = (fingerprint, analysis)
     return analysis


### PR DESCRIPTION
Fixes #202.

When a project contains no `.erl` files, the Erlang backend now skips diagnostic persistence because ELP is never started. This prevents an incorrect `status: "success"` record from being generated.

Successful Erlang analysis diagnostics are now written to:

`<project>/fm_agent/erlang_callgraph.json`

instead of CodeGraph’s `.codegraph/` directory. Existing ELP failure handling remains unchanged, so unavailable or failed backends do not produce misleading success artifacts.