### PR TITLE
refactor(spec): make specification generation plugin-configurable

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -183,6 +183,14 @@ from a stage hook, or at any other time fails. Each `run_pipeline()` call starts
 with a new software-default configuration, and FM-Agent validates the final
 form, form identity, schema version, and reasoning flag after the hook returns.
 
+The current reasoning and bug-validation backend only supports the exact
+built-in `SoftwareSpecForm` type and its `.spec.json` / `.info.json` artifacts.
+Any form whose concrete type is not exactly `SoftwareSpecForm`, including a
+subclass or another plugin-owned implementation, must set
+`enable_reasoning=False`; otherwise configuration fails before Stage 1. This
+compatibility check also applies when the command uses `--only-spec`, which is
+a per-run execution override rather than a different plugin strategy.
+
 ## Resume, isolate, and incremental runs
 
 Modify hooks run whenever execution reaches their stage boundary. They still

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -159,6 +159,30 @@ The file is rewritten for every fresh, resume, or isolate pipeline call. The
 configure hook runs once per `run_pipeline()` call before Stage 1. FM-Agent
 still writes the context when no configure hook is declared.
 
+### Configuring the specification strategy
+
+A configure hook may select a plugin-owned specification form for the built-in
+Stage 6. Assuming `CUSTOM_SPEC_FORM` is a `SpecForm` instance defined or imported
+by the plugin:
+
+```python
+from src.spec_forms import configure_current_spec_generation
+
+
+def configure(proj_dir: str) -> None:
+    del proj_dir
+    configure_current_spec_generation(
+        spec_form=CUSTOM_SPEC_FORM,
+        enable_reasoning=False,
+    )
+```
+
+`configure_current_spec_generation()` is available only while FM-Agent is
+executing the declared configure hook. Calling it while importing `plugin.py`,
+from a stage hook, or at any other time fails. Each `run_pipeline()` call starts
+with a new software-default configuration, and FM-Agent validates the final
+form, form identity, schema version, and reasoning flag after the hook returns.
+
 ## Resume, isolate, and incremental runs
 
 Modify hooks run whenever execution reaches their stage boundary. They still
@@ -180,7 +204,10 @@ FM-Agent checks that:
 - stage names, modes, and field combinations are supported;
 - `plugin.py` exists and imports successfully;
 - declared objects exist, are callable, and have the exact hook signature;
-- hooks do not raise and their actual return values are `None`.
+- hooks do not raise and their actual return values are `None`;
+- a specification strategy configured by the configure hook has a valid
+  `SpecForm`, non-empty form identity and schema version, and a boolean reasoning
+  flag.
 
 FM-Agent does not check:
 

--- a/docs/plugins_zh.md
+++ b/docs/plugins_zh.md
@@ -174,6 +174,13 @@ def configure(proj_dir: str) -> None:
 `run_pipeline()` 都从新的软件默认配置开始；configure Hook 返回后，FM-Agent
 会验证最终 SpecForm、form identity、schema version 和 reasoning 开关。
 
+当前 reasoning 和 Bug Validation backend 只支持精确的内置
+`SoftwareSpecForm` 类型及其 `.spec.json` / `.info.json` 产物。具体类型不是
+`SoftwareSpecForm` 的 form（包括其子类或其他插件自有实现）必须设置
+`enable_reasoning=False`，否则配置会在 Stage 1 前失败。即使命令使用
+`--only-spec`，该兼容性校验仍然执行；`--only-spec` 是单次运行的执行覆盖，
+不是另一种插件策略。
+
 ## Resume、isolate 与 incremental
 
 执行到 Stage 边界时 Modify Hook 就会运行。即使内置 Stage 在 resume 中复用

--- a/docs/plugins_zh.md
+++ b/docs/plugins_zh.md
@@ -152,6 +152,28 @@ fresh、resume 和 isolate 的每次 Pipeline 调用都会重写上下文。conf
 Stage 1 前、每次 `run_pipeline()` 调用中执行一次。未声明 configure Hook 时仍会
 写入上下文文件。
 
+### 配置规约生成策略
+
+configure Hook 可以为内置 Stage 6 选择插件自有的 SpecForm。假设 `CUSTOM_SPEC_FORM`
+是插件定义或导入的 `SpecForm` 实例：
+
+```python
+from src.spec_forms import configure_current_spec_generation
+
+
+def configure(proj_dir: str) -> None:
+    del proj_dir
+    configure_current_spec_generation(
+        spec_form=CUSTOM_SPEC_FORM,
+        enable_reasoning=False,
+    )
+```
+
+`configure_current_spec_generation()` 只在 FM-Agent 执行已声明的 configure Hook
+期间可用。在导入 `plugin.py` 时、Stage Hook 中或其他时机调用都会失败。每次
+`run_pipeline()` 都从新的软件默认配置开始；configure Hook 返回后，FM-Agent
+会验证最终 SpecForm、form identity、schema version 和 reasoning 开关。
+
 ## Resume、isolate 与 incremental
 
 执行到 Stage 边界时 Modify Hook 就会运行。即使内置 Stage 在 resume 中复用
@@ -171,7 +193,9 @@ FM-Agent 检查：
 - Stage 名称、模式和字段组合合法；
 - `plugin.py` 存在且可以导入；
 - 声明的对象存在、可调用并具有精确 Hook 签名；
-- Hook 不抛出异常且实际返回值为 `None`。
+- Hook 不抛出异常且实际返回值为 `None`；
+- configure Hook 配置的规约策略具有合法的 `SpecForm`、非空 form identity 和
+  schema version，以及布尔类型的 reasoning 开关。
 
 FM-Agent 不检查：
 

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from src.verification import _generate_all_bugs_validation_summary
 from src.extract import run_extraction, EXT_TO_LANG
 from src.generate_topdown_layers import generate_topdown_layers
 from src.spec_generation_and_verification import run_spec_generation_and_verification
+from src.spec_forms import SOFTWARE_SPEC_FORM, SpecGenerationConfig
 from src.incremental_reasoner import run_incremental_pipeline
 from src.git import (
     frozen_worktree,
@@ -190,6 +191,10 @@ def run_pipeline(
     output_dir = os.path.join(work_dir, "logic_verification_results")
     script_dir = os.path.dirname(os.path.abspath(__file__))
     extra_call_edges = load_call_edges(extra_call_edges_path)
+    spec_generation_config = SpecGenerationConfig(
+        spec_form=SOFTWARE_SPEC_FORM,
+        enable_reasoning=True,
+    )
 
     # Clean files from the previous run — unless resuming, where we keep all
     # prior progress (phases.json, generated specs, verification results) and
@@ -370,13 +375,8 @@ def run_pipeline(
                 proj_dir,
             )
 
-    # Copy system_prompt.md to spec_prompts/system_prompt.md
     spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
     os.makedirs(spec_prompts_dir, exist_ok=True)
-    shutil.copy2(
-        os.path.join(script_dir, "md", "system_prompt.md"),
-        os.path.join(spec_prompts_dir, "system_prompt.md"),
-    )
 
     phases_path = os.path.join(work_dir, "phases.json")
     with open(phases_path, "r") as f:
@@ -465,7 +465,8 @@ def run_pipeline(
             )
 
     # --- Stage 6: Execute spec generation workflow (per phase, per layer) ---
-    if only_spec:
+    run_reasoning = spec_generation_config.should_run_reasoning(only_spec)
+    if not run_reasoning:
         print("[Pipeline] Stage 6/6: Generating specs (reasoning & bug validation disabled)...")
     else:
         print("[Pipeline] Stage 6/6: Generating specs & verification...")
@@ -499,6 +500,7 @@ def run_pipeline(
             script_dir,
             spec_prompts_dir,
             phases_data,
+            spec_generation_config,
             resume=resume,
             extra_call_edges=extra_call_edges,
             only_spec=only_spec,
@@ -514,9 +516,8 @@ def run_pipeline(
                 proj_dir,
             )
 
-    # Print confirmed bug count (skipped in only-spec mode, which runs no
-    # reasoning or bug validation).
-    if not only_spec:
+    # Print confirmed bug count only when downstream reasoning is enabled.
+    if run_reasoning:
         if all_bugs:
             # A resumed run may find every function and candidate validation
             # already complete, so no watcher runs to refresh the persistent
@@ -539,7 +540,7 @@ def run_pipeline(
     except Exception as exc:
         logging.warning("[Pipeline] report.html generation skipped: %s", exc)
 
-    if only_spec:
+    if not run_reasoning:
         print("[Pipeline] Done (specs only; reasoning & bug validation skipped).")
     else:
         print("[Pipeline] Done.")

--- a/main.py
+++ b/main.py
@@ -12,7 +12,10 @@ from src.file_utils import (
 from src.verification import _generate_all_bugs_validation_summary
 from src.extract import run_extraction, EXT_TO_LANG
 from src.generate_topdown_layers import generate_topdown_layers
-from src.spec_generation_and_verification import run_spec_generation_and_verification
+from src.spec_generation_and_verification import (
+    run_spec_generation_and_verification,
+    stage_spec_generation_prompts,
+)
 from src.spec_forms import SOFTWARE_SPEC_FORM, SpecGenerationConfig
 from src.spec_forms.config import (
     _bind_spec_generation_config,
@@ -401,7 +404,13 @@ def run_pipeline(
             )
 
     spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
-    os.makedirs(spec_prompts_dir, exist_ok=True)
+
+    stage_spec_generation_prompts(
+        spec_form=spec_generation_config.spec_form,
+        script_dir=script_dir,
+        work_dir=work_dir,
+        spec_prompts_dir=spec_prompts_dir,
+    )
 
     phases_path = os.path.join(work_dir, "phases.json")
     with open(phases_path, "r") as f:

--- a/main.py
+++ b/main.py
@@ -384,7 +384,13 @@ def run_pipeline(
                 extraction_stage.input_hook,
                 proj_dir,
             )
-        run_extraction(proj_dir, work_dir=work_dir, force=not resume, verbose=True)
+        run_extraction(
+            proj_dir,
+            work_dir=work_dir,
+            force=not resume,
+            verbose=True,
+            spec_form=spec_generation_config.spec_form,
+        )
         if extraction_stage is not None and extraction_stage.output_hook is not None:
             run_plugin_hook(
                 plugin_config.name,
@@ -429,10 +435,19 @@ def run_pipeline(
                 file_list_stage.input_hook,
                 proj_dir,
             )
-        file_list = collect_file_names(input_dir, file_list_path)
+        file_list = collect_file_names(
+            input_dir,
+            file_list_path,
+            spec_form=spec_generation_config.spec_form,
+        )
         if submodules:
             file_list = _write_file_names(
-                _get_all_phase_files(phases_data, input_dir), file_list_path
+                _get_all_phase_files(
+                    phases_data,
+                    input_dir,
+                    spec_form=spec_generation_config.spec_form,
+                ),
+                file_list_path,
             )
         if file_list_stage is not None and file_list_stage.output_hook is not None:
             run_plugin_hook(
@@ -473,7 +488,11 @@ def run_pipeline(
                 topdown_stage.input_hook,
                 proj_dir,
             )
-        generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
+        generate_topdown_layers(
+            work_dir,
+            extra_call_edges=extra_call_edges,
+            spec_form=spec_generation_config.spec_form,
+        )
         if topdown_stage is not None and topdown_stage.output_hook is not None:
             run_plugin_hook(
                 plugin_config.name,

--- a/main.py
+++ b/main.py
@@ -14,6 +14,10 @@ from src.extract import run_extraction, EXT_TO_LANG
 from src.generate_topdown_layers import generate_topdown_layers
 from src.spec_generation_and_verification import run_spec_generation_and_verification
 from src.spec_forms import SOFTWARE_SPEC_FORM, SpecGenerationConfig
+from src.spec_forms.config import (
+    _bind_spec_generation_config,
+    _validate_spec_generation_config,
+)
 from src.incremental_reasoner import run_incremental_pipeline
 from src.git import (
     frozen_worktree,
@@ -210,8 +214,6 @@ def run_pipeline(
         if initial_history is None:
             preserved_history = preserve_history_before_clean(work_dir)
         _clean_previous_run(work_dir)
-    if resume and not only_spec:
-        _ensure_resume_mode_compatible(output_dir, all_bugs)
     os.makedirs(work_dir, exist_ok=True)
     if preserved_history:
         write_history(work_dir, preserved_history)
@@ -227,13 +229,30 @@ def run_pipeline(
         with open(plugin_context_path, "w", encoding="utf-8") as file:
             json.dump(plugin_context or {}, file, indent=2)
         if plugin_config.configure_hook is not None:
-            run_plugin_hook(
-                plugin_config.name,
-                "configure",
-                plugin_config.configure_function,
-                plugin_config.configure_hook,
-                proj_dir,
-            )
+            with _bind_spec_generation_config(spec_generation_config):
+                run_plugin_hook(
+                    plugin_config.name,
+                    "configure",
+                    plugin_config.configure_function,
+                    plugin_config.configure_hook,
+                    proj_dir,
+                )
+    try:
+        _validate_spec_generation_config(spec_generation_config)
+    except ValueError as exc:
+        if (
+            plugin_config is not None
+            and plugin_config.configure_hook is not None
+        ):
+            raise RuntimeError(
+                f"Plugin '{plugin_config.name}' configured an invalid "
+                f"specification strategy: {exc}"
+            ) from exc
+        raise RuntimeError(
+            f"Invalid built-in specification strategy: {exc}"
+        ) from exc
+    if resume and spec_generation_config.should_run_reasoning(only_spec):
+        _ensure_resume_mode_compatible(output_dir, all_bugs)
     domain_knowledge_relpaths = stage_domain_knowledge_files(
         proj_dir, work_dir, domain_knowledge_files
     )

--- a/src/extract.py
+++ b/src/extract.py
@@ -4,12 +4,14 @@ import re
 import sys
 import shutil
 import logging
+from pathlib import Path
 
-from src.file_utils import is_file_ready, _is_test_file
+from src.file_utils import _is_test_file
 from src.languages.codegraph import canonicalize
 from src.languages.registry import (
     batch_extract_all, function_spans_for_file, BackendUnavailableError,
 )
+from src.spec_forms import SOFTWARE_SPEC_FORM
 
 LANG_CONFIG = {
     "cpp": {
@@ -677,7 +679,7 @@ def _function_spans(filepath, lang_key, proj_dir=None):
 
 def run_extraction(
     proj_dir, work_dir=None, force=False, verbose=False,
-    return_unavailable_backends=False,
+    return_unavailable_backends=False, *, spec_form=SOFTWARE_SPEC_FORM,
 ):
     """Run function extraction on a project directory.
 
@@ -687,7 +689,9 @@ def run_extraction(
 
     Returns (written_count, skipped_count). When
     ``return_unavailable_backends`` is true, appends the languages whose
-    semantic full-project extraction backend failed.
+    semantic full-project extraction backend failed. On resume, ``spec_form``
+    determines whether an existing extracted unit has complete artifacts and
+    must be preserved.
     """
     if work_dir is None:
         work_dir = proj_dir
@@ -775,9 +779,13 @@ def run_extraction(
             # maps "/" -> "_", and falls back to "_function" for empty names.
             out_file = os.path.join(out_dir, _safe_filename(func_name, ext))
 
-            # Skip only when the extracted file already has valid .spec.json and
-            # .info.json sidecars.
-            if not force and os.path.exists(out_file) and is_file_ready(out_file):
+            # Preserve an extracted unit when the active form reports complete
+            # artifacts. This keeps resumed source and specs from diverging.
+            if (
+                not force
+                and os.path.exists(out_file)
+                and spec_form.validate(Path(out_file)).ready
+            ):
                 if verbose:
                     print(f"  SKIP (specced): {os.path.relpath(out_file, proj_dir)}")
                 skipped += 1

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -2,31 +2,10 @@ import json
 import os
 import re
 
-
-# This module is also copied by the current full pipeline and imported as a
-# standalone helper from ``fm_agent/spec_prompts``. Source-package imports use
-# the canonical SoftwareSpecForm; the fallback preserves that copied runtime
-# until batch prompt generation moves in-process in the next refactor stage.
-if __package__:
-    from .spec_forms import SOFTWARE_SPEC_FORM
-else:
-    SOFTWARE_SPEC_FORM = None
+from .spec_forms import SOFTWARE_SPEC_FORM
 
 
 _METADATA_SIDECAR_SUFFIXES = (".spec.json", ".info.json")
-
-_SPEC_FIELDS = {
-    "signature",
-    "pre_condition",
-    "post_condition",
-}
-
-_CALLEE_FIELDS = {
-    "name",
-    "signature",
-    "pre_condition",
-    "post_condition",
-}
 
 _ALL_BUGS_GAP_FIELDS = {
     "spec_claim",
@@ -84,55 +63,17 @@ def collect_file_names(input_dir, output_path="file_list.json"):
 
 def _is_valid_spec_json(data):
     """Check that .spec.json contains exactly the supported fields."""
-    if SOFTWARE_SPEC_FORM is not None:
-        return SOFTWARE_SPEC_FORM.is_valid_spec_data(data)
-    if not isinstance(data, dict):
-        return False
-    if set(data) != _SPEC_FIELDS:
-        return False
-    return all(isinstance(data[field], str) for field in _SPEC_FIELDS)
+    return SOFTWARE_SPEC_FORM.is_valid_spec_data(data)
 
 
 def _is_valid_info_json(data):
     """Check that .info.json contains exactly the supported fields."""
-    if SOFTWARE_SPEC_FORM is not None:
-        return SOFTWARE_SPEC_FORM.is_valid_info_data(data)
-    if not isinstance(data, dict) or set(data) != {"callees"}:
-        return False
-
-    callees = data["callees"]
-    if not isinstance(callees, list):
-        return False
-
-    for callee in callees:
-        if not isinstance(callee, dict) or set(callee) != _CALLEE_FIELDS:
-            return False
-        if not all(isinstance(callee[field], str) for field in _CALLEE_FIELDS):
-            return False
-
-    return True
+    return SOFTWARE_SPEC_FORM.is_valid_info_data(data)
 
 
 def is_file_ready(file_path):
     """Return whether both metadata sidecars contain valid new-format JSON."""
-    if SOFTWARE_SPEC_FORM is not None:
-        return SOFTWARE_SPEC_FORM.validate(file_path).ready
-
-    spec_path = f"{file_path}.spec.json"
-    info_path = f"{file_path}.info.json"
-
-    if not os.path.isfile(spec_path) or not os.path.isfile(info_path):
-        return False
-
-    try:
-        with open(spec_path, "r", encoding="utf-8") as file:
-            spec = json.load(file)
-        with open(info_path, "r", encoding="utf-8") as file:
-            info = json.load(file)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return False
-
-    return _is_valid_spec_json(spec) and _is_valid_info_json(info)
+    return SOFTWARE_SPEC_FORM.validate(file_path).ready
 
 
 # Directories that typically contain test code

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from pathlib import Path
 
 from .spec_forms import SOFTWARE_SPEC_FORM
 
@@ -35,6 +36,38 @@ def _is_metadata_sidecar(file_path):
     return str(file_path).endswith(_METADATA_SIDECAR_SUFFIXES)
 
 
+def _normalized_file_path(file_path):
+    """Return a stable comparison key for a local file path."""
+    return os.path.normcase(
+        os.path.abspath(os.path.normpath(os.fspath(file_path)))
+    )
+
+
+def _exclude_spec_artifacts(file_paths, spec_form=SOFTWARE_SPEC_FORM):
+    """Exclude configured spec artifacts from a collection of analysis units.
+
+    ``SpecForm`` exposes a forward mapping from a unit to its artifacts, so the
+    full candidate collection is needed to identify custom artifact paths.  The
+    fixed software suffix check remains for compatibility with orphaned legacy
+    sidecars whose original unit is no longer present.
+    """
+    file_paths = list(file_paths)
+    configured_artifacts = set()
+    for file_path in file_paths:
+        artifacts = spec_form.artifact_paths(Path(file_path))
+        configured_artifacts.add(_normalized_file_path(artifacts.self_spec))
+        configured_artifacts.add(
+            _normalized_file_path(artifacts.dependency_info)
+        )
+
+    return [
+        file_path
+        for file_path in file_paths
+        if not _is_metadata_sidecar(file_path)
+        and _normalized_file_path(file_path) not in configured_artifacts
+    ]
+
+
 def _write_file_names(file_names, output_path):
     """Write sorted, de-duplicated file names to output_path."""
     file_names = sorted(dict.fromkeys(file_names))
@@ -45,19 +78,25 @@ def _write_file_names(file_names, output_path):
     return file_names
 
 
-def collect_file_names(input_dir, output_path="file_list.json"):
+def collect_file_names(
+    input_dir,
+    output_path="file_list.json",
+    *,
+    spec_form=SOFTWARE_SPEC_FORM,
+):
     """Collect all file names under input_dir and write them to a JSON file.
 
     Each entry contains the relative path starting from input_dir.
     """
-    file_names = []
+    file_paths = []
     for root, _, files in os.walk(input_dir):
         for fname in files:
-            if _is_metadata_sidecar(fname):
-                continue
             full_path = os.path.join(root, fname)
-            rel_path = os.path.relpath(full_path, input_dir)
-            file_names.append(rel_path)
+            file_paths.append(full_path)
+    file_names = [
+        os.path.relpath(file_path, input_dir)
+        for file_path in _exclude_spec_artifacts(file_paths, spec_form)
+    ]
     return _write_file_names(file_names, output_path)
 
 
@@ -342,7 +381,13 @@ def _json_file_is_valid(path):
         return False
 
 
-def _get_phase_files(phases_data, phase_num, input_dir):
+def _get_phase_files(
+    phases_data,
+    phase_num,
+    input_dir,
+    *,
+    spec_form=SOFTWARE_SPEC_FORM,
+):
     """Return relative paths of extracted function files for a given phase."""
     phase = next(p for p in phases_data["phases"] if p["phase"] == phase_num)
     phase_files = []
@@ -364,12 +409,20 @@ def _get_phase_files(phases_data, phase_num, input_dir):
                 for root, _dirs, fnames in os.walk(extracted_dir):
                     for fname in sorted(fnames):
                         fpath = os.path.join(root, fname)
-                        if os.path.isfile(fpath) and not _is_metadata_sidecar(fname):
-                            phase_files.append(os.path.relpath(fpath, input_dir))
-    return phase_files
+                        if os.path.isfile(fpath):
+                            phase_files.append(fpath)
+    return [
+        os.path.relpath(file_path, input_dir)
+        for file_path in _exclude_spec_artifacts(phase_files, spec_form)
+    ]
 
 
-def _get_all_phase_files(phases_data, input_dir):
+def _get_all_phase_files(
+    phases_data,
+    input_dir,
+    *,
+    spec_form=SOFTWARE_SPEC_FORM,
+):
     """Return extracted function files reachable from all phases in phases.json."""
     phase_files = []
     seen = set()
@@ -377,7 +430,12 @@ def _get_all_phase_files(phases_data, input_dir):
         phase_num = phase_info.get("phase")
         if phase_num is None:
             continue
-        for rel in _get_phase_files(phases_data, phase_num, input_dir):
+        for rel in _get_phase_files(
+            phases_data,
+            phase_num,
+            input_dir,
+            spec_form=spec_form,
+        ):
             if rel not in seen:
                 seen.add(rel)
                 phase_files.append(rel)

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -3,6 +3,16 @@ import os
 import re
 
 
+# This module is also copied by the current full pipeline and imported as a
+# standalone helper from ``fm_agent/spec_prompts``. Source-package imports use
+# the canonical SoftwareSpecForm; the fallback preserves that copied runtime
+# until batch prompt generation moves in-process in the next refactor stage.
+if __package__:
+    from .spec_forms import SOFTWARE_SPEC_FORM
+else:
+    SOFTWARE_SPEC_FORM = None
+
+
 _METADATA_SIDECAR_SUFFIXES = (".spec.json", ".info.json")
 
 _SPEC_FIELDS = {
@@ -74,6 +84,8 @@ def collect_file_names(input_dir, output_path="file_list.json"):
 
 def _is_valid_spec_json(data):
     """Check that .spec.json contains exactly the supported fields."""
+    if SOFTWARE_SPEC_FORM is not None:
+        return SOFTWARE_SPEC_FORM.is_valid_spec_data(data)
     if not isinstance(data, dict):
         return False
     if set(data) != _SPEC_FIELDS:
@@ -83,6 +95,8 @@ def _is_valid_spec_json(data):
 
 def _is_valid_info_json(data):
     """Check that .info.json contains exactly the supported fields."""
+    if SOFTWARE_SPEC_FORM is not None:
+        return SOFTWARE_SPEC_FORM.is_valid_info_data(data)
     if not isinstance(data, dict) or set(data) != {"callees"}:
         return False
 
@@ -101,6 +115,9 @@ def _is_valid_info_json(data):
 
 def is_file_ready(file_path):
     """Return whether both metadata sidecars contain valid new-format JSON."""
+    if SOFTWARE_SPEC_FORM is not None:
+        return SOFTWARE_SPEC_FORM.validate(file_path).ready
+
     spec_path = f"{file_path}.spec.json"
     info_path = f"{file_path}.info.json"
 

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -36,35 +36,13 @@ def _is_metadata_sidecar(file_path):
     return str(file_path).endswith(_METADATA_SIDECAR_SUFFIXES)
 
 
-def _normalized_file_path(file_path):
-    """Return a stable comparison key for a local file path."""
-    return os.path.normcase(
-        os.path.abspath(os.path.normpath(os.fspath(file_path)))
-    )
-
-
 def _exclude_spec_artifacts(file_paths, spec_form=SOFTWARE_SPEC_FORM):
-    """Exclude configured spec artifacts from a collection of analysis units.
-
-    ``SpecForm`` exposes a forward mapping from a unit to its artifacts, so the
-    full candidate collection is needed to identify custom artifact paths.  The
-    fixed software suffix check remains for compatibility with orphaned legacy
-    sidecars whose original unit is no longer present.
-    """
-    file_paths = list(file_paths)
-    configured_artifacts = set()
-    for file_path in file_paths:
-        artifacts = spec_form.artifact_paths(Path(file_path))
-        configured_artifacts.add(_normalized_file_path(artifacts.self_spec))
-        configured_artifacts.add(
-            _normalized_file_path(artifacts.dependency_info)
-        )
-
+    """Exclude artifacts owned by the configured specification form."""
     return [
         file_path
         for file_path in file_paths
         if not _is_metadata_sidecar(file_path)
-        and _normalized_file_path(file_path) not in configured_artifacts
+        and not spec_form.is_artifact_path(Path(file_path))
     ]
 
 

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -342,7 +342,10 @@ def generate_batch_prompts(
                 prompt_funcs = [
                     fn
                     for fn in fn_batch
-                    if not spec_form.validate(work_dir / fn["file"]).ready
+                    if not spec_form.validate(
+                        work_dir / fn["file"],
+                        expected_dependencies=fn.get("all_callees", ()),
+                    ).ready
                 ]
                 skipped_functions += len(fn_batch) - len(prompt_funcs)
             out_path = output_dir / filename

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -2,17 +2,17 @@
 
 import argparse
 import json
-import re
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
-try:
-    # When imported as part of the src package (e.g. incremental_reasoner).
-    from .file_utils import is_file_ready
+# Keep the source-tree CLI usable without making the pipeline copy this module
+# into each target project. Package imports use the canonical domain helper and
+# specification contract; direct execution retains the small path-only helper.
+if __package__:
     from .domain_knowledge import list_staged_domain_knowledge_relpaths
-except ImportError:
-    # When run directly from the source tree, file_utils.py sits beside this script.
-    from file_utils import is_file_ready
+    from .spec_forms import SOFTWARE_SPEC_FORM, SpecForm
+else:
+    from spec_forms import SOFTWARE_SPEC_FORM, SpecForm
 
     def list_staged_domain_knowledge_relpaths(work_dir, prefix="fm_agent"):
         knowledge_dir = Path(work_dir) / "spec_prompts" / "domain_context" / "user_knowledge"
@@ -64,7 +64,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--resume",
         action="store_true",
-        help="Skip functions already specced (file_utils.is_file_ready) when building batches",
+        help="Skip functions whose software specification artifacts are already valid",
     )
     return parser.parse_args()
 
@@ -82,47 +82,14 @@ def parse_layers_spec(layers_spec: str) -> Tuple[int, int]:
     return start, end
 
 
-def _spec_json_path(filepath: Path) -> Path:
-    """Return the spec sidecar next to one extracted function file."""
-    return Path(str(filepath) + ".spec.json")
-
-
-def _info_json_path(filepath: Path) -> Path:
-    """Return the info sidecar next to one extracted function file."""
-    return Path(str(filepath) + ".info.json")
-
-
 def extract_spec_block(filepath: Path) -> Optional[str]:
-    """Read .spec.json and rebuild reasoner-facing spec text."""
-    spec_path = _spec_json_path(filepath)
-
-    try:
-        with spec_path.open("r", encoding="utf-8") as file:
-            spec = json.load(file)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
-
-    if not isinstance(spec, dict):
-        return None
-
-    return (
-        f"{spec.get('signature', '')}\n\n"
-        f"Pre-condition:\n{spec.get('pre_condition', '')}\n\n"
-        f"Post-condition:\n{spec.get('post_condition', '')}"
-    )
+    """Compatibility adapter for incremental software reasoning."""
+    return SOFTWARE_SPEC_FORM.read_self_spec(filepath)
 
 
 def extract_info_block(filepath: Path) -> Optional[dict]:
-    """Read the adjacent .info.json object when it is usable."""
-    info_path = _info_json_path(filepath)
-
-    try:
-        with info_path.open("r", encoding="utf-8") as file:
-            info = json.load(file)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
-
-    return info if isinstance(info, dict) else None
+    """Compatibility adapter for incremental software reasoning."""
+    return SOFTWARE_SPEC_FORM.read_info_data(filepath)
 
 
 def extract_callee_spec_from_info(
@@ -130,40 +97,12 @@ def extract_callee_spec_from_info(
     callee_fqn: str,
     aliases: Optional[Sequence[str]] = None,
 ) -> Optional[dict]:
-    """Return the callee object matching the requested FQN or edge aliases."""
-    names = _callee_match_names(callee_fqn, aliases or ())
-    callees = info_dict.get("callees", [])
-    if not isinstance(callees, list):
-        return None
-
-    for callee in callees:
-        if not isinstance(callee, dict):
-            continue
-        name = callee.get("name", "")
-        if not isinstance(name, str):
-            continue
-        if any(_info_line_mentions_name(name, candidate) for candidate in names):
-            return callee
-    return None
-
-
-def _callee_match_names(callee_fqn: str, aliases: Sequence[str]) -> List[str]:
-    names = [callee_fqn, callee_fqn.split("::")[-1]]
-    for alias in aliases:
-        if not alias:
-            continue
-        names.append(alias)
-        if "::" in alias:
-            names.append(alias.rsplit("::", 1)[-1])
-    return list(dict.fromkeys(names))
-
-
-def _info_line_mentions_name(first_line: str, name: str) -> bool:
-    if not name:
-        return False
-    if "::" in name:
-        return name in first_line
-    return bool(re.search(rf"(?<![A-Za-z0-9_]){re.escape(name)}(?:\s*\(|\b)", first_line))
+    """Compatibility adapter for incremental software reasoning."""
+    return SOFTWARE_SPEC_FORM.find_dependency_entry(
+        info_dict,
+        callee_fqn,
+        aliases or (),
+    )
 
 
 def chunked(items: List[dict], size: int) -> List[List[dict]]:
@@ -213,6 +152,7 @@ def build_prompt(
     work_dir: Path,
     fm_agent_prefix: str,
     ext_to_lang: Dict[str, str],
+    spec_form: SpecForm,
 ) -> str:
     lines: List[str] = []
     sample_lang = "unknown"
@@ -221,10 +161,7 @@ def build_prompt(
 
     lines.append(f"You are generating behavioral specifications for Phase {phase}, Layer {layer_idx}.")
     lines.append("")
-    lines.append(
-        f"Language: {sample_lang}. "
-        "Write specifications to adjacent .spec.json and .info.json files."
-    )
+    lines.append(spec_form.batch_intro(sample_lang))
     lines.append("")
     lines.append(f"Read {fm_agent_prefix}spec_prompts/system_prompt.md FIRST for the mandatory spec format rules.")
     lines.append(f"Read: {fm_agent_prefix}spec_prompts/domain_context/engine_overview.txt")
@@ -261,21 +198,15 @@ def build_prompt(
             if not caller_meta:
                 continue
             caller_file = work_dir / caller_meta["file"]
-            spec_block = extract_spec_block(caller_file)
+            spec_block = spec_form.read_self_spec(caller_file)
             if spec_block and (caller_name, spec_block) not in caller_specs:
                 caller_specs.append((caller_name, spec_block))
-            info_dict = extract_info_block(caller_file)
-            if not info_dict:
-                continue
-            entry = extract_callee_spec_from_info(
-                info_dict, fn_name, info_names_by_caller.get(caller_name, [])
+            entry_text = spec_form.read_dependency_expectation(
+                caller_file,
+                fn_name,
+                info_names_by_caller.get(caller_name, []),
             )
-            if entry:
-                entry_text = (
-                    f"{entry.get('signature', '')}\n"
-                    f"  Pre-condition: {entry.get('pre_condition', '')}\n"
-                    f"  Post-condition: {entry.get('post_condition', '')}"
-                )
+            if entry_text:
                 caller_expectations.setdefault(fn_name, []).append(
                     (caller_name, entry_text)
                 )
@@ -328,44 +259,7 @@ def build_prompt(
             lines.append("  Earlier-layer callers: (none)")
 
     lines.append("")
-    lines.append("## SPEC FORMAT (write JSON files; do NOT modify source files)")
-    lines.append("")
-    lines.append(
-        "For each function file `<function-file>`, "
-        "write TWO JSON files in the SAME directory. "
-        "`<function-file>` includes its original extension "
-        "(for example, `foo.py` must produce `foo.py.spec.json` "
-        "and `foo.py.info.json`):"
-    )
-    lines.append("")
-    lines.append("`<function-file>.spec.json`:")
-    lines.append("```json")
-    lines.append(
-        '{"signature": "<FunctionName>(<params>) -> <ReturnType>", '
-        '"pre_condition": "...", "post_condition": "..."}'
-    )
-    lines.append("```")
-    lines.append("")
-    lines.append("`<function-file>.info.json`:")
-    lines.append("```json")
-    lines.append(
-        '{"callees": [{"name": "<callee_name>", "signature": "...", '
-        '"pre_condition": "...", "post_condition": "..."}]}'
-    )
-    lines.append("```")
-    lines.append("")
-    lines.append('If the function has no callees: write `{"callees": []}` to the .info.json file.')
-    lines.append("")
-    lines.append("## PROCESS")
-    lines.append("For each function:")
-    lines.append("1. Read the extracted file")
-    lines.append("2. Read caller expectations above - what do callers NEED from this function?")
-    lines.append("3. Write a behavioral spec describing WHAT it guarantees (not HOW)")
-    lines.append(
-        "4. Write the COMPLETE .spec.json and .info.json objects next to the "
-        "UNCHANGED source file"
-    )
-    lines.append("5. Use the Write tool to save both JSON files")
+    lines.extend(spec_form.output_contract_prompt().splitlines())
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -374,6 +268,7 @@ def generate_batch_prompts(
     phase: int,
     layers_spec: str,
     *,
+    spec_form: SpecForm,
     batch_size: int = 2,
     output_dir: Optional[Path] = None,
     resume: bool = False,
@@ -384,7 +279,6 @@ def generate_batch_prompts(
         raise ValueError("--batch-size must be > 0")
 
     work_dir = Path(work_dir)
-    # fm_agent_prefix is the relative path from the project root to work_dir
     repo_root = work_dir.parent
     fm_agent_prefix = str(work_dir.relative_to(repo_root)) + "/"
 
@@ -394,13 +288,19 @@ def generate_batch_prompts(
     exts = phases_json.get("file_extensions", [])
     ext_to_lang = {ext.lower().lstrip("."): lang for ext, lang in zip(exts, languages)}
 
-    topdown_path = work_dir / "spec_prompts" / f"phase_{phase:02d}_topdown_layers.json"
+    topdown_path = (
+        work_dir
+        / "spec_prompts"
+        / f"phase_{phase:02d}_topdown_layers.json"
+    )
     topdown = read_json(topdown_path)
     layers = topdown.get("layers", [])
     total_layers = len(layers)
     start_layer, end_layer = parse_layers_spec(layers_spec)
     if start_layer < 0 or end_layer >= total_layers:
-        raise ValueError(f"layer range {layers_spec} out of bounds [0, {total_layers - 1}]")
+        raise ValueError(
+            f"layer range {layers_spec} out of bounds [0, {total_layers - 1}]"
+        )
 
     output_dir = Path(output_dir) if output_dir is not None else (
         work_dir / "spec_prompts" / f"batch_prompts_{project}_phase{phase:02d}"
@@ -439,7 +339,11 @@ def generate_batch_prompts(
             # done — but the manifest below still records the full batch.
             prompt_funcs = fn_batch
             if resume:
-                prompt_funcs = [fn for fn in fn_batch if not is_file_ready(work_dir / fn["file"])]
+                prompt_funcs = [
+                    fn
+                    for fn in fn_batch
+                    if not spec_form.validate(work_dir / fn["file"]).ready
+                ]
                 skipped_functions += len(fn_batch) - len(prompt_funcs)
             out_path = output_dir / filename
             # On resume, a batch whose functions are all already specced has no
@@ -458,6 +362,7 @@ def generate_batch_prompts(
                     work_dir,
                     fm_agent_prefix,
                     ext_to_lang,
+                    spec_form,
                 )
                 write_targets.append((out_path, content))
             else:
@@ -518,12 +423,13 @@ def generate_batch_prompts(
 
 
 def main() -> int:
-    """Run the source-tree command-line adapter."""
+    """Run the software-only source-tree CLI adapter."""
     args = parse_args()
     generate_batch_prompts(
         work_dir=Path.cwd() / "fm_agent",
         phase=args.phase,
         layers_spec=args.layers,
+        spec_form=SOFTWARE_SPEC_FORM,
         batch_size=args.batch_size,
         output_dir=Path(args.output_dir) if args.output_dir else None,
         resume=args.resume,

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -7,8 +7,9 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 from src.extract import EXT_TO_LANG, LANG_CONFIG
-from src.file_utils import _is_metadata_sidecar
+from src.file_utils import _exclude_spec_artifacts
 from src.languages.registry import call_edges_all
+from src.spec_forms import SOFTWARE_SPEC_FORM
 
 
 # ---------------------------------------------------------------------------
@@ -26,7 +27,12 @@ def _load_phases(proj_dir):
 # 1.2 Collect files per phase
 # ---------------------------------------------------------------------------
 
-def _collect_phase_files(proj_dir, phase_data):
+def _collect_phase_files(
+    proj_dir,
+    phase_data,
+    *,
+    spec_form=SOFTWARE_SPEC_FORM,
+):
     """For a phase, collect all extracted function file paths.
 
     Returns list of (file_path, module_name) tuples.
@@ -57,10 +63,20 @@ def _collect_phase_files(proj_dir, phase_data):
             for root, _dirs, fnames in os.walk(func_dir):
                 for fname in fnames:
                     fpath = os.path.join(root, fname)
-                    if os.path.isfile(fpath) and not _is_metadata_sidecar(fname):
+                    if os.path.isfile(fpath):
                         results.append((fpath, module_name))
 
-    return results
+    included_paths = set(
+        _exclude_spec_artifacts(
+            (file_path for file_path, _module_name in results),
+            spec_form,
+        )
+    )
+    return [
+        (file_path, module_name)
+        for file_path, module_name in results
+        if file_path in included_paths
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -650,13 +666,20 @@ def _compute_layers(phase_fqns, callees_map, callers_map):
 # Main entry point
 # ---------------------------------------------------------------------------
 
-def generate_topdown_layers(proj_dir, phase_numbers=None, extra_call_edges=None):
+def generate_topdown_layers(
+    proj_dir,
+    phase_numbers=None,
+    extra_call_edges=None,
+    *,
+    spec_form=SOFTWARE_SPEC_FORM,
+):
     """Generate topdown layer JSON files for the specified phases (or all phases).
 
     Args:
         proj_dir: project root directory
         phase_numbers: list of phase numbers to process, or None for all
         extra_call_edges: optional iterable of supplemental caller/callee edges
+        spec_form: active specification form used to exclude artifact files
 
     Returns:
         list of output file paths written
@@ -669,7 +692,11 @@ def generate_topdown_layers(proj_dir, phase_numbers=None, extra_call_edges=None)
     # Build global stem->FQN mapping across ALL phases for all_callees
     global_stem_to_fqns = defaultdict(set)
     for pi in phases_data["phases"]:
-        for filepath, _ in _collect_phase_files(proj_dir, pi):
+        for filepath, _ in _collect_phase_files(
+            proj_dir,
+            pi,
+            spec_form=spec_form,
+        ):
             fqn = _file_to_fqn(filepath, proj_dir)
             stem = fqn.split("::")[-1]
             global_stem_to_fqns[stem].add(fqn)
@@ -684,7 +711,11 @@ def generate_topdown_layers(proj_dir, phase_numbers=None, extra_call_edges=None)
             continue
 
         # 1.2 Collect files
-        phase_files = _collect_phase_files(proj_dir, phase_info)
+        phase_files = _collect_phase_files(
+            proj_dir,
+            phase_info,
+            spec_form=spec_form,
+        )
         if not phase_files:
             logging.warning(f"Phase {phase_num} ({phase_name}): no extracted files found, skipping.")
             continue

--- a/src/spec_forms/__init__.py
+++ b/src/spec_forms/__init__.py
@@ -1,0 +1,12 @@
+"""Specification artifact contracts used by the pipeline."""
+
+from .base import SpecArtifactPaths, SpecForm, SpecValidationResult
+from .software import SOFTWARE_SPEC_FORM, SoftwareSpecForm
+
+__all__ = [
+    "SOFTWARE_SPEC_FORM",
+    "SoftwareSpecForm",
+    "SpecArtifactPaths",
+    "SpecForm",
+    "SpecValidationResult",
+]

--- a/src/spec_forms/__init__.py
+++ b/src/spec_forms/__init__.py
@@ -1,6 +1,7 @@
 """Specification artifact contracts used by the pipeline."""
 
 from .base import SpecArtifactPaths, SpecForm, SpecValidationResult
+from .config import SpecGenerationConfig
 from .software import SOFTWARE_SPEC_FORM, SoftwareSpecForm
 
 __all__ = [
@@ -8,5 +9,6 @@ __all__ = [
     "SoftwareSpecForm",
     "SpecArtifactPaths",
     "SpecForm",
+    "SpecGenerationConfig",
     "SpecValidationResult",
 ]

--- a/src/spec_forms/__init__.py
+++ b/src/spec_forms/__init__.py
@@ -1,7 +1,10 @@
 """Specification artifact contracts used by the pipeline."""
 
 from .base import SpecArtifactPaths, SpecForm, SpecValidationResult
-from .config import SpecGenerationConfig
+from .config import (
+    SpecGenerationConfig,
+    configure_current_spec_generation,
+)
 from .software import SOFTWARE_SPEC_FORM, SoftwareSpecForm
 
 __all__ = [
@@ -11,4 +14,5 @@ __all__ = [
     "SpecForm",
     "SpecGenerationConfig",
     "SpecValidationResult",
+    "configure_current_spec_generation",
 ]

--- a/src/spec_forms/base.py
+++ b/src/spec_forms/base.py
@@ -46,3 +46,24 @@ class SpecForm(ABC):
         expected_dependencies: Sequence[str] = (),
     ) -> SpecValidationResult:
         """Check artifact completeness without modifying the artifacts."""
+
+    @abstractmethod
+    def read_self_spec(self, unit_file: Path) -> str | None:
+        """Return caller-facing self-spec context, or ``None`` if unreadable."""
+
+    @abstractmethod
+    def read_dependency_expectation(
+        self,
+        caller_file: Path,
+        callee_fqn: str,
+        aliases: Sequence[str] = (),
+    ) -> str | None:
+        """Return one caller's expectation for a callee, if recorded."""
+
+    @abstractmethod
+    def batch_intro(self, language: str) -> str:
+        """Render the form-specific introduction for a batch prompt."""
+
+    @abstractmethod
+    def output_contract_prompt(self) -> str:
+        """Render the form-specific output contract for a batch prompt."""

--- a/src/spec_forms/base.py
+++ b/src/spec_forms/base.py
@@ -1,0 +1,48 @@
+"""Base contract for one specification artifact form."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class SpecArtifactPaths:
+    """The self-spec and dependency-info artifacts for one analysis unit."""
+
+    self_spec: Path
+    dependency_info: Path
+
+
+@dataclass(frozen=True)
+class SpecValidationResult:
+    """Side-effect-free result of checking one unit's spec artifacts."""
+
+    ready: bool
+    errors: tuple[str, ...] = ()
+
+
+class SpecForm(ABC):
+    """Describe the artifacts produced by one specification form.
+
+    Project analysis, unit extraction, dependency discovery, orchestration,
+    reasoning, and candidate validation deliberately remain outside this
+    contract.
+    """
+
+    id: str
+    schema_version: str
+
+    @abstractmethod
+    def artifact_paths(self, unit_file: Path) -> SpecArtifactPaths:
+        """Return the specification artifacts adjacent to ``unit_file``."""
+
+    @abstractmethod
+    def validate(
+        self,
+        unit_file: Path,
+        expected_dependencies: Sequence[str] = (),
+    ) -> SpecValidationResult:
+        """Check artifact completeness without modifying the artifacts."""

--- a/src/spec_forms/base.py
+++ b/src/spec_forms/base.py
@@ -40,6 +40,10 @@ class SpecForm(ABC):
         """Return the specification artifacts adjacent to ``unit_file``."""
 
     @abstractmethod
+    def is_artifact_path(self, path: Path) -> bool:
+        """Return whether ``path`` is an artifact produced by this form."""
+
+    @abstractmethod
     def validate(
         self,
         unit_file: Path,

--- a/src/spec_forms/base.py
+++ b/src/spec_forms/base.py
@@ -67,3 +67,23 @@ class SpecForm(ABC):
     @abstractmethod
     def output_contract_prompt(self) -> str:
         """Render the form-specific output contract for a batch prompt."""
+
+    @abstractmethod
+    def system_prompt_path(self, script_dir: Path) -> Path:
+        """Return the source path for the form's staged system prompt."""
+
+    @abstractmethod
+    def workflow_prompt_path(self, script_dir: Path) -> Path:
+        """Return the source path for the form's staged workflow prompt."""
+
+    @abstractmethod
+    def generation_instruction(
+        self,
+        batch_prompt_rel: str,
+        attempt: int,
+    ) -> str:
+        """Render the agent instruction for one batch attempt."""
+
+    @abstractmethod
+    def trace_outputs(self, unit_files: Sequence[Path]) -> list[str]:
+        """Return the artifact paths expected from one traced batch."""

--- a/src/spec_forms/config.py
+++ b/src/spec_forms/config.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Iterator
 
 from .base import SpecForm
+from .software import SoftwareSpecForm
 
 
 @dataclass
@@ -82,4 +83,16 @@ def _validate_spec_generation_config(
     ):
         raise ValueError(
             "SpecForm.schema_version must be a non-empty string"
+        )
+    # The downstream parser is tied to SoftwareSpecForm's exact sidecar
+    # contract. Subclasses can override that contract, so isinstance() would
+    # claim compatibility that the reasoning backend does not actually have.
+    if (
+        config.enable_reasoning
+        and type(config.spec_form) is not SoftwareSpecForm
+    ):
+        raise ValueError(
+            "the current reasoning backend only supports the built-in "
+            "SoftwareSpecForm (.spec.json/.info.json); custom SpecForms "
+            "must set enable_reasoning=False"
         )

--- a/src/spec_forms/config.py
+++ b/src/spec_forms/config.py
@@ -1,0 +1,17 @@
+"""Runtime configuration for the built-in specification pipeline."""
+
+from dataclasses import dataclass
+
+from .base import SpecForm
+
+
+@dataclass
+class SpecGenerationConfig:
+    """Select the specification strategy and optional downstream reasoning."""
+
+    spec_form: SpecForm
+    enable_reasoning: bool = True
+
+    def should_run_reasoning(self, only_spec: bool) -> bool:
+        """Return whether reasoning and bug validation should run."""
+        return self.enable_reasoning and not only_spec

--- a/src/spec_forms/config.py
+++ b/src/spec_forms/config.py
@@ -1,6 +1,9 @@
 """Runtime configuration for the built-in specification pipeline."""
 
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
+from typing import Iterator
 
 from .base import SpecForm
 
@@ -15,3 +18,68 @@ class SpecGenerationConfig:
     def should_run_reasoning(self, only_spec: bool) -> bool:
         """Return whether reasoning and bug validation should run."""
         return self.enable_reasoning and not only_spec
+
+
+_CURRENT_SPEC_GENERATION_CONFIG: ContextVar[SpecGenerationConfig] = (
+    ContextVar("fm_agent_spec_generation_config")
+)
+
+
+@contextmanager
+def _bind_spec_generation_config(
+    config: SpecGenerationConfig,
+) -> Iterator[None]:
+    """Bind one pipeline run's configuration while its configure hook runs."""
+    token = _CURRENT_SPEC_GENERATION_CONFIG.set(config)
+    try:
+        yield
+    finally:
+        _CURRENT_SPEC_GENERATION_CONFIG.reset(token)
+
+
+def configure_current_spec_generation(
+    *,
+    spec_form: SpecForm,
+    enable_reasoning: bool,
+) -> None:
+    """Update the specification strategy for the active pipeline run."""
+    try:
+        config = _CURRENT_SPEC_GENERATION_CONFIG.get()
+    except LookupError as exc:
+        raise RuntimeError(
+            "configure_current_spec_generation() may only be called from "
+            "a plugin configure hook"
+        ) from exc
+
+    config.spec_form = spec_form
+    config.enable_reasoning = enable_reasoning
+
+
+def _validate_spec_generation_config(
+    config: SpecGenerationConfig,
+) -> None:
+    """Fail fast when a pipeline run has an invalid specification strategy."""
+    if not isinstance(config, SpecGenerationConfig):
+        raise ValueError(
+            "specification strategy must be a SpecGenerationConfig instance"
+        )
+    if not isinstance(config.spec_form, SpecForm):
+        raise ValueError(
+            "SpecGenerationConfig.spec_form must be a SpecForm instance"
+        )
+    if type(config.enable_reasoning) is not bool:
+        raise ValueError(
+            "SpecGenerationConfig.enable_reasoning must be bool"
+        )
+    if (
+        not isinstance(config.spec_form.id, str)
+        or not config.spec_form.id.strip()
+    ):
+        raise ValueError("SpecForm.id must be a non-empty string")
+    if (
+        not isinstance(config.spec_form.schema_version, str)
+        or not config.spec_form.schema_version.strip()
+    ):
+        raise ValueError(
+            "SpecForm.schema_version must be a non-empty string"
+        )

--- a/src/spec_forms/software.py
+++ b/src/spec_forms/software.py
@@ -37,6 +37,10 @@ class SoftwareSpecForm(SpecForm):
             dependency_info=Path(f"{unit_file}.info.json"),
         )
 
+    def is_artifact_path(self, path: Path) -> bool:
+        """Return whether ``path`` is a software specification sidecar."""
+        return str(path).endswith((".spec.json", ".info.json"))
+
     @staticmethod
     def is_valid_spec_data(data: object) -> bool:
         """Return whether data matches the exact software self-spec schema."""

--- a/src/spec_forms/software.py
+++ b/src/spec_forms/software.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Sequence
 
@@ -97,6 +98,131 @@ class SoftwareSpecForm(SpecForm):
             )
 
         return SpecValidationResult(ready=not errors, errors=tuple(errors))
+
+    def read_self_spec(self, unit_file: Path) -> str | None:
+        """Reproduce the current permissive caller self-spec rendering."""
+        spec = self._read_json(self.artifact_paths(unit_file).self_spec)
+        if not isinstance(spec, dict):
+            return None
+        return (
+            f"{spec.get('signature', '')}\n\n"
+            f"Pre-condition:\n{spec.get('pre_condition', '')}\n\n"
+            f"Post-condition:\n{spec.get('post_condition', '')}"
+        )
+
+    def read_info_data(self, unit_file: Path) -> dict | None:
+        """Return the current permissive caller dependency-info object."""
+        info = self._read_json(self.artifact_paths(unit_file).dependency_info)
+        return info if isinstance(info, dict) else None
+
+    @staticmethod
+    def dependency_match_names(
+        callee_fqn: str,
+        aliases: Sequence[str] = (),
+    ) -> list[str]:
+        """Return the existing FQN, short-name, and edge-alias candidates."""
+        names = [callee_fqn, callee_fqn.split("::")[-1]]
+        for alias in aliases:
+            if not alias:
+                continue
+            names.append(alias)
+            if "::" in alias:
+                names.append(alias.rsplit("::", 1)[-1])
+        return list(dict.fromkeys(names))
+
+    @staticmethod
+    def dependency_name_matches(recorded_name: str, candidate: str) -> bool:
+        """Reproduce the current dependency-name boundary matching."""
+        if not candidate:
+            return False
+        if "::" in candidate:
+            return candidate in recorded_name
+        return bool(
+            re.search(
+                rf"(?<![A-Za-z0-9_]){re.escape(candidate)}(?:\s*\(|\b)",
+                recorded_name,
+            )
+        )
+
+    def find_dependency_entry(
+        self,
+        info: dict,
+        callee_fqn: str,
+        aliases: Sequence[str] = (),
+    ) -> dict | None:
+        """Find the first callee entry matching any known dependency name."""
+        names = self.dependency_match_names(callee_fqn, aliases)
+        callees = info.get("callees", [])
+        if not isinstance(callees, list):
+            return None
+        for callee in callees:
+            if not isinstance(callee, dict):
+                continue
+            recorded_name = callee.get("name", "")
+            if not isinstance(recorded_name, str):
+                continue
+            if any(
+                self.dependency_name_matches(recorded_name, candidate)
+                for candidate in names
+            ):
+                return callee
+        return None
+
+    def read_dependency_expectation(
+        self,
+        caller_file: Path,
+        callee_fqn: str,
+        aliases: Sequence[str] = (),
+    ) -> str | None:
+        info = self.read_info_data(caller_file)
+        if info is None:
+            return None
+        entry = self.find_dependency_entry(info, callee_fqn, aliases)
+        if entry is None:
+            return None
+        return (
+            f"{entry.get('signature', '')}\n"
+            f"  Pre-condition: {entry.get('pre_condition', '')}\n"
+            f"  Post-condition: {entry.get('post_condition', '')}"
+        )
+
+    def batch_intro(self, language: str) -> str:
+        return (
+            f"Language: {language}. "
+            "Write specifications to adjacent .spec.json and .info.json files."
+        )
+
+    def output_contract_prompt(self) -> str:
+        return "\n".join([
+            "## SPEC FORMAT (write JSON files; do NOT modify source files)",
+            "",
+            "For each function file `<function-file>`, write TWO JSON files in the SAME "
+            "directory. `<function-file>` includes its original extension (for example, "
+            "`foo.py` must produce `foo.py.spec.json` and `foo.py.info.json`):",
+            "",
+            "`<function-file>.spec.json`:",
+            "```json",
+            '{"signature": "<FunctionName>(<params>) -> <ReturnType>", '
+            '"pre_condition": "...", "post_condition": "..."}',
+            "```",
+            "",
+            "`<function-file>.info.json`:",
+            "```json",
+            '{"callees": [{"name": "<callee_name>", "signature": "...", '
+            '"pre_condition": "...", "post_condition": "..."}]}',
+            "```",
+            "",
+            'If the function has no callees: write `{"callees": []}` to the .info.json file.',
+            "",
+            "## PROCESS",
+            "For each function:",
+            "1. Read the extracted file",
+            "2. Read caller expectations above - what do callers NEED from this function?",
+            "3. Write a behavioral spec describing WHAT it guarantees (not HOW)",
+            "4. Write the COMPLETE .spec.json and .info.json objects next to the UNCHANGED "
+            "source file",
+            "5. Use the Write tool to save both JSON files",
+        ])
 
 
 SOFTWARE_SPEC_FORM = SoftwareSpecForm()

--- a/src/spec_forms/software.py
+++ b/src/spec_forms/software.py
@@ -224,5 +224,45 @@ class SoftwareSpecForm(SpecForm):
             "5. Use the Write tool to save both JSON files",
         ])
 
+    def system_prompt_path(self, script_dir: Path) -> Path:
+        return Path(script_dir) / "md" / "system_prompt.md"
+
+    def workflow_prompt_path(self, script_dir: Path) -> Path:
+        return Path(script_dir) / "md" / "workflow_spec_step4_batch.md"
+
+    def generation_instruction(
+        self,
+        batch_prompt_rel: str,
+        attempt: int,
+    ) -> str:
+        fm_reminder = (
+            "IMPORTANT: fm_agent/ is your output workspace, not project source. "
+            "Do NOT modify any existing project files."
+        )
+        if attempt == 1:
+            return (
+                f"Process the batch prompt file at {batch_prompt_rel}. "
+                "Read it and fm_agent/spec_prompts/system_prompt.md, "
+                "generate behavioral specs for each function listed, "
+                "and write the .spec.json and .info.json files for each function. "
+                f"Do not modify the function source files. {fm_reminder}"
+            )
+        return (
+            f"Continue processing the batch prompt file at {batch_prompt_rel}. "
+            "Some functions may already have valid specs from a previous attempt. "
+            "Check each function listed in the batch prompt. Skip it only when both "
+            "its .spec.json and .info.json files contain valid JSON matching the "
+            "schemas in fm_agent/spec_prompts/system_prompt.md. If either sidecar "
+            "is missing, malformed, or schema-invalid, rewrite the complete "
+            ".spec.json and .info.json files for that function. "
+            f"Do not modify the function source files. {fm_reminder}"
+        )
+
+    def trace_outputs(self, unit_files: Sequence[Path]) -> list[str]:
+        paths = [self.artifact_paths(unit_file) for unit_file in unit_files]
+        return [str(path.self_spec) for path in paths] + [
+            str(path.dependency_info) for path in paths
+        ]
+
 
 SOFTWARE_SPEC_FORM = SoftwareSpecForm()

--- a/src/spec_forms/software.py
+++ b/src/spec_forms/software.py
@@ -1,0 +1,102 @@
+"""Pre-condition/post-condition JSON specification artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Sequence
+
+from .base import SpecArtifactPaths, SpecForm, SpecValidationResult
+
+
+_SPEC_FIELDS = frozenset({
+    "signature",
+    "pre_condition",
+    "post_condition",
+})
+
+_CALLEE_FIELDS = frozenset({
+    "name",
+    "signature",
+    "pre_condition",
+    "post_condition",
+})
+
+
+class SoftwareSpecForm(SpecForm):
+    """The existing software ``.spec.json`` / ``.info.json`` contract."""
+
+    id = "software"
+    schema_version = "V1"
+
+    def artifact_paths(self, unit_file: Path) -> SpecArtifactPaths:
+        unit_file = Path(unit_file)
+        return SpecArtifactPaths(
+            self_spec=Path(f"{unit_file}.spec.json"),
+            dependency_info=Path(f"{unit_file}.info.json"),
+        )
+
+    @staticmethod
+    def is_valid_spec_data(data: object) -> bool:
+        """Return whether data matches the exact software self-spec schema."""
+        if not isinstance(data, dict) or set(data) != _SPEC_FIELDS:
+            return False
+        return all(isinstance(data[field], str) for field in _SPEC_FIELDS)
+
+    @staticmethod
+    def is_valid_info_data(data: object) -> bool:
+        """Return whether data matches the exact dependency-info schema."""
+        if not isinstance(data, dict) or set(data) != {"callees"}:
+            return False
+
+        callees = data["callees"]
+        if not isinstance(callees, list):
+            return False
+
+        for callee in callees:
+            if not isinstance(callee, dict) or set(callee) != _CALLEE_FIELDS:
+                return False
+            if not all(
+                isinstance(callee[field], str)
+                for field in _CALLEE_FIELDS
+            ):
+                return False
+
+        return True
+
+    @staticmethod
+    def _read_json(path: Path) -> object | None:
+        try:
+            with path.open("r", encoding="utf-8") as file:
+                return json.load(file)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+
+    def validate(
+        self,
+        unit_file: Path,
+        expected_dependencies: Sequence[str] = (),
+    ) -> SpecValidationResult:
+        # Software readiness intentionally does not enforce static dependency
+        # coverage. Keep the argument for the common SpecForm contract.
+        del expected_dependencies
+        paths = self.artifact_paths(unit_file)
+        errors = []
+
+        spec = self._read_json(paths.self_spec)
+        if not self.is_valid_spec_data(spec):
+            errors.append(
+                f"missing or invalid software spec: {paths.self_spec}"
+            )
+
+        info = self._read_json(paths.dependency_info)
+        if not self.is_valid_info_data(info):
+            errors.append(
+                "missing or invalid software dependency info: "
+                f"{paths.dependency_info}"
+            )
+
+        return SpecValidationResult(ready=not errors, errors=tuple(errors))
+
+
+SOFTWARE_SPEC_FORM = SoftwareSpecForm()

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -22,6 +22,27 @@ from src.spec_forms import SpecForm, SpecGenerationConfig
 from src.verification import streaming_reasoner
 
 
+def stage_spec_generation_prompts(
+    *,
+    spec_form: SpecForm,
+    script_dir,
+    work_dir,
+    spec_prompts_dir,
+):
+    """Stage the active form's prompts before plugin stage hooks run."""
+    os.makedirs(spec_prompts_dir, exist_ok=True)
+    system_prompt_src = spec_form.system_prompt_path(Path(script_dir))
+    system_prompt_dst = os.path.join(spec_prompts_dir, "system_prompt.md")
+    shutil.copy2(system_prompt_src, system_prompt_dst)
+
+    workflow_prompt_src = spec_form.workflow_prompt_path(Path(script_dir))
+    workflow_prompt_dst = os.path.join(
+        work_dir,
+        "workflow_spec_step4_batch.md",
+    )
+    shutil.copy2(workflow_prompt_src, workflow_prompt_dst)
+
+
 def _get_pending_batches(
     batches,
     proj_dir,
@@ -121,15 +142,6 @@ def run_spec_generation_and_verification(
     # --- Stage 6: Execute spec generation workflow (per phase, per layer) ---
     spec_form = spec_generation_config.spec_form
     run_reasoning = spec_generation_config.should_run_reasoning(only_spec)
-
-    os.makedirs(spec_prompts_dir, exist_ok=True)
-    system_prompt_src = spec_form.system_prompt_path(Path(script_dir))
-    system_prompt_dst = os.path.join(spec_prompts_dir, "system_prompt.md")
-    shutil.copy2(system_prompt_src, system_prompt_dst)
-
-    batch_md_src = spec_form.workflow_prompt_path(Path(script_dir))
-    batch_md_dst = os.path.join(work_dir, "workflow_spec_step4_batch.md")
-    shutil.copy2(batch_md_src, batch_md_dst)
 
     all_processed = set()
     num_phases = len(phases_data["phases"])

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -138,7 +138,12 @@ def run_spec_generation_and_verification(
     for phase_info in sorted(phases_data["phases"], key=lambda p: p["phase"]):
         phase_num = phase_info["phase"]
         phase_name = phase_info["name"]
-        phase_files = _get_phase_files(phases_data, phase_num, input_dir)
+        phase_files = _get_phase_files(
+            phases_data,
+            phase_num,
+            input_dir,
+            spec_form=spec_form,
+        )
 
         if not phase_files:
             logging.info(f"Phase {phase_num} ({phase_name}): no extracted files, skipping.")
@@ -149,7 +154,12 @@ def run_spec_generation_and_verification(
             spec_prompts_dir, f"phase_{phase_num:02d}_topdown_layers.json"
         )
         if not os.path.exists(layers_json_path):
-            generate_topdown_layers(work_dir, [phase_num], extra_call_edges=extra_call_edges)
+            generate_topdown_layers(
+                work_dir,
+                [phase_num],
+                extra_call_edges=extra_call_edges,
+                spec_form=spec_form,
+            )
         with open(layers_json_path, "r") as f:
             layers_data = json.load(f)
         total_layers = layers_data.get("total_layers", 1)

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -18,6 +18,7 @@ from src.generate_batch_prompts import generate_batch_prompts
 from src.generate_topdown_layers import generate_topdown_layers
 from src.llm_client import build_llm_cli_command
 from src.opencode_trace import function_id_from_extracted_path, run_opencode_traced
+from src.spec_forms import SOFTWARE_SPEC_FORM
 from src.verification import streaming_reasoner
 
 
@@ -153,12 +154,13 @@ def run_spec_generation_and_verification(
         for layer_idx in range(total_layers):
             print(f"[Pipeline] Stage 6/6: Phase {phase_num}/{num_phases} — {phase_name}, Layer {layer_idx}/{total_layers - 1}")
 
-            # Generate batch prompts for this layer. On resume, skip functions
-            # that were already specced in a previous run.
+            # Generate batch prompts in-process. Stage C will replace this
+            # temporary software form with the resolved Stage 6 strategy.
             manifest = generate_batch_prompts(
                 work_dir=Path(work_dir),
                 phase=phase_num,
                 layers_spec=str(layer_idx),
+                spec_form=SOFTWARE_SPEC_FORM,
                 output_dir=Path(batch_dir),
                 resume=resume,
             )

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -13,25 +13,47 @@ from pathlib import Path
 
 from config import MAX_WORKERS, OPENCODE_MAX_RETRIES, OPENCODE_SPEC_MODEL
 from src.domain_knowledge import list_staged_domain_knowledge_relpaths
-from src.file_utils import _get_incomplete_verification_files, _get_phase_files, is_file_ready
+from src.file_utils import _get_incomplete_verification_files, _get_phase_files
 from src.generate_batch_prompts import generate_batch_prompts
 from src.generate_topdown_layers import generate_topdown_layers
 from src.llm_client import build_llm_cli_command
 from src.opencode_trace import function_id_from_extracted_path, run_opencode_traced
-from src.spec_forms import SOFTWARE_SPEC_FORM
+from src.spec_forms import SpecForm, SpecGenerationConfig
 from src.verification import streaming_reasoner
 
 
-def _get_pending_batches(batches, proj_dir):
+def _get_pending_batches(
+    batches,
+    proj_dir,
+    spec_form: SpecForm,
+    expected_dependencies_by_file,
+):
     """Return batches that still have at least one function without specs."""
     pending = []
     for batch in batches:
         for func_rel in batch.get("functions", []):
-            full_path = os.path.join(proj_dir, func_rel)
-            if not is_file_ready(full_path):
+            full_path = os.path.normpath(os.path.join(proj_dir, func_rel))
+            expected_dependencies = expected_dependencies_by_file.get(
+                full_path,
+                (),
+            )
+            if not spec_form.validate(
+                Path(full_path),
+                expected_dependencies=expected_dependencies,
+            ).ready:
                 pending.append(batch)
                 break
     return pending
+
+
+def _topdown_unit_path(proj_dir, work_dir, file_rel):
+    """Resolve a topdown unit path, including a tolerated fm_agent/ prefix."""
+    file_path = Path(file_rel)
+    if file_path.is_absolute():
+        return os.path.normpath(file_path)
+    if file_path.parts[:1] == (Path(work_dir).name,):
+        return os.path.normpath(Path(proj_dir) / file_path)
+    return os.path.normpath(Path(work_dir) / file_path)
 
 
 def _run_spec_generation_batch(
@@ -42,6 +64,7 @@ def _run_spec_generation_batch(
     layer_idx,
     batch_rel_dir,
     batch_info,
+    spec_form: SpecForm,
 ):
     # Run one batch end-to-end so the executor can refill slots as soon as a
     # batch finishes, instead of waiting for a whole chunk barrier.
@@ -52,27 +75,7 @@ def _run_spec_generation_batch(
         function_id_from_extracted_path(func_rel)
         for func_rel in function_files
     ]
-    fm_reminder = ("IMPORTANT: fm_agent/ is your output workspace, not project source. "
-                    "Do NOT modify any existing project files.")
-    if attempt == 1:
-        prompt = (
-            f"Process the batch prompt file at {batch_prompt_rel}. "
-            f"Read it and fm_agent/spec_prompts/system_prompt.md, "
-            f"generate behavioral specs for each function listed, "
-            f"and write the .spec.json and .info.json files for each function. "
-            f"Do not modify the function source files. {fm_reminder}"
-        )
-    else:
-        prompt = (
-            f"Continue processing the batch prompt file at {batch_prompt_rel}. "
-            f"Some functions may already have valid specs from a previous attempt. "
-            f"Check each function listed in the batch prompt. Skip it only when both "
-            f"its .spec.json and .info.json files contain valid JSON matching the "
-            f"schemas in fm_agent/spec_prompts/system_prompt.md. If either sidecar "
-            f"is missing, malformed, or schema-invalid, rewrite the complete "
-            f".spec.json and .info.json files for that function. "
-            f"Do not modify the function source files. {fm_reminder}"
-        )
+    prompt = spec_form.generation_instruction(batch_prompt_rel, attempt)
     prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_spec_step4_batch.md")
     command = build_llm_cli_command(
         model=OPENCODE_SPEC_MODEL,
@@ -93,13 +96,9 @@ def _run_spec_generation_batch(
                 "fm_agent/spec_prompts/system_prompt.md",
                 *list_staged_domain_knowledge_relpaths(work_dir),
             ],
-            output_files=[
-                f"{function_file}.spec.json"
-                for function_file in function_files
-            ] + [
-                f"{function_file}.info.json"
-                for function_file in function_files
-            ],
+            output_files=spec_form.trace_outputs(
+                [Path(function_file) for function_file in function_files]
+            ),
             summary=f"OpenCode spec generation for {batch_file}",
             metadata={
                 "attempt": attempt,
@@ -115,11 +114,20 @@ def _run_spec_generation_batch(
 
 def run_spec_generation_and_verification(
     proj_dir, work_dir, input_dir, output_dir, script_dir, spec_prompts_dir,
-    phases_data, resume=False, extra_call_edges=None, only_spec=False,
-    bug_validator_path=None, all_bugs=False,
+    phases_data, spec_generation_config: SpecGenerationConfig, resume=False,
+    extra_call_edges=None, only_spec=False, bug_validator_path=None,
+    all_bugs=False,
 ):
-    # --- Stage 4: Execute spec generation workflow (per phase, per layer) ---
-    batch_md_src = os.path.join(script_dir, "md", "workflow_spec_step4_batch.md")
+    # --- Stage 6: Execute spec generation workflow (per phase, per layer) ---
+    spec_form = spec_generation_config.spec_form
+    run_reasoning = spec_generation_config.should_run_reasoning(only_spec)
+
+    os.makedirs(spec_prompts_dir, exist_ok=True)
+    system_prompt_src = spec_form.system_prompt_path(Path(script_dir))
+    system_prompt_dst = os.path.join(spec_prompts_dir, "system_prompt.md")
+    shutil.copy2(system_prompt_src, system_prompt_dst)
+
+    batch_md_src = spec_form.workflow_prompt_path(Path(script_dir))
     batch_md_dst = os.path.join(work_dir, "workflow_spec_step4_batch.md")
     shutil.copy2(batch_md_src, batch_md_dst)
 
@@ -145,6 +153,13 @@ def run_spec_generation_and_verification(
         with open(layers_json_path, "r") as f:
             layers_data = json.load(f)
         total_layers = layers_data.get("total_layers", 1)
+        expected_dependencies_by_file = {
+            _topdown_unit_path(proj_dir, work_dir, fn["file"]): tuple(
+                fn.get("all_callees", ())
+            )
+            for layer in layers_data.get("layers", [])
+            for fn in layer.get("functions", [])
+        }
 
         batch_dir = os.path.join(
             spec_prompts_dir,
@@ -154,13 +169,11 @@ def run_spec_generation_and_verification(
         for layer_idx in range(total_layers):
             print(f"[Pipeline] Stage 6/6: Phase {phase_num}/{num_phases} — {phase_name}, Layer {layer_idx}/{total_layers - 1}")
 
-            # Generate batch prompts in-process. Stage C will replace this
-            # temporary software form with the resolved Stage 6 strategy.
             manifest = generate_batch_prompts(
                 work_dir=Path(work_dir),
                 phase=phase_num,
                 layers_spec=str(layer_idx),
-                spec_form=SOFTWARE_SPEC_FORM,
+                spec_form=spec_form,
                 output_dir=Path(batch_dir),
                 resume=resume,
             )
@@ -183,11 +196,16 @@ def run_spec_generation_and_verification(
 
             for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
                 # Find batches with unspecced functions
-                pending_batches = _get_pending_batches(all_batches, proj_dir)
+                pending_batches = _get_pending_batches(
+                    all_batches,
+                    proj_dir,
+                    spec_form,
+                    expected_dependencies_by_file,
+                )
                 if not pending_batches:
-                    # All functions in this layer are specced. In only-spec mode
-                    # we stop here without running the reasoner/bug validation.
-                    if not only_spec:
+                    # All functions in this layer are specced. When downstream
+                    # reasoning is disabled, there is no further layer work.
+                    if run_reasoning:
                         incomplete_verification = _get_incomplete_verification_files(
                             layer_files,
                             input_dir,
@@ -239,6 +257,7 @@ def run_spec_generation_and_verification(
                                 layer_idx,
                                 batch_rel_dir,
                                 batch_info,
+                                spec_form,
                             )
                         )
 
@@ -247,7 +266,7 @@ def run_spec_generation_and_verification(
                         f"submitted {len(spec_futures)} spec-generation batch tasks "
                         f"(max_workers={MAX_WORKERS}, total_pending_batches={len(pending_batches)})"
                     )
-                    if spec_futures and not only_spec:
+                    if spec_futures and run_reasoning:
                         newly_processed = streaming_reasoner(
                             input_dir, output_dir, file_list=layer_files,
                             proj_dir=proj_dir, work_dir=work_dir,
@@ -268,9 +287,20 @@ def run_spec_generation_and_verification(
                 # Check if any files in this layer received specs
                 specs_generated = sum(
                     1 for rel in layer_files
-                    if is_file_ready(os.path.join(input_dir, rel))
+                    if spec_form.validate(
+                        Path(os.path.normpath(os.path.join(input_dir, rel))),
+                        expected_dependencies=expected_dependencies_by_file.get(
+                            os.path.normpath(os.path.join(input_dir, rel)),
+                            (),
+                        ),
+                    ).ready
                 )
-                if specs_generated > 0 and not _get_pending_batches(all_batches, proj_dir):
+                if specs_generated > 0 and not _get_pending_batches(
+                    all_batches,
+                    proj_dir,
+                    spec_form,
+                    expected_dependencies_by_file,
+                ):
                     break
 
                 if specs_generated > 0:


### PR DESCRIPTION
## Summary

This PR lays the core groundwork for #181 while preserving the existing top-down workflow.

- Introduce a `SpecForm` abstraction and a built-in `SoftwareSpecForm` that preserves the existing `.spec.json` / `.info.json` contract.
- Generate batch prompts in process and make Stage 6 consume a `SpecGenerationConfig`.
- Allow plugins to configure the per-run spec form and reasoning policy through the existing `configure_function(proj_dir)` hook, without changing the plugin manifest or hook signature.
- Preserve the default software pipeline and `--only-spec` behavior.
- Document the plugin-side configuration API.

Chisel and Verilog plugins are not included in this PR; this change provides the shared Stage 6 foundation needed to integrate them without duplicating the orchestration logic.

## Validation

- Compared `--only-spec` runs between `main` and this branch: extracted units, layers, batches, manifests, and artifact schemas remained consistent.
- Verified the configuration path with a smoke plugin that keeps `SoftwareSpecForm` but disables reasoning; running without `--only-spec` completed after spec generation as expected.