### PR TITLE
fix(spec): disambiguate qualified callee expectation matching

### DIFF
--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import logging
 import re
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
@@ -56,6 +57,12 @@ COMMENT_PREFIX_BY_LANG = {
 }
 
 _QUALIFIED_NAME_SEPARATOR_RE = re.compile(r"::|\.")
+_ERLANG_NAME_RE = re.compile(
+    r"^(?P<module>[A-Za-z_][\w@]*)\s*:\s*"
+    r"(?P<function>[A-Za-z_][\w@]*)/(?P<arity>\d+)$"
+)
+
+logger = logging.getLogger(__name__)
 
 
 def parse_args() -> argparse.Namespace:
@@ -138,6 +145,11 @@ def extract_callee_spec_from_info(
     names = _callee_match_names(callee_fqn, aliases or ())
     callees = info_dict.get("callees", [])
     if not isinstance(callees, list):
+        logger.warning(
+            "No callee expectation matched FQN %s (aliases=%s, entries=invalid)",
+            callee_fqn,
+            list(aliases or ()),
+        )
         return None
 
     named_callees = []
@@ -148,13 +160,14 @@ def extract_callee_spec_from_info(
         if not isinstance(name, str):
             continue
         normalized_name = _name_without_call_decoration(name)
-        named_callees.append((callee, name, normalized_name))
+        bare_name = _bare_name_for_matching(normalized_name)
+        named_callees.append((callee, name, normalized_name, bare_name))
 
-    for callee, name, _normalized_name in named_callees:
+    for callee, name, _normalized_name, _bare_name in named_callees:
         if _info_name_matches_fqn(name, callee_fqn):
             return callee
 
-    for callee, name, _normalized_name in named_callees:
+    for callee, name, _normalized_name, _bare_name in named_callees:
         if any(
             _info_name_matches_alias(name, alias)
             for alias in aliases or ()
@@ -163,14 +176,34 @@ def extract_callee_spec_from_info(
             return callee
 
     bare_names = [name for name in names if not _is_qualified_name(name)]
-    for callee, _name, normalized_name in named_callees:
-        if _is_qualified_name(normalized_name):
+    bare_name_counts = {}
+    for _callee, _name, _normalized_name, bare_name in named_callees:
+        if bare_name:
+            bare_name_counts[bare_name.casefold()] = (
+                bare_name_counts.get(bare_name.casefold(), 0) + 1
+            )
+    for callee, _name, normalized_name, bare_name in named_callees:
+        if not bare_name or bare_name_counts.get(bare_name.casefold(), 0) != 1:
+            continue
+        if _is_qualified_name(normalized_name) and not _qualified_source_name_compatible(
+            normalized_name, callee_fqn
+        ):
+            continue
+        if _erlang_name_parts(normalized_name) and not _erlang_name_matches_fqn(
+            normalized_name, callee_fqn
+        ):
             continue
         if any(
-            _info_line_mentions_name(normalized_name, candidate)
+            _info_line_mentions_name(bare_name, candidate)
             for candidate in bare_names
         ):
             return callee
+    logger.warning(
+        "No callee expectation matched FQN %s (aliases=%s, entries=%d)",
+        callee_fqn,
+        list(aliases or ()),
+        len(named_callees),
+    )
     return None
 
 
@@ -196,11 +229,11 @@ def _is_qualified_name(name: str) -> bool:
     return bool(_QUALIFIED_NAME_SEPARATOR_RE.search(name))
 
 
-def _name_without_call_decoration(name: str) -> str:
-    """Remove one balanced trailing call expression from a source name."""
+def _trailing_parenthesized_group(name: str) -> Optional[Tuple[str, str]]:
+    """Return the prefix and contents of one balanced trailing ``(...)`` group."""
     stripped = name.rstrip()
     if not stripped.endswith(")"):
-        return name
+        return None
 
     depth = 0
     for index in range(len(stripped) - 1, -1, -1):
@@ -210,15 +243,63 @@ def _name_without_call_decoration(name: str) -> str:
         elif char == "(":
             depth -= 1
             if depth == 0:
-                undecorated = stripped[:index].rstrip()
-                # ``operator()`` is a function name; only a following pair of
-                # parentheses represents a call decoration for that operator.
-                components = _QUALIFIED_NAME_SEPARATOR_RE.split(undecorated)
-                last_component = components[-1].strip()
-                if last_component == "operator" and stripped[index:] == "()":
-                    return name
-                return undecorated
-    return name
+                return stripped[:index].rstrip(), stripped[index + 1 : -1].strip()
+    return None
+
+
+def _name_without_call_decoration(name: str) -> str:
+    """Remove one balanced trailing call expression from a source name."""
+    group = _trailing_parenthesized_group(name)
+    if not group:
+        return name
+    undecorated, contents = group
+    # ``operator()`` is a function name; only a following pair of parentheses
+    # represents a call decoration for that operator.
+    components = _QUALIFIED_NAME_SEPARATOR_RE.split(undecorated)
+    if components[-1].strip() == "operator" and not contents:
+        return name
+    return undecorated
+
+
+def _is_operator_call_name(name: str) -> bool:
+    group = _trailing_parenthesized_group(name)
+    if not group or group[1]:
+        return False
+    components = _QUALIFIED_NAME_SEPARATOR_RE.split(group[0])
+    return components[-1].strip() == "operator"
+
+
+def _erlang_name_parts(name: str) -> Optional[Tuple[str, str, int]]:
+    match = _ERLANG_NAME_RE.fullmatch(name.strip())
+    if not match:
+        return None
+    return match.group("module"), match.group("function"), int(match.group("arity"))
+
+
+def _erlang_name_matches_fqn(info_name: str, callee_fqn: str) -> bool:
+    parts = _erlang_name_parts(info_name)
+    fqn_parts = [part for part in callee_fqn.split("::") if part]
+    if not parts or len(fqn_parts) < 2:
+        return False
+    module, function, _arity = parts
+    return (
+        module.casefold() == fqn_parts[-2].casefold()
+        and function.casefold() == fqn_parts[-1].casefold()
+    )
+
+
+def _bare_name_for_matching(name: str) -> str:
+    """Return the final source-level component used by safe bare fallback."""
+    erlang_parts = _erlang_name_parts(name)
+    if erlang_parts:
+        return erlang_parts[1]
+    source_candidates = _source_name_fqn_candidates(name)
+    if source_candidates:
+        return source_candidates[0].split("::")[-1]
+    if _is_qualified_name(name):
+        parts = _qualified_name_parts(name)
+        return _codegraph_source_component(parts[-1]) if parts else ""
+    return name.strip().split()[0] if name.strip() else ""
 
 
 def _codegraph_source_component(component: str) -> str:
@@ -338,6 +419,31 @@ def _source_name_fqn_candidates(name: str) -> List[str]:
     return list(dict.fromkeys(candidates))
 
 
+def _qualified_source_name_compatible(name: str, callee_fqn: str) -> bool:
+    """Allow bare fallback only when a qualified spelling has a compatible suffix."""
+    fqn_parts = [part for part in callee_fqn.split("::") if part]
+    for candidate in _source_name_fqn_candidates(name):
+        candidate_parts = [part for part in candidate.split("::") if part]
+        if len(candidate_parts) <= 1:
+            continue
+        candidate_tails = [candidate_parts]
+        # A pure C++ namespace prefix may be absent from CodeGraph's FQN. Do
+        # not apply this relaxation to dot-prefixed source names such as
+        # ``pkg.Class::method`` where dropping ``pkg`` changes the meaning.
+        if "." not in name:
+            candidate_tails.extend(
+                candidate_parts[start:]
+                for start in range(1, len(candidate_parts) - 1)
+            )
+        for tail in candidate_tails:
+            if len(tail) <= len(fqn_parts) and all(
+                left.casefold() == right.casefold()
+                for left, right in zip(fqn_parts[-len(tail) :], tail)
+            ):
+                return True
+    return False
+
+
 def _fqn_has_component_suffix(callee_fqn: str, candidate: str) -> bool:
     """Return whether candidate equals a complete ``::``-delimited FQN suffix."""
     callee_parts = callee_fqn.split("::")
@@ -353,32 +459,75 @@ def _fqn_has_component_suffix(callee_fqn: str, candidate: str) -> bool:
 
 def _info_name_matches_fqn(info_name: str, callee_fqn: str) -> bool:
     """Match a complete FQN or a source-language-qualified suffix."""
-    if info_name == callee_fqn:
-        return True
-    # Preserve literal FM-Agent FQN components, which may contain dots.
-    if "::" in info_name and _fqn_has_component_suffix(callee_fqn, info_name):
-        return True
-    info_name = _name_without_call_decoration(info_name)
-    if info_name == callee_fqn:
-        return True
-    if "::" in info_name and _fqn_has_component_suffix(callee_fqn, info_name):
-        return True
-    return any(
-        _fqn_has_component_suffix(callee_fqn, candidate)
-        for candidate in _source_name_fqn_candidates(info_name)
-    )
+    variants = [info_name]
+    undecorated = _name_without_call_decoration(info_name)
+    if undecorated != info_name:
+        variants.append(undecorated)
+    for variant in variants:
+        if variant == callee_fqn:
+            return True
+        # Preserve literal FM-Agent FQN components, which may contain dots.
+        if "::" in variant and _fqn_has_component_suffix(callee_fqn, variant):
+            return True
+        if _erlang_name_matches_fqn(variant, callee_fqn):
+            return True
+        # Do not let the component normalizer erase a remaining call layer.
+        # Literal suffix matching above still supports ``operator()`` and one
+        # preserved call decoration when the FQN contains it.
+        if _trailing_parenthesized_group(variant) and not _is_operator_call_name(variant):
+            continue
+        if any(
+            _fqn_has_component_suffix(callee_fqn, candidate)
+            for candidate in _source_name_fqn_candidates(variant)
+        ):
+            return True
+
+    group = _trailing_parenthesized_group(info_name)
+    if group:
+        prefix, label = group
+        fqn_parts = [part for part in callee_fqn.split("::") if part]
+        if (
+            label
+            and len(fqn_parts) >= 2
+            and label.casefold() == fqn_parts[-1].casefold()
+            and _bare_name_for_matching(prefix).casefold()
+            == fqn_parts[-2].casefold()
+        ):
+            return True
+    return False
 
 
 def _info_name_matches_alias(info_name: str, alias: str) -> bool:
     """Match an exact alias while accepting equivalent source qualifiers."""
-    if info_name == alias:
-        return True
-    info_name = _name_without_call_decoration(info_name)
-    if info_name == alias:
-        return True
-    if not _is_qualified_name(info_name) or not _is_qualified_name(alias):
-        return False
-    return _qualified_name_parts(info_name) == _qualified_name_parts(alias)
+    variants = [info_name]
+    undecorated = _name_without_call_decoration(info_name)
+    if undecorated != info_name:
+        variants.append(undecorated)
+    for variant in variants:
+        if variant == alias:
+            return True
+        if _erlang_name_parts(variant) and _erlang_name_parts(alias):
+            left = _erlang_name_parts(variant)
+            right = _erlang_name_parts(alias)
+            if left and right and left == right:
+                return True
+        if _is_qualified_name(variant) and _is_qualified_name(alias):
+            if _qualified_name_parts(variant) == _qualified_name_parts(alias):
+                return True
+
+    group = _trailing_parenthesized_group(info_name)
+    if group:
+        prefix, label = group
+        alias_parts = alias.split("::") if "::" in alias else _qualified_name_parts(alias)
+        if (
+            label
+            and len(alias_parts) >= 2
+            and label.casefold() == alias_parts[-1].casefold()
+            and _bare_name_for_matching(prefix).casefold()
+            == alias_parts[-2].casefold()
+        ):
+            return True
+    return False
 
 
 def _info_line_mentions_name(first_line: str, name: str) -> bool:

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -138,13 +138,27 @@ def extract_callee_spec_from_info(
     if not isinstance(callees, list):
         return None
 
+    named_callees = []
     for callee in callees:
         if not isinstance(callee, dict):
             continue
         name = callee.get("name", "")
         if not isinstance(name, str):
             continue
-        if any(_info_line_mentions_name(name, candidate) for candidate in names):
+        named_callees.append((callee, name))
+
+    for callee, name in named_callees:
+        if _info_name_matches_fqn(name, callee_fqn):
+            return callee
+
+    alias_names = {alias for alias in aliases or () if alias}
+    for callee, name in named_callees:
+        if name in alias_names:
+            return callee
+
+    bare_names = [name for name in names if "::" not in name]
+    for callee, name in named_callees:
+        if any(_info_line_mentions_name(name, candidate) for candidate in bare_names):
             return callee
     return None
 
@@ -158,6 +172,13 @@ def _callee_match_names(callee_fqn: str, aliases: Sequence[str]) -> List[str]:
         if "::" in alias:
             names.append(alias.rsplit("::", 1)[-1])
     return list(dict.fromkeys(names))
+
+
+def _info_name_matches_fqn(info_name: str, callee_fqn: str) -> bool:
+    """Match a complete FQN or a ``::``-qualified suffix of it."""
+    if info_name == callee_fqn:
+        return True
+    return "::" in info_name and callee_fqn.endswith(f"::{info_name}")
 
 
 def _info_line_mentions_name(first_line: str, name: str) -> bool:

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -147,13 +147,14 @@ def extract_callee_spec_from_info(
         name = callee.get("name", "")
         if not isinstance(name, str):
             continue
-        named_callees.append((callee, name))
+        normalized_name = _name_without_call_decoration(name)
+        named_callees.append((callee, name, normalized_name))
 
-    for callee, name in named_callees:
+    for callee, name, _normalized_name in named_callees:
         if _info_name_matches_fqn(name, callee_fqn):
             return callee
 
-    for callee, name in named_callees:
+    for callee, name, _normalized_name in named_callees:
         if any(
             _info_name_matches_alias(name, alias)
             for alias in aliases or ()
@@ -162,10 +163,13 @@ def extract_callee_spec_from_info(
             return callee
 
     bare_names = [name for name in names if not _is_qualified_name(name)]
-    for callee, name in named_callees:
-        if _is_qualified_name(name):
+    for callee, _name, normalized_name in named_callees:
+        if _is_qualified_name(normalized_name):
             continue
-        if any(_info_line_mentions_name(name, candidate) for candidate in bare_names):
+        if any(
+            _info_line_mentions_name(normalized_name, candidate)
+            for candidate in bare_names
+        ):
             return callee
     return None
 
@@ -192,11 +196,41 @@ def _is_qualified_name(name: str) -> bool:
     return bool(_QUALIFIED_NAME_SEPARATOR_RE.search(name))
 
 
+def _name_without_call_decoration(name: str) -> str:
+    """Remove one balanced trailing call expression from a source name."""
+    stripped = name.rstrip()
+    if not stripped.endswith(")"):
+        return name
+
+    depth = 0
+    for index in range(len(stripped) - 1, -1, -1):
+        char = stripped[index]
+        if char == ")":
+            depth += 1
+        elif char == "(":
+            depth -= 1
+            if depth == 0:
+                undecorated = stripped[:index].rstrip()
+                # ``operator()`` is a function name; only a following pair of
+                # parentheses represents a call decoration for that operator.
+                components = _QUALIFIED_NAME_SEPARATOR_RE.split(undecorated)
+                last_component = components[-1].strip()
+                if last_component == "operator" and stripped[index:] == "()":
+                    return name
+                return undecorated
+    return name
+
+
 def _info_name_matches_fqn(info_name: str, callee_fqn: str) -> bool:
     """Match a complete FQN or a source-language-qualified suffix."""
     if info_name == callee_fqn:
         return True
     # Preserve literal FM-Agent FQN components, which may contain dots.
+    if "::" in info_name and callee_fqn.endswith(f"::{info_name}"):
+        return True
+    info_name = _name_without_call_decoration(info_name)
+    if info_name == callee_fqn:
+        return True
     if "::" in info_name and callee_fqn.endswith(f"::{info_name}"):
         return True
     info_parts = _qualified_name_parts(info_name)
@@ -211,6 +245,9 @@ def _info_name_matches_fqn(info_name: str, callee_fqn: str) -> bool:
 
 def _info_name_matches_alias(info_name: str, alias: str) -> bool:
     """Match an exact alias while accepting equivalent source qualifiers."""
+    if info_name == alias:
+        return True
+    info_name = _name_without_call_decoration(info_name)
     if info_name == alias:
         return True
     if not _is_qualified_name(info_name) or not _is_qualified_name(alias):

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -141,7 +141,12 @@ def extract_callee_spec_from_info(
     callee_fqn: str,
     aliases: Optional[Sequence[str]] = None,
 ) -> Optional[dict]:
-    """Return the callee object matching the requested FQN or edge aliases."""
+    """Return the callee object matching the FQN or trusted edge aliases.
+
+    ``aliases`` must contain only names supplied by a supplemental edge's
+    ``callee.info_names``.  The matcher deliberately does not infer aliases
+    from the candidate entries in ``info_dict``.
+    """
     names = _callee_match_names(callee_fqn, aliases or ())
     callees = info_dict.get("callees", [])
     if not isinstance(callees, list):
@@ -185,10 +190,14 @@ def extract_callee_spec_from_info(
     for callee, _name, normalized_name, bare_name in named_callees:
         if not bare_name or bare_name_counts.get(bare_name.casefold(), 0) != 1:
             continue
-        if _is_qualified_name(normalized_name) and not _qualified_source_name_compatible(
-            normalized_name, callee_fqn
-        ):
-            continue
+        if _is_qualified_name(normalized_name):
+            # A source-qualified entry that failed the explicit FQN/alias
+            # passes must not be reduced to its final component: doing so can
+            # attach ``wrong::Class::method`` to ``src::Class::method``.
+            # ``self``/``this`` are receiver syntax, not namespaces; dotted
+            # member syntax is eligible only when its receiver names target.
+            if not _qualified_source_name_compatible(normalized_name, callee_fqn):
+                continue
         if _erlang_name_parts(normalized_name) and not _erlang_name_matches_fqn(
             normalized_name, callee_fqn
         ):
@@ -226,7 +235,19 @@ def _qualified_name_parts(name: str) -> List[str]:
 
 def _is_qualified_name(name: str) -> bool:
     """Return whether a source-level name contains a known qualifier."""
-    return bool(_QUALIFIED_NAME_SEPARATOR_RE.search(name))
+    angle_depth = 0
+    index = 0
+    while index < len(name):
+        char = name[index]
+        if char == "<":
+            angle_depth += 1
+        elif char == ">" and angle_depth:
+            angle_depth -= 1
+        elif angle_depth == 0:
+            if char == "." or name.startswith("::", index):
+                return True
+        index += 1
+    return False
 
 
 def _trailing_parenthesized_group(name: str) -> Optional[Tuple[str, str]]:
@@ -281,7 +302,23 @@ def _erlang_name_matches_fqn(info_name: str, callee_fqn: str) -> bool:
     fqn_parts = [part for part in callee_fqn.split("::") if part]
     if not parts or len(fqn_parts) < 2:
         return False
-    module, function, _arity = parts
+    module, function, arity = parts
+
+    # Erlang functions produced by the ELP adapter use an encoded final
+    # component: ``module__function__arity``.  Older metadata may instead
+    # expose ``module::function`` without an arity.  Compare arity whenever
+    # the FQN carries it, while retaining compatibility for the old form.
+    encoded = re.fullmatch(
+        r"(?P<module>[A-Za-z_][\w@]*)__(?P<function>[A-Za-z_][\w@]*)__(?P<arity>\d+)",
+        fqn_parts[-1],
+    )
+    if encoded:
+        return (
+            module.casefold() == encoded.group("module").casefold()
+            and function.casefold() == encoded.group("function").casefold()
+            and arity == int(encoded.group("arity"))
+        )
+
     return (
         module.casefold() == fqn_parts[-2].casefold()
         and function.casefold() == fqn_parts[-1].casefold()
@@ -299,7 +336,32 @@ def _bare_name_for_matching(name: str) -> str:
     if _is_qualified_name(name):
         parts = _qualified_name_parts(name)
         return _codegraph_source_component(parts[-1]) if parts else ""
-    return name.strip().split()[0] if name.strip() else ""
+    bare = name.strip().split()[0] if name.strip() else ""
+    # Template arguments decorate a function name but do not identify its
+    # callee for the safe bare fallback.  Canonicalizing here makes
+    # ``run<int>()`` and ``run<float>()`` collide instead of selecting the
+    # first entry based on incidental ordering.
+    if "<" in name:
+        # Look at the original spelling so spaces inside template arguments
+        # do not truncate the token before we canonicalize it.
+        template_start = name.find("<")
+        prefix = name[:template_start].strip()
+        if re.fullmatch(r"[A-Za-z_]\w*", prefix):
+            bare = prefix
+            return bare
+    if "<" in bare:
+        angle_depth = 0
+        end = None
+        for index, char in enumerate(bare):
+            if char == "<":
+                if angle_depth == 0:
+                    end = index
+                angle_depth += 1
+            elif char == ">" and angle_depth:
+                angle_depth -= 1
+        if end is not None and angle_depth == 0:
+            bare = bare[:end]
+    return bare
 
 
 def _codegraph_source_component(component: str) -> str:
@@ -382,6 +444,23 @@ def _normalized_source_name_parts(name: str) -> List[str]:
     # source decoration and must not be mistaken for that file marker.
     if _has_top_level_hyphen_before_final_component(name):
         return []
+    # Namespace separators inside template arguments do not qualify the
+    # function itself (for example, ``run<std::pair<int, float>>``).
+    angle_depth = 0
+    has_top_level_separator = False
+    index = 0
+    while index < len(name):
+        char = name[index]
+        if char == "<":
+            angle_depth += 1
+        elif char == ">" and angle_depth:
+            angle_depth -= 1
+        elif angle_depth == 0 and (char == "." or name.startswith("::", index)):
+            has_top_level_separator = True
+            break
+        index += 1
+    if not has_top_level_separator:
+        return []
     parts = _QUALIFIED_NAME_SEPARATOR_RE.split(name)
     if len(parts) <= 1 or any(not part.strip() for part in parts):
         return []
@@ -420,27 +499,27 @@ def _source_name_fqn_candidates(name: str) -> List[str]:
 
 
 def _qualified_source_name_compatible(name: str, callee_fqn: str) -> bool:
-    """Allow bare fallback only when a qualified spelling has a compatible suffix."""
+    """Allow only receiver/member spellings safe for bare fallback."""
+    parts = _qualified_name_parts(name)
+    if len(parts) == 2 and parts[0].strip().casefold() in {"self", "this"}:
+        return True
+
+    # Preserve the existing receiver/member spelling used by languages that
+    # write ``Engine.start`` while requiring its receiver to identify the same
+    # class as the target FQN.  This avoids treating arbitrary dotted names
+    # such as ``myself.run`` as pseudo-receivers.
     fqn_parts = [part for part in callee_fqn.split("::") if part]
-    for candidate in _source_name_fqn_candidates(name):
-        candidate_parts = [part for part in candidate.split("::") if part]
-        if len(candidate_parts) <= 1:
-            continue
-        candidate_tails = [candidate_parts]
-        # A pure C++ namespace prefix may be absent from CodeGraph's FQN. Do
-        # not apply this relaxation to dot-prefixed source names such as
-        # ``pkg.Class::method`` where dropping ``pkg`` changes the meaning.
-        if "." not in name:
-            candidate_tails.extend(
-                candidate_parts[start:]
-                for start in range(1, len(candidate_parts) - 1)
-            )
-        for tail in candidate_tails:
-            if len(tail) <= len(fqn_parts) and all(
-                left.casefold() == right.casefold()
-                for left, right in zip(fqn_parts[-len(tail) :], tail)
-            ):
-                return True
+    if (
+        len(parts) == 2
+        and len(fqn_parts) >= 2
+        and parts[0].strip().casefold() == fqn_parts[-2].casefold()
+        and parts[1].strip().casefold() == fqn_parts[-1].casefold()
+    ):
+        return True
+
+    # Qualified names have already had an exact/normalized suffix comparison
+    # opportunity.  Never trim arbitrary namespace components during the bare
+    # fallback: a shared tail is not evidence that the qualifiers agree.
     return False
 
 

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -55,6 +55,8 @@ COMMENT_PREFIX_BY_LANG = {
     "prolog": "%",
 }
 
+_QUALIFIED_NAME_SEPARATOR_RE = re.compile(r"::|\.")
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate spec batch prompts for one phase/layer range.")
@@ -151,14 +153,17 @@ def extract_callee_spec_from_info(
         if _info_name_matches_fqn(name, callee_fqn):
             return callee
 
-    alias_names = {alias for alias in aliases or () if alias}
     for callee, name in named_callees:
-        if name in alias_names:
+        if any(
+            _info_name_matches_alias(name, alias)
+            for alias in aliases or ()
+            if alias
+        ):
             return callee
 
-    bare_names = [name for name in names if "::" not in name]
+    bare_names = [name for name in names if not _is_qualified_name(name)]
     for callee, name in named_callees:
-        if "::" in name:
+        if _is_qualified_name(name):
             continue
         if any(_info_line_mentions_name(name, candidate) for candidate in bare_names):
             return callee
@@ -171,16 +176,46 @@ def _callee_match_names(callee_fqn: str, aliases: Sequence[str]) -> List[str]:
         if not alias:
             continue
         names.append(alias)
-        if "::" in alias:
-            names.append(alias.rsplit("::", 1)[-1])
+        alias_parts = _qualified_name_parts(alias)
+        if len(alias_parts) > 1:
+            names.append(alias_parts[-1])
     return list(dict.fromkeys(names))
 
 
+def _qualified_name_parts(name: str) -> List[str]:
+    """Split C++- and dot-qualified source names into components."""
+    return [part for part in _QUALIFIED_NAME_SEPARATOR_RE.split(name) if part]
+
+
+def _is_qualified_name(name: str) -> bool:
+    """Return whether a source-level name contains a known qualifier."""
+    return bool(_QUALIFIED_NAME_SEPARATOR_RE.search(name))
+
+
 def _info_name_matches_fqn(info_name: str, callee_fqn: str) -> bool:
-    """Match a complete FQN or a ``::``-qualified suffix of it."""
+    """Match a complete FQN or a source-language-qualified suffix."""
     if info_name == callee_fqn:
         return True
-    return "::" in info_name and callee_fqn.endswith(f"::{info_name}")
+    # Preserve literal FM-Agent FQN components, which may contain dots.
+    if "::" in info_name and callee_fqn.endswith(f"::{info_name}"):
+        return True
+    info_parts = _qualified_name_parts(info_name)
+    if len(info_parts) <= 1:
+        return False
+    fqn_parts = callee_fqn.split("::")
+    return (
+        len(info_parts) <= len(fqn_parts)
+        and fqn_parts[-len(info_parts) :] == info_parts
+    )
+
+
+def _info_name_matches_alias(info_name: str, alias: str) -> bool:
+    """Match an exact alias while accepting equivalent source qualifiers."""
+    if info_name == alias:
+        return True
+    if not _is_qualified_name(info_name) or not _is_qualified_name(alias):
+        return False
+    return _qualified_name_parts(info_name) == _qualified_name_parts(alias)
 
 
 def _info_line_mentions_name(first_line: str, name: str) -> bool:

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -158,6 +158,8 @@ def extract_callee_spec_from_info(
 
     bare_names = [name for name in names if "::" not in name]
     for callee, name in named_callees:
+        if "::" in name:
+            continue
         if any(_info_line_mentions_name(name, candidate) for candidate in bare_names):
             return callee
     return None

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -221,25 +221,151 @@ def _name_without_call_decoration(name: str) -> str:
     return name
 
 
+def _codegraph_source_component(component: str) -> str:
+    """Mirror CodeGraph's bare-name and FQN-safe normalization for one part."""
+    name = component.strip()
+    if not name:
+        return ""
+
+    tail = name
+    if "::" in tail:
+        tail = tail.rsplit("::", 1)[1].lstrip()
+    elif "." in tail:
+        tail = tail.rsplit(".", 1)[1].lstrip()
+
+    if tail.startswith("operator"):
+        rest = tail[len("operator") :].lstrip()
+        if rest.startswith("[]"):
+            return "operator[]"
+        if rest.startswith("()"):
+            return "operator()"
+        if re.fullmatch(r"new(?:\s*\[\s*\])?", rest):
+            return "operator new[]" if "[" in rest else "operator new"
+        if re.fullmatch(r"delete(?:\s*\[\s*\])?", rest):
+            return "operator delete[]" if "[" in rest else "operator delete"
+
+        symbol = []
+        for char in rest:
+            if char in "+-*/%&|^~!=<>,":
+                symbol.append(char)
+            else:
+                break
+        if symbol:
+            return ("operator" + "".join(symbol)).replace("/", "_")
+
+    match = re.search(r"(?:^|::|\.)(\w+)$", name)
+    if match:
+        return match.group(1)
+    match = re.match(r"\(\s*\*\s*(\w+)\s*\)", name)
+    if match:
+        return match.group(1)
+    match = re.match(r"\*\s*(\w+)", name)
+    if match:
+        return match.group(1)
+    match = re.match(r"^(\w+)", name)
+    if match:
+        return match.group(1)
+    return name.replace("/", "_")
+
+
+def _has_top_level_hyphen_before_final_component(name: str) -> bool:
+    """Distinguish a literal ``base-ext`` FQN prefix from template arguments."""
+    angle_depth = 0
+    top_level_hyphens: List[int] = []
+    last_separator = -1
+    index = 0
+    while index < len(name):
+        char = name[index]
+        if char == "<":
+            angle_depth += 1
+        elif char == ">" and angle_depth:
+            angle_depth -= 1
+        elif angle_depth == 0:
+            if name.startswith("::", index):
+                last_separator = index
+                index += 2
+                continue
+            if char == ".":
+                last_separator = index
+            elif char == "-":
+                top_level_hyphens.append(index)
+        index += 1
+    return any(position < last_separator for position in top_level_hyphens)
+
+
+def _normalized_source_name_parts(name: str) -> List[str]:
+    """Return CodeGraph-shaped parts for one source-qualified spelling."""
+    # FM-Agent's file component uses ``base-ext`` and is not source syntax.
+    # It must stay on the literal-prefix side of a mixed candidate boundary.
+    # A hyphen inside a template argument (for example, ``Widget<-1>``) is
+    # source decoration and must not be mistaken for that file marker.
+    if _has_top_level_hyphen_before_final_component(name):
+        return []
+    parts = _QUALIFIED_NAME_SEPARATOR_RE.split(name)
+    if len(parts) <= 1 or any(not part.strip() for part in parts):
+        return []
+    normalized_parts = [_codegraph_source_component(part) for part in parts]
+    if any(not part for part in normalized_parts):
+        return []
+    return normalized_parts
+
+
+def _source_name_fqn_candidates(name: str) -> List[str]:
+    """Return complete source and literal-FQN-prefix interpretations of a name."""
+    candidates: List[str] = []
+
+    # Treat the complete spelling as a source-qualified name. This covers pure
+    # ``::``, pure dot, and mixed source scopes, including template arguments
+    # whose namespaces become separate CodeGraph components.
+    normalized_parts = _normalized_source_name_parts(name)
+    if normalized_parts:
+        candidates.append("::".join(normalized_parts))
+
+    # A leading FM-Agent FQN component may contain literal dots (for example,
+    # ``foo.test-go``). At every explicit FQN boundary, preserve the prefix and
+    # independently interpret the remaining qualified tail as source spelling.
+    for boundary in re.finditer(r"::", name):
+        literal_prefix = name[: boundary.start()].strip()
+        source_tail = name[boundary.end() :].strip()
+        if not literal_prefix or not source_tail:
+            continue
+        if any(not part.strip() for part in literal_prefix.split("::")):
+            continue
+        normalized_tail_parts = _normalized_source_name_parts(source_tail)
+        if normalized_tail_parts:
+            normalized_tail = "::".join(normalized_tail_parts)
+            candidates.append(f"{literal_prefix}::{normalized_tail}")
+    return list(dict.fromkeys(candidates))
+
+
+def _fqn_has_component_suffix(callee_fqn: str, candidate: str) -> bool:
+    """Return whether candidate equals a complete ``::``-delimited FQN suffix."""
+    callee_parts = callee_fqn.split("::")
+    candidate_parts = candidate.split("::")
+    return (
+        bool(candidate_parts)
+        and all(callee_parts)
+        and all(candidate_parts)
+        and len(candidate_parts) <= len(callee_parts)
+        and callee_parts[-len(candidate_parts) :] == candidate_parts
+    )
+
+
 def _info_name_matches_fqn(info_name: str, callee_fqn: str) -> bool:
     """Match a complete FQN or a source-language-qualified suffix."""
     if info_name == callee_fqn:
         return True
     # Preserve literal FM-Agent FQN components, which may contain dots.
-    if "::" in info_name and callee_fqn.endswith(f"::{info_name}"):
+    if "::" in info_name and _fqn_has_component_suffix(callee_fqn, info_name):
         return True
     info_name = _name_without_call_decoration(info_name)
     if info_name == callee_fqn:
         return True
-    if "::" in info_name and callee_fqn.endswith(f"::{info_name}"):
+    if "::" in info_name and _fqn_has_component_suffix(callee_fqn, info_name):
         return True
-    info_parts = _qualified_name_parts(info_name)
-    if len(info_parts) <= 1:
-        return False
-    fqn_parts = callee_fqn.split("::")
-    return (
-        len(info_parts) <= len(fqn_parts)
-        and fqn_parts[-len(info_parts) :] == info_parts
+    return any(
+        _fqn_has_component_suffix(callee_fqn, candidate)
+        for candidate in _source_name_fqn_candidates(info_name)
     )
 
 

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -467,6 +467,8 @@ def _add_resolved_extra_edge(
 
     before = len(all_callees_map[caller_fqn])
     all_callees_map[caller_fqn].add(callee_fqn)
+    # Preserve only the explicit aliases supplied by this supplemental edge;
+    # the prompt matcher treats these as trusted evidence for qualified names.
     edge_aliases_map[callee_fqn][caller_fqn].update(edge.info_names)
 
     if callee_fqn in phase_fqns:

--- a/src/incremental_reasoner.py
+++ b/src/incremental_reasoner.py
@@ -1773,6 +1773,8 @@ def _collect_caller_context(fqn, callers_map, file_map, edge_aliases_map=None):
         info_dict = extract_info_block(cpath_p)
         aliases = ()
         if edge_aliases_map:
+            # These are edge-scoped callee.info_names from supplemental edges,
+            # not names inferred from the caller's .info.json candidates.
             aliases = tuple(edge_aliases_map.get(fqn, {}).get(caller_fqn, ()))
         callee_entry = (
             extract_callee_spec_from_info(info_dict, fqn, aliases)


### PR DESCRIPTION
## Summary

- Prioritize exact FQN and qualified-suffix matches when resolving caller expectations.
- Support both C++-style `Class::method` and dot-qualified `Class.method` names.
- Match explicit `callee.info_names` aliases before attempting bare-name fallback.
- Prevent qualified entries from being incorrectly selected through bare-name matching.
- Preserve literal dots inside FM-Agent FQN components such as `foo.test-py`.


Closes #213