### PR TITLE
 fix: separate CLI responses from diagnostics

### DIFF
--- a/src/cli_backend.py
+++ b/src/cli_backend.py
@@ -164,12 +164,14 @@ def run_agent_for_messages(model, messages):
     )
     cwd = os.path.abspath(os.getcwd())
     command = build_agent_command(model=model, prompt=prompt, cwd=cwd)
+    # Agent CLIs write the final response to stdout and diagnostics/transcripts
+    # to stderr; keep them separate so echoed JSON never reaches the parser.
     result = subprocess.run(
         command.argv,
         input=command.stdin,
         cwd=cwd,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         text=True,
         encoding="utf-8",
         errors="replace",
@@ -177,8 +179,12 @@ def run_agent_for_messages(model, messages):
         check=False,
     )
     if result.returncode != 0:
-        output = (result.stdout or "")[-4000:]
+        output = "\n".join(
+            part.strip()
+            for part in (result.stdout or "", result.stderr or "")
+            if part.strip()
+        )[-4000:]
         raise RuntimeError(
             f"{command.backend} exited with code {result.returncode}: {output}"
         )
-    return result.stdout.strip(), {}
+    return (result.stdout or "").strip(), {}


### PR DESCRIPTION
## Summary

  Fix structured verification failures when FM-Agent uses the `codex-cli`
  backend.

  Local agent CLIs write their final response to `stdout` and their
  diagnostics/session transcript to `stderr`. FM-Agent previously merged these
  streams, causing structured responses echoed in the transcript to be parsed
  again.

  This change:

  - captures `stdout` and `stderr` separately;
  - parses only `stdout` after a successful CLI invocation;
  - preserves both streams in the error message when the CLI exits unsuccessfully.

  Fixes #207.