### PR TITLE
Route ArkTS .ets extraction through CodeGraph (#211)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "tree-sitter-go>=0.25,<0.26",
     "tree-sitter-rust>=0.24,<0.25",
     "tree-sitter-typescript>=0.23,<0.24",
+    "tree-sitter-arkts",
 ]
 
 [project.scripts]
@@ -27,3 +28,6 @@ fm-agent = "main:main"
 
 [tool.uv]
 package = false
+
+[tool.uv.sources]
+tree-sitter-arkts = { git = "https://github.com/harmony-contrib/tree-sitter-arkts.git", rev = "9c7395bd9534cce840dd7115fd79be6c6ff45872" }

--- a/src/languages/arkts.py
+++ b/src/languages/arkts.py
@@ -24,16 +24,24 @@ def remove_comments(code: str) -> str | None:
     source_start = 0
     source_end = len(source)
     if tree.root_node.has_error:
-        prefix = b"class __FM_AGENT_COMMENT_WRAPPER__ {\n"
-        source = prefix + source + b"\n}"
-        try:
-            tree = parser.parse(source)
-        except (TypeError, UnicodeError, ValueError):
+        tree = None
+        for prefix in (
+            b"class __FM_AGENT_COMMENT_WRAPPER__ {\n",
+            b"struct __FM_AGENT_COMMENT_WRAPPER__ {\n",
+        ):
+            wrapped_source = prefix + source + b"\n}"
+            try:
+                candidate = parser.parse(wrapped_source)
+            except (TypeError, UnicodeError, ValueError):
+                return None
+            if not candidate.root_node.has_error:
+                source = wrapped_source
+                tree = candidate
+                source_start = len(prefix)
+                source_end += source_start
+                break
+        if tree is None:
             return None
-        if tree.root_node.has_error:
-            return None
-        source_start = len(prefix)
-        source_end += source_start
 
     cleaned = bytearray(source)
     nodes = [tree.root_node]

--- a/src/languages/arkts.py
+++ b/src/languages/arkts.py
@@ -3,6 +3,52 @@
 from src.languages.codegraph import CodeGraphExtractor
 
 
+_COMMENT_TYPES = {"comment", "html_comment"}
+
+
+def remove_comments(code: str) -> str | None:
+    """Remove ArkTS comments using the pinned ArkTS Tree-sitter grammar."""
+    try:
+        import tree_sitter_arkts as ts_arkts
+        from tree_sitter import Language, Parser
+    except (ImportError, OSError):
+        return None
+
+    try:
+        source = code.encode("utf-8")
+        parser = Parser(Language(ts_arkts.language()))
+        tree = parser.parse(source)
+    except (TypeError, UnicodeError, ValueError):
+        return None
+
+    source_start = 0
+    source_end = len(source)
+    if tree.root_node.has_error:
+        prefix = b"class __FM_AGENT_COMMENT_WRAPPER__ {\n"
+        source = prefix + source + b"\n}"
+        try:
+            tree = parser.parse(source)
+        except (TypeError, UnicodeError, ValueError):
+            return None
+        if tree.root_node.has_error:
+            return None
+        source_start = len(prefix)
+        source_end += source_start
+
+    cleaned = bytearray(source)
+    nodes = [tree.root_node]
+    while nodes:
+        node = nodes.pop()
+        if node.type in _COMMENT_TYPES:
+            for index in range(node.start_byte, node.end_byte):
+                if cleaned[index] not in (ord("\n"), ord("\r")):
+                    cleaned[index] = ord(" ")
+            continue
+        nodes.extend(node.children)
+
+    return cleaned[source_start:source_end].decode("utf-8")
+
+
 def batch_extract(proj_dir: str) -> dict:
     """Return {abs_filepath: [(func_name, body)]} for all ArkTS files."""
     cg = CodeGraphExtractor.from_proj_dir(proj_dir)

--- a/src/languages/arkts.py
+++ b/src/languages/arkts.py
@@ -1,0 +1,21 @@
+"""CodeGraph-backed extraction helpers for ArkTS."""
+
+from src.languages.codegraph import CodeGraphExtractor
+
+
+def batch_extract(proj_dir: str) -> dict:
+    """Return {abs_filepath: [(func_name, body)]} for all ArkTS files."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_functions_by_file("arkts", proj_dir) if cg else {}
+
+
+def call_edges(proj_dir: str) -> dict:
+    """Return CodeGraph call edges for ArkTS."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_call_edges("arkts") if cg else None
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return ArkTS function spans, or None when CodeGraph is unavailable."""
+    cg = CodeGraphExtractor.from_proj_dir(proj_dir)
+    return cg.get_function_spans("arkts", filepath) if cg else None

--- a/src/languages/codegraph.py
+++ b/src/languages/codegraph.py
@@ -154,7 +154,6 @@ def _bare_function_name(name: str) -> str:
 
 # Maps FM-Agent lang_key → the language string stored in codegraph's SQLite
 # nodes.language column. Only includes languages that codegraph actually supports.
-# ArkTS is omitted (not supported by codegraph).
 # CUDA: .cu is not in codegraph's built-in extension list and will not be indexed.
 #   To enable partial CUDA support, add {"extensions": {".cu": "cpp"}} to a
 #   codegraph.json file at the project root — codegraph will then parse .cu files
@@ -169,6 +168,7 @@ _CG_LANG = {
     "java":       ["java"],
     "javascript": ["javascript", "jsx"],  # codegraph stores .jsx files as language='jsx'
     "typescript": ["typescript", "tsx"],  # codegraph stores .tsx files as language='tsx'
+    "arkts":      ["arkts"],
 }
 
 # SQL fragment used to match the constructor method node when resolving
@@ -182,6 +182,7 @@ _CG_LANG = {
 _CONSTRUCTOR_FILTER = {
     "python":     "ctor.name = '__init__'",
     "typescript": "ctor.name = 'constructor'",
+    "arkts":      "ctor.name = 'constructor'",
     "javascript": "ctor.name = 'constructor'",
     "java":       "ctor.name = cls.name",
     "cpp":        "ctor.name = cls.name",

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -11,6 +11,7 @@ from src.languages import java as _java
 from src.languages import rust as _rust
 from src.languages import javascript as _javascript
 from src.languages import typescript as _typescript
+from src.languages import arkts as _arkts
 from src.languages import erlang as _erlang
 
 from src.languages.base import BackendUnavailableError as _BackendUnavailableError
@@ -62,6 +63,7 @@ REGISTRY: dict = {
     "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges,       function_spans=_rust.function_spans, split_blocks=_rust.split_blocks, remove_comments=_rust.remove_comments),
     "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges, function_spans=_javascript.function_spans, split_blocks=_javascript.split_blocks, remove_comments=_javascript.remove_comments),
     "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges, function_spans=_typescript.function_spans, split_blocks=_typescript.split_blocks, remove_comments=_typescript.remove_comments),
+    "arkts":      LanguageHandler(batch_extract=_arkts.batch_extract,      call_edges=_arkts.call_edges,      function_spans=_arkts.function_spans),
     "erlang":     LanguageHandler(batch_extract=_erlang.batch_extract,     call_edges=_erlang.call_edges,     function_spans=_erlang.function_spans, incremental_source_extract=_erlang.extract_functions_from_sources),
 }
 

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -63,7 +63,7 @@ REGISTRY: dict = {
     "rust":       LanguageHandler(batch_extract=_rust.batch_extract,       call_edges=_rust.call_edges,       function_spans=_rust.function_spans, split_blocks=_rust.split_blocks, remove_comments=_rust.remove_comments),
     "javascript": LanguageHandler(batch_extract=_javascript.batch_extract, call_edges=_javascript.call_edges, function_spans=_javascript.function_spans, split_blocks=_javascript.split_blocks, remove_comments=_javascript.remove_comments),
     "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges, function_spans=_typescript.function_spans, split_blocks=_typescript.split_blocks, remove_comments=_typescript.remove_comments),
-    "arkts":      LanguageHandler(batch_extract=_arkts.batch_extract,      call_edges=_arkts.call_edges,      function_spans=_arkts.function_spans),
+    "arkts":      LanguageHandler(batch_extract=_arkts.batch_extract,      call_edges=_arkts.call_edges,      function_spans=_arkts.function_spans, remove_comments=_arkts.remove_comments),
     "erlang":     LanguageHandler(batch_extract=_erlang.batch_extract,     call_edges=_erlang.call_edges,     function_spans=_erlang.function_spans, incremental_source_extract=_erlang.extract_functions_from_sources),
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -323,6 +323,7 @@ dependencies = [
     { name = "rich" },
     { name = "socksio" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-arkts" },
     { name = "tree-sitter-c" },
     { name = "tree-sitter-cpp" },
     { name = "tree-sitter-go" },
@@ -342,6 +343,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7.0" },
     { name = "socksio", specifier = ">=1.0.0" },
     { name = "tree-sitter", specifier = ">=0.25,<0.27" },
+    { name = "tree-sitter-arkts", git = "https://github.com/harmony-contrib/tree-sitter-arkts.git?rev=9c7395bd9534cce840dd7115fd79be6c6ff45872" },
     { name = "tree-sitter-c", specifier = ">=0.24,<0.25" },
     { name = "tree-sitter-cpp", specifier = ">=0.23.4,<0.24" },
     { name = "tree-sitter-go", specifier = ">=0.25,<0.26" },
@@ -1522,6 +1524,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/1b/0b36fe2a984ecedc4ce6aefd5d56447a6626a8e9b595c4e48658510ce8f8/tree_sitter-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:a4033fecc8f606c7f2e8b8014d0057b74668a7f0152763606f7bc25c5f9ec64c", size = 132688, upload-time = "2026-06-30T12:14:26.106Z" },
     { url = "https://files.pythonhosted.org/packages/4d/74/ebc041a13fbf40144afdb0d4b447e48e0b4012ca866c63de8b48f801f0c1/tree_sitter-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:823251c4b6725a7c03ed497a339135ede7ae4bdde75bb8be7ef5e305aeb4ff52", size = 120287, upload-time = "2026-06-30T12:14:26.991Z" },
 ]
+
+[[package]]
+name = "tree-sitter-arkts"
+version = "0.2.0"
+source = { git = "https://github.com/harmony-contrib/tree-sitter-arkts.git?rev=9c7395bd9534cce840dd7115fd79be6c6ff45872#9c7395bd9534cce840dd7115fd79be6c6ff45872" }
 
 [[package]]
 name = "tree-sitter-c"


### PR DESCRIPTION
Register ArkTS in FM-Agent’s language registry and CodeGraph language mapping so .ets files use the pinned CodeGraph backend instead of the regex extractor. Add the ArkTS adapter for function extraction, function spans, and call edges, including TypeScript-compatible constructor edge handling while preserving the existing fallback behavior when CodeGraph is unavailable.