### PR TITLE
feat(chip): add plugin-driven Chisel and Verilog specification generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!tools/chisel-circt/lib/
+!tools/chisel-circt/lib/**
 lib64/
 parts/
 sdist/

--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ Erlang support is optional because its toolchain is not needed for other languag
 
 The Erlang option uses Homebrew on macOS and the RabbitMQ Team Erlang PPA on Ubuntu when the system OTP is missing or too old. The Ubuntu configuration has been tested with Erlang/OTP 26+; the macOS Erlang configuration has not been tested and uses the current formula versions selected by Homebrew. On Linux, rebar3 and ELP are installed into `~/.local/bin`; ensure this directory is on `PATH` in new shells. You can still install these tools manually, verify `rebar3 version` and `elp version`, and set `ELP_COMMAND` to an absolute ELP path if needed.
 
+Chisel projects can be analyzed with the built-in `chip` pipeline plugin using
+source analysis alone. Direct elaborated-module analysis through CIRCT is an
+optional enhancement. To build a pinned `firtool` and the matching FM-Agent
+pass plugin, run:
+
+```bash
+./install.sh --with-chisel
+```
+
+This checkout and build can be large; it is not required for Verilog or for
+the Chisel source fallback. See
+[`tools/chisel-circt/README.md`](tools/chisel-circt/README.md) for the CIRCT
+input and environment-variable contract.
+
 FM-Agent configures OpenCode's provider automatically from `fm-agent.toml`, so
 you do not need to hand-edit `~/.config/opencode/opencode.json` for the model
 or key. The configuration wizard above can still keep that file synchronized for
@@ -234,6 +248,20 @@ def hook(proj_dir: str) -> None:
 
 See [Pipeline Plugins](docs/plugins.md) for the plugin layout, JSON
 configuration, execution modes, lifecycle, and trust boundary.
+
+The built-in `chip` plugin generates standalone hardware module specifications
+for Chisel or Verilog/SystemVerilog projects:
+
+```bash
+uv run python main.py <proj_dir> --plugin chip
+```
+
+It selects one dialect from the in-scope file extensions, prefers Chisel when
+both dialects are present, and writes `_spec.md` / `_info.md` artifacts beside
+each extracted module under `fm_agent/extracted_functions/`. Use a narrower
+`proj_dir` or `--submodule` for a hardware subtree in a mixed repository. See
+[the chip plugin documentation](docs/plugins.md#built-in-chip-plugin) for
+supported extensions, optional backends, validation rules, and limitations.
 
 `proj_dir` must be a git repository.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -128,6 +128,18 @@ Erlang 工具链不影响其他语言，因此默认不安装。如需自动安�
 
 该选项在 macOS 上使用 Homebrew；在 Ubuntu 上，当系统 OTP 缺失或版本过低时使用 RabbitMQ Team Erlang PPA。Ubuntu 配置已使用 Erlang/OTP 26+ 验证；macOS Erlang 配置尚未测试，将使用 Homebrew 选择的当前公式版本。Linux 下的 rebar3 和 ELP 会安装到 `~/.local/bin`，请确保新终端的 `PATH` 包含该目录。你也可以手动安装这些工具，确认 `rebar3 version` 和 `elp version` 可执行，并在需要时将 `ELP_COMMAND` 设置为 ELP 的绝对路径。
 
+Chisel 项目可以直接通过内置 `chip` Pipeline 插件使用源码分析。基于 CIRCT
+的 elaborated module 分析是可选增强；如需构建固定版本的 `firtool` 及与其匹配
+的 FM-Agent pass plugin，运行：
+
+```bash
+./install.sh --with-chisel
+```
+
+CIRCT checkout 和构建体积可能较大；Verilog 和 Chisel source fallback 都不依赖
+它。CIRCT 输入与环境变量契约见
+[`tools/chisel-circt/README.md`](tools/chisel-circt/README.md)。
+
 FM-Agent 会从 `fm-agent.toml` 自动配置 OpenCode 的 provider，因此无需手动编辑 `~/.config/opencode/opencode.json` 来设置模型或密钥。上面的配置向导仍然可以把该文件同步好，并把 API 密钥写入用户状态/配置目录下按 provider 区分的私有本地文件，方便独立使用 OpenCode（见 [docs/config_llm.md](docs/config_llm.md)）。
 如果你已经设置了 `OPENCODE_CONFIG`，向导会优先更新那个文件，而不是默认的全局路径。若未设置该变量但设置了 `OPENCODE_CONFIG_DIR`，向导会更新该目录中的 `opencode.jsonc`（存在时）或 `opencode.json`。
 
@@ -183,6 +195,19 @@ def hook(proj_dir: str) -> None:
 
 插件目录结构、JSON 配置、执行模式、生命周期和信任边界参见
 [Pipeline 插件](docs/plugins_zh.md)。
+
+内置 `chip` 插件可为 Chisel 或 Verilog/SystemVerilog 项目生成独立的硬件模块
+规约：
+
+```bash
+uv run python main.py <proj_dir> --plugin chip
+```
+
+插件根据当前范围内的文件扩展名选择一种方言；两类文件同时存在时优先选择
+Chisel。每个提取模块的 `_spec.md` / `_info.md` 会写到
+`fm_agent/extracted_functions/` 中。混合仓库应使用更窄的 `proj_dir` 或
+`--submodule` 指向目标硬件子树。支持的扩展名、可选 backend、校验规则和限制见
+[chip 插件说明](docs/plugins_zh.md#内置-chip-插件)。
 
 `proj_dir` 必须是一个 git 仓库。
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -183,6 +183,14 @@ from a stage hook, or at any other time fails. Each `run_pipeline()` call starts
 with a new software-default configuration, and FM-Agent validates the final
 form, form identity, schema version, and reasoning flag after the hook returns.
 
+The current reasoning and bug-validation backend only supports the exact
+built-in `SoftwareSpecForm` type and its `.spec.json` / `.info.json` artifacts.
+Any form whose concrete type is not exactly `SoftwareSpecForm`, including a
+subclass or another plugin-owned implementation, must set
+`enable_reasoning=False`; otherwise configuration fails before Stage 1. This
+compatibility check also applies when the command uses `--only-spec`, which is
+a per-run execution override rather than a different plugin strategy.
+
 ## Resume, isolate, and incremental runs
 
 Modify hooks run whenever execution reaches their stage boundary. They still

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -159,6 +159,30 @@ The file is rewritten for every fresh, resume, or isolate pipeline call. The
 configure hook runs once per `run_pipeline()` call before Stage 1. FM-Agent
 still writes the context when no configure hook is declared.
 
+### Configuring the specification strategy
+
+A configure hook may select a plugin-owned specification form for the built-in
+Stage 6. Assuming `CUSTOM_SPEC_FORM` is a `SpecForm` instance defined or imported
+by the plugin:
+
+```python
+from src.spec_forms import configure_current_spec_generation
+
+
+def configure(proj_dir: str) -> None:
+    del proj_dir
+    configure_current_spec_generation(
+        spec_form=CUSTOM_SPEC_FORM,
+        enable_reasoning=False,
+    )
+```
+
+`configure_current_spec_generation()` is available only while FM-Agent is
+executing the declared configure hook. Calling it while importing `plugin.py`,
+from a stage hook, or at any other time fails. Each `run_pipeline()` call starts
+with a new software-default configuration, and FM-Agent validates the final
+form, form identity, schema version, and reasoning flag after the hook returns.
+
 ## Resume, isolate, and incremental runs
 
 Modify hooks run whenever execution reaches their stage boundary. They still
@@ -180,7 +204,10 @@ FM-Agent checks that:
 - stage names, modes, and field combinations are supported;
 - `plugin.py` exists and imports successfully;
 - declared objects exist, are callable, and have the exact hook signature;
-- hooks do not raise and their actual return values are `None`.
+- hooks do not raise and their actual return values are `None`;
+- a specification strategy configured by the configure hook has a valid
+  `SpecForm`, non-empty form identity and schema version, and a boolean reasoning
+  flag.
 
 FM-Agent does not check:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -191,6 +191,65 @@ subclass or another plugin-owned implementation, must set
 compatibility check also applies when the command uses `--only-spec`, which is
 a per-run execution override rather than a different plugin strategy.
 
+## Built-in chip plugin
+
+The `chip` plugin runs the standard Stage 1–6 specification pipeline for one
+hardware dialect:
+
+```bash
+uv run python main.py <proj_dir> --plugin chip
+```
+
+It recognizes these project files:
+
+| Dialect | Extensions |
+| --- | --- |
+| Chisel | `.scala`, `.sc` |
+| Verilog/SystemVerilog | `.v`, `.sv`, `.svh` |
+
+The plugin scans the selected `proj_dir` / `--submodule` scope once before
+Stage 1 and writes the result to `fm_agent/chip_context.json`. Chisel is chosen
+when at least one Chisel file is present. If Verilog files are also present,
+the run remains Chisel-only and emits a warning. A Verilog run is selected only
+when the scope contains Verilog files and no Chisel files. Point `proj_dir` or
+`--submodule` at a narrower hardware subtree when this default is not the
+intended boundary.
+
+Chisel extraction identifies `Module`, `RawModule`, `BlackBox`, `ExtModule`,
+and `MultiIOModule` declarations. It uses conservative source analysis by
+default. When `FM_AGENT_CHISEL_CIRCT_INPUT` names elaborated `.fir` or `.mlir`
+input, it attempts the direct CIRCT pass and falls back to source analysis if
+the optional toolchain cannot run. `./install.sh --with-chisel` installs a
+pinned `firtool` and matching pass plugin; the complete settings are documented
+in [`tools/chisel-circt/README.md`](../tools/chisel-circt/README.md).
+
+Verilog/SystemVerilog extraction prefers `verible-verilog-syntax` when it is
+available on `PATH` and falls back to a conservative source scanner otherwise.
+Set `FM_AGENT_NO_VERIBLE=1` to force the fallback for diagnosis or comparison.
+
+Each extracted module receives sibling Markdown artifacts:
+
+- `<Module>_spec.md` describes its observable interface and behavioral
+  contract using the FG/FC/CK coverage structure and mandatory `<FG-API>`.
+- `<Module>_info.md` records caller-visible expectations for each direct
+  instantiated module, or `(no submodules)` for a leaf.
+
+Missing dependency coverage is advisory for Chisel because source-level Scala
+analysis may not see dynamic elaboration. It is blocking for Verilog when the
+registered language service provides a direct module edge. The chip forms
+disable the current software-only reasoning and bug-validation backend, so a
+successful run ends after hardware specifications are generated and checked.
+
+Current limitations:
+
+- one run never mixes Chisel and Verilog specification units;
+- there is no CLI dialect override; narrow the input scope instead;
+- resume semantics are not supported for chip runs;
+- Scala metaprogramming and dynamic Chisel elaboration can exceed source
+  analysis; use the direct CIRCT backend when an elaborated input is available;
+- generated exact-cycle and protocol claims should be reviewed against RTL,
+  especially when the source diverges from a named protocol convention.
+
 ## Resume, isolate, and incremental runs
 
 Modify hooks run whenever execution reaches their stage boundary. They still

--- a/docs/plugins_zh.md
+++ b/docs/plugins_zh.md
@@ -174,6 +174,13 @@ def configure(proj_dir: str) -> None:
 `run_pipeline()` 都从新的软件默认配置开始；configure Hook 返回后，FM-Agent
 会验证最终 SpecForm、form identity、schema version 和 reasoning 开关。
 
+当前 reasoning 和 Bug Validation backend 只支持精确的内置
+`SoftwareSpecForm` 类型及其 `.spec.json` / `.info.json` 产物。具体类型不是
+`SoftwareSpecForm` 的 form（包括其子类或其他插件自有实现）必须设置
+`enable_reasoning=False`，否则配置会在 Stage 1 前失败。即使命令使用
+`--only-spec`，该兼容性校验仍然执行；`--only-spec` 是单次运行的执行覆盖，
+不是另一种插件策略。
+
 ## Resume、isolate 与 incremental
 
 执行到 Stage 边界时 Modify Hook 就会运行。即使内置 Stage 在 resume 中复用

--- a/docs/plugins_zh.md
+++ b/docs/plugins_zh.md
@@ -152,6 +152,28 @@ fresh、resume 和 isolate 的每次 Pipeline 调用都会重写上下文。conf
 Stage 1 前、每次 `run_pipeline()` 调用中执行一次。未声明 configure Hook 时仍会
 写入上下文文件。
 
+### 配置规约生成策略
+
+configure Hook 可以为内置 Stage 6 选择插件自有的 SpecForm。假设 `CUSTOM_SPEC_FORM`
+是插件定义或导入的 `SpecForm` 实例：
+
+```python
+from src.spec_forms import configure_current_spec_generation
+
+
+def configure(proj_dir: str) -> None:
+    del proj_dir
+    configure_current_spec_generation(
+        spec_form=CUSTOM_SPEC_FORM,
+        enable_reasoning=False,
+    )
+```
+
+`configure_current_spec_generation()` 只在 FM-Agent 执行已声明的 configure Hook
+期间可用。在导入 `plugin.py` 时、Stage Hook 中或其他时机调用都会失败。每次
+`run_pipeline()` 都从新的软件默认配置开始；configure Hook 返回后，FM-Agent
+会验证最终 SpecForm、form identity、schema version 和 reasoning 开关。
+
 ## Resume、isolate 与 incremental
 
 执行到 Stage 边界时 Modify Hook 就会运行。即使内置 Stage 在 resume 中复用
@@ -171,7 +193,9 @@ FM-Agent 检查：
 - Stage 名称、模式和字段组合合法；
 - `plugin.py` 存在且可以导入；
 - 声明的对象存在、可调用并具有精确 Hook 签名；
-- Hook 不抛出异常且实际返回值为 `None`。
+- Hook 不抛出异常且实际返回值为 `None`；
+- configure Hook 配置的规约策略具有合法的 `SpecForm`、非空 form identity 和
+  schema version，以及布尔类型的 reasoning 开关。
 
 FM-Agent 不检查：
 

--- a/docs/plugins_zh.md
+++ b/docs/plugins_zh.md
@@ -181,6 +181,61 @@ def configure(proj_dir: str) -> None:
 `--only-spec`，该兼容性校验仍然执行；`--only-spec` 是单次运行的执行覆盖，
 不是另一种插件策略。
 
+## 内置 chip 插件
+
+`chip` 插件针对单一硬件方言运行标准 Stage 1–6 规约生成流程：
+
+```bash
+uv run python main.py <proj_dir> --plugin chip
+```
+
+支持以下项目文件：
+
+| 方言 | 扩展名 |
+| --- | --- |
+| Chisel | `.scala`、`.sc` |
+| Verilog/SystemVerilog | `.v`、`.sv`、`.svh` |
+
+插件在 Stage 1 前只扫描一次所选 `proj_dir` / `--submodule` 范围，并把结果写入
+`fm_agent/chip_context.json`。只要范围内存在 Chisel 文件就选择 Chisel；如果
+同时存在 Verilog 文件，本次运行仍然只分析 Chisel，并输出警告。只有存在
+Verilog 文件且不存在 Chisel 文件时才选择 Verilog。若该默认边界不符合预期，
+请把 `proj_dir` 或 `--submodule` 指向更窄的硬件子树。
+
+Chisel 提取支持 `Module`、`RawModule`、`BlackBox`、`ExtModule` 和
+`MultiIOModule` 声明，默认使用保守的源码分析。当
+`FM_AGENT_CHISEL_CIRCT_INPUT` 指向 elaborated `.fir` 或 `.mlir` 输入时，插件会
+尝试 direct CIRCT pass；可选工具链无法运行时自动回退到源码分析。
+`./install.sh --with-chisel` 可安装固定版本的 `firtool` 和与其匹配的 pass
+plugin；完整设置见
+[`tools/chisel-circt/README.md`](../tools/chisel-circt/README.md)。
+
+Verilog/SystemVerilog 提取会优先使用 `PATH` 中的
+`verible-verilog-syntax`，不可用时回退到保守源码扫描。诊断或对比时可设置
+`FM_AGENT_NO_VERIBLE=1` 强制使用 fallback。
+
+每个提取模块生成两个相邻 Markdown 产物：
+
+- `<Module>_spec.md` 使用 FG/FC/CK coverage 结构和必需的 `<FG-API>` 描述可观察
+  接口与行为契约；
+- `<Module>_info.md` 记录父模块对每个直接实例化子模块的要求；叶模块写
+  `(no submodules)`。
+
+Chisel 源码分析可能无法看到动态 elaboration，因此缺失依赖覆盖仅作为
+advisory。对于语言服务提供的直接 Verilog 模块边，缺失依赖覆盖会阻塞产物通过。
+chip SpecForm 会关闭当前仅支持软件规约的 reasoning 和 Bug Validation backend，
+因此成功运行会在硬件规约生成和校验完成后结束。
+
+当前限制：
+
+- 单次运行不会混合 Chisel 与 Verilog 规约单元；
+- 没有 CLI 方言覆盖选项，需要通过缩小输入范围调整；
+- chip run 不支持 resume 语义；
+- Scala 元编程和动态 Chisel elaboration 可能超出源码分析能力；有 elaborated
+  输入时应使用 direct CIRCT backend；
+- 生成的精确周期和协议语义仍需对照 RTL 人工检查，尤其是源码行为偏离命名协议
+  惯例的情况。
+
 ## Resume、isolate 与 incremental
 
 执行到 Stage 边界时 Modify Hook 就会运行。即使内置 Stage 在 resume 中复用

--- a/install.sh
+++ b/install.sh
@@ -4,19 +4,24 @@ set -euo pipefail
 echo "=== fm-agent: installing required software ==="
 
 INSTALL_ERLANG_SUPPORT=0
+INSTALL_CHISEL_SUPPORT=0
 for arg in "$@"; do
     case "$arg" in
         --with-erlang)
             INSTALL_ERLANG_SUPPORT=1
             ;;
+        --with-chisel)
+            INSTALL_CHISEL_SUPPORT=1
+            ;;
         -h|--help)
-            echo "Usage: ./install.sh [--with-erlang]"
+            echo "Usage: ./install.sh [--with-erlang] [--with-chisel]"
             echo "  --with-erlang  Install/verify Erlang/OTP 26+, rebar3 3.24.0+, and ELP"
+            echo "  --with-chisel  Install/verify CIRCT firtool and the FM-Agent Chisel pass plugin"
             exit 0
             ;;
         *)
             echo "[!!] unknown option: $arg"
-            echo "Usage: ./install.sh [--with-erlang]"
+            echo "Usage: ./install.sh [--with-erlang] [--with-chisel]"
             exit 1
             ;;
     esac
@@ -252,6 +257,82 @@ print(max(candidates)[2])
     export PATH="$HOME/.local/bin:$PATH"
 }
 
+install_circt_and_chisel_tool() {
+    local circt_root circt_src circt_build tool_build parallel_jobs plugin_path
+    local circt_revision circt_commit
+    circt_root="${FM_AGENT_CIRCT_ROOT:-$HOME/.cache/fm-agent/circt}"
+    circt_src="$circt_root/src"
+    parallel_jobs="${FM_AGENT_CIRCT_JOBS:-1}"
+    circt_revision="${FM_AGENT_CIRCT_REVISION:-0dc3e50e63db2d502e6f97161592cb1032df55f4}"
+
+    command -v git &>/dev/null || { echo "[!!] git is required for CIRCT support"; exit 1; }
+    command -v cmake &>/dev/null || { echo "[!!] cmake is required for CIRCT support"; exit 1; }
+    command -v ninja &>/dev/null || { echo "[!!] ninja is required for CIRCT support"; exit 1; }
+    command -v c++ &>/dev/null || { echo "[!!] a C++ compiler is required for CIRCT support"; exit 1; }
+
+    mkdir -p "$circt_root"
+    if [[ ! -d "$circt_src/.git" ]]; then
+        echo "[..] initializing llvm/circt source cache"
+        mkdir -p "$circt_src"
+        git -C "$circt_src" init --quiet
+        git -C "$circt_src" remote add origin https://github.com/llvm/circt.git
+    else
+        echo "[ok] CIRCT source found: $circt_src"
+    fi
+
+    if ! git -C "$circt_src" cat-file -e "$circt_revision^{commit}" 2>/dev/null; then
+        echo "[..] fetching CIRCT revision $circt_revision"
+        git -C "$circt_src" fetch --depth 1 origin "$circt_revision"
+        circt_revision="$(git -C "$circt_src" rev-parse 'FETCH_HEAD^{commit}')"
+    fi
+    git -C "$circt_src" checkout --detach "$circt_revision"
+    git -C "$circt_src" submodule sync --recursive
+    git -C "$circt_src" submodule update --init --depth 1 --recursive
+    circt_commit="$(git -C "$circt_src" rev-parse HEAD)"
+    circt_build="$circt_root/build-${circt_commit:0:12}"
+    tool_build="$circt_root/fm-agent-chisel-build-${circt_commit:0:12}"
+    echo "[ok] CIRCT revision: $circt_commit"
+
+    if [[ ! -f "$circt_build/lib/cmake/circt/CIRCTConfig.cmake" ]]; then
+        echo "[..] configuring CIRCT"
+        cmake -G Ninja "$circt_src/llvm/llvm" -B "$circt_build" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DLLVM_TARGETS_TO_BUILD=host \
+            -DLLVM_ENABLE_PROJECTS=mlir \
+            -DLLVM_EXTERNAL_PROJECTS=circt \
+            -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR="$circt_src"
+    fi
+
+    if [[ ! -x "$circt_build/bin/firtool" ]]; then
+        echo "[..] building CIRCT firtool"
+        ninja -C "$circt_build" -j"$parallel_jobs" bin/firtool
+    fi
+
+    echo "[..] configuring FM-Agent Chisel CIRCT plugin"
+    cmake -G Ninja -S "$SCRIPT_DIR/tools/chisel-circt" -B "$tool_build" \
+        -DCIRCT_DIR="$circt_build/lib/cmake/circt" \
+        -DMLIR_DIR="$circt_build/lib/cmake/mlir" \
+        -DLLVM_DIR="$circt_build/lib/cmake/llvm"
+
+    echo "[..] building FM-Agent Chisel CIRCT plugin"
+    ninja -C "$tool_build" -j"$parallel_jobs" FMAgentChiselCirctPlugin
+
+    mkdir -p "$HOME/.local/bin" "$HOME/.local/lib"
+    install -m 0755 "$circt_build/bin/firtool" "$HOME/.local/bin/firtool"
+    plugin_path="$(find "$tool_build" -type f \( \
+        -name 'libFMAgentChiselCirctPlugin.so' -o \
+        -name 'FMAgentChiselCirctPlugin.so' -o \
+        -name 'libFMAgentChiselCirctPlugin.dylib' -o \
+        -name 'FMAgentChiselCirctPlugin.dylib' \) -print -quit)"
+    [[ -n "$plugin_path" ]] || {
+        echo "[!!] Chisel CIRCT plugin build succeeded but no plugin library was found"
+        exit 1
+    }
+    install -m 0755 "$plugin_path" "$HOME/.local/lib/$(basename "$plugin_path")"
+    export PATH="$HOME/.local/bin:$PATH"
+}
+
 if [[ "$INSTALL_ERLANG_SUPPORT" -eq 1 ]]; then
     echo "[..] installing/verifying optional Erlang support"
     os_name="$(uname -s)"
@@ -323,6 +404,14 @@ if [[ "$INSTALL_ERLANG_SUPPORT" -eq 1 ]]; then
     echo "[ok] Erlang/OTP $installed_otp"
     echo "[ok] rebar3 $installed_rebar"
     echo "[ok] $(elp version)"
+fi
+
+if [[ "$INSTALL_CHISEL_SUPPORT" -eq 1 ]]; then
+    echo "[..] installing/verifying optional Chisel/CIRCT support"
+    install_circt_and_chisel_tool
+    command -v firtool &>/dev/null || { echo "[!!] firtool was not installed"; exit 1; }
+    echo "[ok] firtool installed"
+    echo "[ok] FM-Agent Chisel CIRCT plugin installed"
 fi
 
 echo ""

--- a/main.py
+++ b/main.py
@@ -187,6 +187,10 @@ def run_pipeline(
     if not os.path.isdir(proj_dir):
         print(f"[Pipeline] ERROR: proj_dir does not exist or is not a directory: {proj_dir}")
         sys.exit(1)
+    # Keep programmatic callers on the same normalized scope contract as the
+    # CLI. Chip plugin hooks read this persisted value because their public
+    # hook signature intentionally remains (proj_dir) -> None.
+    submodules = _normalize_submodules(proj_dir, submodules)
     # A plugin may support source languages that are intentionally not in the
     # built-in registry yet. Its configure hook owns the corresponding
     # pre-Stage-1 validation (the chip plugin detects Chisel/Verilog here).
@@ -232,8 +236,10 @@ def run_pipeline(
     _print_preflight_summary(estimate, estimate_path)
     if plugin_config is not None:
         plugin_context_path = os.path.join(work_dir, "plugin_context.json")
+        effective_plugin_context = dict(plugin_context or {})
+        effective_plugin_context["submodules"] = list(submodules or [])
         with open(plugin_context_path, "w", encoding="utf-8") as file:
-            json.dump(plugin_context or {}, file, indent=2)
+            json.dump(effective_plugin_context, file, indent=2)
         if plugin_config.configure_hook is not None:
             with _bind_spec_generation_config(spec_generation_config):
                 run_plugin_hook(
@@ -756,6 +762,7 @@ if __name__ == "__main__":
         extra_call_edges_path = os.path.abspath(extra_call_edges_path)
     plugin_context = {
         "extra_edge": extra_call_edges_path,
+        "submodules": [],
     }
     try:
         bug_validator_path = _resolve_bug_validator_path(args.bug_validator)
@@ -765,6 +772,7 @@ if __name__ == "__main__":
         submodules = _normalize_submodules(proj_dir, args.submodule)
     except ValueError as exc:
         parser.error(str(exc))
+    plugin_context["submodules"] = list(submodules)
 
     try:
         domain_knowledge_files = collect_domain_knowledge_paths(

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from src.verification import _generate_all_bugs_validation_summary
 from src.extract import run_extraction, EXT_TO_LANG
 from src.generate_topdown_layers import generate_topdown_layers
 from src.spec_generation_and_verification import run_spec_generation_and_verification
+from src.spec_forms import SOFTWARE_SPEC_FORM, SpecGenerationConfig
 from src.incremental_reasoner import run_incremental_pipeline
 from src.git import (
     frozen_worktree,
@@ -190,6 +191,10 @@ def run_pipeline(
     output_dir = os.path.join(work_dir, "logic_verification_results")
     script_dir = os.path.dirname(os.path.abspath(__file__))
     extra_call_edges = load_call_edges(extra_call_edges_path)
+    spec_generation_config = SpecGenerationConfig(
+        spec_form=SOFTWARE_SPEC_FORM,
+        enable_reasoning=True,
+    )
 
     # Clean files from the previous run — unless resuming, where we keep all
     # prior progress (phases.json, generated specs, verification results) and
@@ -370,13 +375,8 @@ def run_pipeline(
                 proj_dir,
             )
 
-    # Copy system_prompt.md to spec_prompts/system_prompt.md
     spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
     os.makedirs(spec_prompts_dir, exist_ok=True)
-    shutil.copy2(
-        os.path.join(script_dir, "md", "system_prompt.md"),
-        os.path.join(spec_prompts_dir, "system_prompt.md"),
-    )
 
     phases_path = os.path.join(work_dir, "phases.json")
     with open(phases_path, "r") as f:
@@ -465,7 +465,8 @@ def run_pipeline(
             )
 
     # --- Stage 6: Execute spec generation workflow (per phase, per layer) ---
-    if only_spec:
+    run_reasoning = spec_generation_config.should_run_reasoning(only_spec)
+    if not run_reasoning:
         print("[Pipeline] Stage 6/6: Generating specs (reasoning & bug validation disabled)...")
     else:
         print("[Pipeline] Stage 6/6: Generating specs & verification...")
@@ -499,6 +500,7 @@ def run_pipeline(
             script_dir,
             spec_prompts_dir,
             phases_data,
+            spec_generation_config,
             resume=resume,
             extra_call_edges=extra_call_edges,
             only_spec=only_spec,
@@ -514,9 +516,8 @@ def run_pipeline(
                 proj_dir,
             )
 
-    # Print confirmed bug count (skipped in only-spec mode, which runs no
-    # reasoning or bug validation).
-    if not only_spec:
+    # Print confirmed bug count only when downstream reasoning is enabled.
+    if run_reasoning:
         if all_bugs:
             # A resumed run may find every function and candidate validation
             # already complete, so no watcher runs to refresh the persistent
@@ -539,7 +540,7 @@ def run_pipeline(
     except Exception as exc:
         logging.warning("[Pipeline] report.html generation skipped: %s", exc)
 
-    if only_spec:
+    if not run_reasoning:
         print("[Pipeline] Done (specs only; reasoning & bug validation skipped).")
     else:
         print("[Pipeline] Done.")

--- a/main.py
+++ b/main.py
@@ -191,10 +191,7 @@ def run_pipeline(
     # CLI. Chip plugin hooks read this persisted value because their public
     # hook signature intentionally remains (proj_dir) -> None.
     submodules = _normalize_submodules(proj_dir, submodules)
-    # A plugin may support source languages that are intentionally not in the
-    # built-in registry yet. Its configure hook owns the corresponding
-    # pre-Stage-1 validation (the chip plugin detects Chisel/Verilog here).
-    if plugin_config is None and not _has_source_code(proj_dir, submodules):
+    if not _has_source_code(proj_dir, submodules):
         scope = f" selected submodule(s): {', '.join(submodules)}" if submodules else f" {proj_dir}"
         print(f"[Pipeline] ERROR: No source code files found in{scope}. "
               f"Supported extensions: {', '.join(sorted(EXT_TO_LANG.keys()))}")

--- a/main.py
+++ b/main.py
@@ -12,7 +12,10 @@ from src.file_utils import (
 from src.verification import _generate_all_bugs_validation_summary
 from src.extract import run_extraction, EXT_TO_LANG
 from src.generate_topdown_layers import generate_topdown_layers
-from src.spec_generation_and_verification import run_spec_generation_and_verification
+from src.spec_generation_and_verification import (
+    run_spec_generation_and_verification,
+    stage_spec_generation_prompts,
+)
 from src.spec_forms import SOFTWARE_SPEC_FORM, SpecGenerationConfig
 from src.spec_forms.config import (
     _bind_spec_generation_config,
@@ -401,7 +404,13 @@ def run_pipeline(
             )
 
     spec_prompts_dir = os.path.join(work_dir, "spec_prompts")
-    os.makedirs(spec_prompts_dir, exist_ok=True)
+
+    stage_spec_generation_prompts(
+        spec_form=spec_generation_config.spec_form,
+        script_dir=script_dir,
+        work_dir=work_dir,
+        spec_prompts_dir=spec_prompts_dir,
+    )
 
     phases_path = os.path.join(work_dir, "phases.json")
     with open(phases_path, "r") as f:

--- a/main.py
+++ b/main.py
@@ -187,7 +187,10 @@ def run_pipeline(
     if not os.path.isdir(proj_dir):
         print(f"[Pipeline] ERROR: proj_dir does not exist or is not a directory: {proj_dir}")
         sys.exit(1)
-    if not _has_source_code(proj_dir, submodules):
+    # A plugin may support source languages that are intentionally not in the
+    # built-in registry yet. Its configure hook owns the corresponding
+    # pre-Stage-1 validation (the chip plugin detects Chisel/Verilog here).
+    if plugin_config is None and not _has_source_code(proj_dir, submodules):
         scope = f" selected submodule(s): {', '.join(submodules)}" if submodules else f" {proj_dir}"
         print(f"[Pipeline] ERROR: No source code files found in{scope}. "
               f"Supported extensions: {', '.join(sorted(EXT_TO_LANG.keys()))}")

--- a/main.py
+++ b/main.py
@@ -384,7 +384,13 @@ def run_pipeline(
                 extraction_stage.input_hook,
                 proj_dir,
             )
-        run_extraction(proj_dir, work_dir=work_dir, force=not resume, verbose=True)
+        run_extraction(
+            proj_dir,
+            work_dir=work_dir,
+            force=not resume,
+            verbose=True,
+            spec_form=spec_generation_config.spec_form,
+        )
         if extraction_stage is not None and extraction_stage.output_hook is not None:
             run_plugin_hook(
                 plugin_config.name,
@@ -429,10 +435,19 @@ def run_pipeline(
                 file_list_stage.input_hook,
                 proj_dir,
             )
-        file_list = collect_file_names(input_dir, file_list_path)
+        file_list = collect_file_names(
+            input_dir,
+            file_list_path,
+            spec_form=spec_generation_config.spec_form,
+        )
         if submodules:
             file_list = _write_file_names(
-                _get_all_phase_files(phases_data, input_dir), file_list_path
+                _get_all_phase_files(
+                    phases_data,
+                    input_dir,
+                    spec_form=spec_generation_config.spec_form,
+                ),
+                file_list_path,
             )
         if file_list_stage is not None and file_list_stage.output_hook is not None:
             run_plugin_hook(
@@ -473,7 +488,11 @@ def run_pipeline(
                 topdown_stage.input_hook,
                 proj_dir,
             )
-        generate_topdown_layers(work_dir, extra_call_edges=extra_call_edges)
+        generate_topdown_layers(
+            work_dir,
+            extra_call_edges=extra_call_edges,
+            spec_form=spec_generation_config.spec_form,
+        )
         if topdown_stage is not None and topdown_stage.output_hook is not None:
             run_plugin_hook(
                 plugin_config.name,

--- a/main.py
+++ b/main.py
@@ -14,6 +14,10 @@ from src.extract import run_extraction, EXT_TO_LANG
 from src.generate_topdown_layers import generate_topdown_layers
 from src.spec_generation_and_verification import run_spec_generation_and_verification
 from src.spec_forms import SOFTWARE_SPEC_FORM, SpecGenerationConfig
+from src.spec_forms.config import (
+    _bind_spec_generation_config,
+    _validate_spec_generation_config,
+)
 from src.incremental_reasoner import run_incremental_pipeline
 from src.git import (
     frozen_worktree,
@@ -210,8 +214,6 @@ def run_pipeline(
         if initial_history is None:
             preserved_history = preserve_history_before_clean(work_dir)
         _clean_previous_run(work_dir)
-    if resume and not only_spec:
-        _ensure_resume_mode_compatible(output_dir, all_bugs)
     os.makedirs(work_dir, exist_ok=True)
     if preserved_history:
         write_history(work_dir, preserved_history)
@@ -227,13 +229,30 @@ def run_pipeline(
         with open(plugin_context_path, "w", encoding="utf-8") as file:
             json.dump(plugin_context or {}, file, indent=2)
         if plugin_config.configure_hook is not None:
-            run_plugin_hook(
-                plugin_config.name,
-                "configure",
-                plugin_config.configure_function,
-                plugin_config.configure_hook,
-                proj_dir,
-            )
+            with _bind_spec_generation_config(spec_generation_config):
+                run_plugin_hook(
+                    plugin_config.name,
+                    "configure",
+                    plugin_config.configure_function,
+                    plugin_config.configure_hook,
+                    proj_dir,
+                )
+    try:
+        _validate_spec_generation_config(spec_generation_config)
+    except ValueError as exc:
+        if (
+            plugin_config is not None
+            and plugin_config.configure_hook is not None
+        ):
+            raise RuntimeError(
+                f"Plugin '{plugin_config.name}' configured an invalid "
+                f"specification strategy: {exc}"
+            ) from exc
+        raise RuntimeError(
+            f"Invalid built-in specification strategy: {exc}"
+        ) from exc
+    if resume and spec_generation_config.should_run_reasoning(only_spec):
+        _ensure_resume_mode_compatible(output_dir, all_bugs)
     domain_knowledge_relpaths = stage_domain_knowledge_files(
         proj_dir, work_dir, domain_knowledge_files
     )

--- a/plugins/chip/__init__.py
+++ b/plugins/chip/__init__.py
@@ -1,0 +1,2 @@
+"""Unified Chisel and Verilog pipeline plugin."""
+

--- a/plugins/chip/__init__.py
+++ b/plugins/chip/__init__.py
@@ -1,2 +1,1 @@
 """Unified Chisel and Verilog pipeline plugin."""
-

--- a/plugins/chip/detection.py
+++ b/plugins/chip/detection.py
@@ -9,6 +9,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from src.languages.hardware import (
+    CHISEL_EXTENSIONS,
+    SOURCE_SCAN_EXCLUDED_DIRECTORY_NAMES,
+    VERILOG_EXTENSIONS,
+    is_excluded_source_directory,
+)
+
 
 Dialect = Literal["chisel", "verilog"]
 
@@ -16,25 +23,8 @@ SCHEMA_VERSION = 1
 CONTEXT_RELATIVE_PATH = Path("fm_agent") / "chip_context.json"
 SAMPLE_LIMIT = 5
 
-CHISEL_EXTENSIONS = frozenset({".scala", ".sc"})
-VERILOG_EXTENSIONS = frozenset({".v", ".sv", ".svh"})
-
-# This list is shared by dialect detection now and is intended to be reused by
-# the Stage 1/2 strategies and language handlers as they are added.
-EXCLUDED_DIRECTORY_NAMES = frozenset({
-    ".git",
-    ".hg",
-    ".svn",
-    ".idea",
-    ".vscode",
-    ".venv",
-    "node_modules",
-    "fm_agent",
-    "target",
-    "build",
-    "out",
-    "dist",
-})
+# Public compatibility name used by C0 tests and future dialect strategies.
+EXCLUDED_DIRECTORY_NAMES = SOURCE_SCAN_EXCLUDED_DIRECTORY_NAMES
 
 
 class ChipContextError(ValueError):
@@ -43,7 +33,7 @@ class ChipContextError(ValueError):
 
 def is_excluded_directory(name: str) -> bool:
     """Return whether a nested directory is outside chip source discovery."""
-    return name.startswith(".") or name in EXCLUDED_DIRECTORY_NAMES
+    return is_excluded_source_directory(name)
 
 
 @dataclass(frozen=True)

--- a/plugins/chip/detection.py
+++ b/plugins/chip/detection.py
@@ -1,0 +1,264 @@
+"""Run-scoped Chisel/Verilog dialect detection and context persistence."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+Dialect = Literal["chisel", "verilog"]
+
+SCHEMA_VERSION = 1
+CONTEXT_RELATIVE_PATH = Path("fm_agent") / "chip_context.json"
+SAMPLE_LIMIT = 5
+
+CHISEL_EXTENSIONS = frozenset({".scala", ".sc"})
+VERILOG_EXTENSIONS = frozenset({".v", ".sv", ".svh"})
+
+# This list is shared by dialect detection now and is intended to be reused by
+# the Stage 1/2 strategies and language handlers as they are added.
+EXCLUDED_DIRECTORY_NAMES = frozenset({
+    ".git",
+    ".hg",
+    ".svn",
+    ".idea",
+    ".vscode",
+    ".venv",
+    "node_modules",
+    "fm_agent",
+    "target",
+    "build",
+    "out",
+    "dist",
+})
+
+
+class ChipContextError(ValueError):
+    """Raised when dialect detection or its persisted context is invalid."""
+
+
+def is_excluded_directory(name: str) -> bool:
+    """Return whether a nested directory is outside chip source discovery."""
+    return name.startswith(".") or name in EXCLUDED_DIRECTORY_NAMES
+
+
+@dataclass(frozen=True)
+class DialectEvidence:
+    """Deterministic evidence collected while selecting a hardware dialect."""
+
+    chisel_count: int
+    verilog_count: int
+    chisel_samples: tuple[str, ...]
+    verilog_samples: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "chisel_count": self.chisel_count,
+            "verilog_count": self.verilog_count,
+            "chisel_samples": list(self.chisel_samples),
+            "verilog_samples": list(self.verilog_samples),
+        }
+
+
+@dataclass(frozen=True)
+class ChipContext:
+    """The single routing fact used throughout one chip-plugin run."""
+
+    dialect: Dialect
+    evidence: DialectEvidence
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "dialect": self.dialect,
+            "evidence": self.evidence.to_dict(),
+        }
+
+
+def _relative_samples(proj_dir: Path) -> tuple[list[str], list[str]]:
+    chisel_files: list[str] = []
+    verilog_files: list[str] = []
+
+    for current_root, dirnames, filenames in os.walk(proj_dir):
+        dirnames[:] = sorted(
+            name
+            for name in dirnames
+            if not is_excluded_directory(name)
+        )
+        root = Path(current_root)
+        for filename in sorted(filenames):
+            suffix = Path(filename).suffix.lower()
+            if suffix not in CHISEL_EXTENSIONS | VERILOG_EXTENSIONS:
+                continue
+            relative_path = (root / filename).relative_to(proj_dir).as_posix()
+            if suffix in CHISEL_EXTENSIONS:
+                chisel_files.append(relative_path)
+            else:
+                verilog_files.append(relative_path)
+
+    # os.walk is ordered above, but sorting the final paths also makes the
+    # evidence independent of platform traversal details.
+    return sorted(chisel_files), sorted(verilog_files)
+
+
+def detect_chip_context(proj_dir: str | Path) -> ChipContext:
+    """Scan *proj_dir* once and deterministically select one hardware dialect."""
+    project = Path(proj_dir).resolve()
+    if not project.is_dir():
+        raise ChipContextError(f"project directory does not exist: {project}")
+
+    chisel_files, verilog_files = _relative_samples(project)
+    evidence = DialectEvidence(
+        chisel_count=len(chisel_files),
+        verilog_count=len(verilog_files),
+        chisel_samples=tuple(chisel_files[:SAMPLE_LIMIT]),
+        verilog_samples=tuple(verilog_files[:SAMPLE_LIMIT]),
+    )
+
+    if chisel_files:
+        dialect: Dialect = "chisel"
+        if verilog_files:
+            logging.warning(
+                "Chip dialect detection found both Chisel (%d file(s), e.g. %s) "
+                "and Verilog (%d file(s), e.g. %s); selecting Chisel for this run.",
+                len(chisel_files),
+                ", ".join(evidence.chisel_samples),
+                len(verilog_files),
+                ", ".join(evidence.verilog_samples),
+            )
+    elif verilog_files:
+        dialect = "verilog"
+    else:
+        supported = ", ".join(sorted(CHISEL_EXTENSIONS | VERILOG_EXTENSIONS))
+        raise ChipContextError(
+            "chip plugin found no Chisel or Verilog source files under "
+            f"{project}; expected one of: {supported}"
+        )
+
+    return ChipContext(dialect=dialect, evidence=evidence)
+
+
+def _require_non_negative_int(value: object, field: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ChipContextError(
+            f"chip context field '{field}' must be a non-negative integer"
+        )
+    return value
+
+
+def _require_string_list(value: object, field: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) for item in value
+    ):
+        raise ChipContextError(
+            f"chip context field '{field}' must be a list of strings"
+        )
+    if len(value) > SAMPLE_LIMIT:
+        raise ChipContextError(
+            f"chip context field '{field}' contains more than {SAMPLE_LIMIT} samples"
+        )
+    return tuple(value)
+
+
+def parse_chip_context(data: object) -> ChipContext:
+    """Validate and parse the persisted chip context schema."""
+    if not isinstance(data, dict):
+        raise ChipContextError("chip context must be a JSON object")
+    if set(data) != {"schema_version", "dialect", "evidence"}:
+        raise ChipContextError("chip context has missing or unsupported top-level fields")
+    if data["schema_version"] != SCHEMA_VERSION:
+        raise ChipContextError(
+            "unsupported chip context schema_version: "
+            f"{data['schema_version']!r}; expected {SCHEMA_VERSION}"
+        )
+
+    dialect = data["dialect"]
+    if dialect not in {"chisel", "verilog"}:
+        raise ChipContextError(f"unsupported chip dialect: {dialect!r}")
+
+    evidence_data = data["evidence"]
+    expected_evidence_fields = {
+        "chisel_count",
+        "verilog_count",
+        "chisel_samples",
+        "verilog_samples",
+    }
+    if (
+        not isinstance(evidence_data, dict)
+        or set(evidence_data) != expected_evidence_fields
+    ):
+        raise ChipContextError("chip context evidence has missing or unsupported fields")
+
+    evidence = DialectEvidence(
+        chisel_count=_require_non_negative_int(
+            evidence_data["chisel_count"], "evidence.chisel_count"
+        ),
+        verilog_count=_require_non_negative_int(
+            evidence_data["verilog_count"], "evidence.verilog_count"
+        ),
+        chisel_samples=_require_string_list(
+            evidence_data["chisel_samples"], "evidence.chisel_samples"
+        ),
+        verilog_samples=_require_string_list(
+            evidence_data["verilog_samples"], "evidence.verilog_samples"
+        ),
+    )
+    if len(evidence.chisel_samples) > evidence.chisel_count:
+        raise ChipContextError("Chisel sample count exceeds detected file count")
+    if len(evidence.verilog_samples) > evidence.verilog_count:
+        raise ChipContextError("Verilog sample count exceeds detected file count")
+    if dialect == "chisel" and evidence.chisel_count == 0:
+        raise ChipContextError("Chisel dialect requires at least one Chisel evidence file")
+    if dialect == "verilog" and (
+        evidence.verilog_count == 0 or evidence.chisel_count != 0
+    ):
+        raise ChipContextError(
+            "Verilog dialect requires Verilog evidence and no Chisel evidence"
+        )
+
+    return ChipContext(dialect=dialect, evidence=evidence)
+
+
+def write_chip_context(proj_dir: str | Path, context: ChipContext) -> Path:
+    """Atomically persist a validated run-scoped dialect context."""
+    project = Path(proj_dir).resolve()
+    parsed = parse_chip_context(context.to_dict())
+    context_path = project / CONTEXT_RELATIVE_PATH
+    context_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = context_path.with_suffix(".json.tmp")
+    try:
+        with temporary_path.open("w", encoding="utf-8") as file:
+            json.dump(parsed.to_dict(), file, indent=2)
+            file.write("\n")
+        temporary_path.replace(context_path)
+    except OSError:
+        temporary_path.unlink(missing_ok=True)
+        raise
+    return context_path
+
+
+def read_chip_context(proj_dir: str | Path) -> ChipContext:
+    """Read the persisted routing fact without falling back to a rescan."""
+    context_path = Path(proj_dir).resolve() / CONTEXT_RELATIVE_PATH
+    try:
+        with context_path.open("r", encoding="utf-8") as file:
+            data = json.load(file)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ChipContextError(
+            f"missing or invalid chip context at {context_path}: {exc}"
+        ) from exc
+    return parse_chip_context(data)
+
+
+def validate_context_dialect(context: ChipContext, expected: Dialect) -> None:
+    """Fail fast if a configured strategy disagrees with the run context."""
+    if context.dialect != expected:
+        raise ChipContextError(
+            f"chip context dialect {context.dialect!r} does not match "
+            f"configured dialect {expected!r}"
+        )

--- a/plugins/chip/detection.py
+++ b/plugins/chip/detection.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Literal
 
 from src.languages.hardware import (
@@ -16,14 +16,11 @@ from src.languages.hardware import (
     is_excluded_source_directory,
 )
 
-
 Dialect = Literal["chisel", "verilog"]
-
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 CONTEXT_RELATIVE_PATH = Path("fm_agent") / "chip_context.json"
+PLUGIN_CONTEXT_RELATIVE_PATH = Path("fm_agent") / "plugin_context.json"
 SAMPLE_LIMIT = 5
-
-# Public compatibility name used by C0 tests and future dialect strategies.
 EXCLUDED_DIRECTORY_NAMES = SOURCE_SCAN_EXCLUDED_DIRECTORY_NAMES
 
 
@@ -32,14 +29,11 @@ class ChipContextError(ValueError):
 
 
 def is_excluded_directory(name: str) -> bool:
-    """Return whether a nested directory is outside chip source discovery."""
     return is_excluded_source_directory(name)
 
 
 @dataclass(frozen=True)
 class DialectEvidence:
-    """Deterministic evidence collected while selecting a hardware dialect."""
-
     chisel_count: int
     verilog_count: int
     chisel_samples: tuple[str, ...]
@@ -56,53 +50,126 @@ class DialectEvidence:
 
 @dataclass(frozen=True)
 class ChipContext:
-    """The single routing fact used throughout one chip-plugin run."""
+    """The routing fact used throughout one chip-plugin run."""
 
     dialect: Dialect
     evidence: DialectEvidence
+    submodules: tuple[str, ...] = ()
     schema_version: int = SCHEMA_VERSION
 
     def to_dict(self) -> dict[str, object]:
         return {
             "schema_version": self.schema_version,
             "dialect": self.dialect,
+            "scope": {"submodules": list(self.submodules)},
             "evidence": self.evidence.to_dict(),
         }
 
 
-def _relative_samples(proj_dir: Path) -> tuple[list[str], list[str]]:
+def _normalize_scope(project: Path, submodules: object) -> tuple[str, ...]:
+    """Validate and canonicalize a plugin scope relative to *project*."""
+    if submodules is None:
+        return ()
+    if not isinstance(submodules, (list, tuple)):
+        raise ChipContextError("plugin scope 'submodules' must be a list of strings")
+
+    project_root = project.resolve()
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in submodules:
+        if not isinstance(raw, str) or not raw.strip():
+            raise ChipContextError(
+                "plugin scope 'submodules' must contain non-empty strings"
+            )
+        candidate = Path(raw.strip())
+        if not candidate.is_absolute():
+            candidate = project_root / candidate
+        candidate = candidate.resolve()
+        try:
+            inside = candidate.is_relative_to(project_root)
+        except AttributeError:  # pragma: no cover
+            inside = os.path.commonpath(
+                [str(project_root), str(candidate)]
+            ) == str(project_root)
+        if not inside or candidate == project_root or not candidate.is_dir():
+            raise ChipContextError(
+                "plugin scope submodule must name a directory inside project: "
+                f"{raw!r}"
+            )
+        relative = candidate.relative_to(project_root).as_posix()
+        if relative not in seen:
+            normalized.append(relative)
+            seen.add(relative)
+
+    collapsed: list[str] = []
+    for relative in sorted(normalized, key=lambda path: (path.count("/"), path)):
+        if not any(
+            relative == parent or relative.startswith(parent + "/")
+            for parent in collapsed
+        ):
+            collapsed.append(relative)
+    return tuple(collapsed)
+
+
+def read_plugin_submodules(proj_dir: str | Path) -> tuple[str, ...]:
+    """Read the normalized run scope persisted by the public pipeline."""
+    project = Path(proj_dir).resolve()
+    context_path = project / PLUGIN_CONTEXT_RELATIVE_PATH
+    if not context_path.is_file():
+        return ()
+    try:
+        with context_path.open("r", encoding="utf-8") as file:
+            data = json.load(file)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ChipContextError(
+            f"missing or invalid plugin context at {context_path}: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ChipContextError("plugin context must be a JSON object")
+    if "submodules" not in data:
+        raise ChipContextError("plugin context is missing 'submodules'")
+    return _normalize_scope(project, data["submodules"])
+
+
+def _relative_samples(
+    proj_dir: Path,
+    submodules: tuple[str, ...] = (),
+) -> tuple[list[str], list[str]]:
     chisel_files: list[str] = []
     verilog_files: list[str] = []
-
-    for current_root, dirnames, filenames in os.walk(proj_dir):
-        dirnames[:] = sorted(
-            name
-            for name in dirnames
-            if not is_excluded_directory(name)
-        )
-        root = Path(current_root)
-        for filename in sorted(filenames):
-            suffix = Path(filename).suffix.lower()
-            if suffix not in CHISEL_EXTENSIONS | VERILOG_EXTENSIONS:
-                continue
-            relative_path = (root / filename).relative_to(proj_dir).as_posix()
-            if suffix in CHISEL_EXTENSIONS:
-                chisel_files.append(relative_path)
-            else:
-                verilog_files.append(relative_path)
-
-    # os.walk is ordered above, but sorting the final paths also makes the
-    # evidence independent of platform traversal details.
+    roots = [proj_dir / relative for relative in submodules] if submodules else [proj_dir]
+    seen: set[str] = set()
+    for scan_root in roots:
+        for current_root, dirnames, filenames in os.walk(scan_root):
+            dirnames[:] = sorted(
+                name for name in dirnames if not is_excluded_directory(name)
+            )
+            root = Path(current_root)
+            for filename in sorted(filenames):
+                suffix = Path(filename).suffix.lower()
+                if suffix not in CHISEL_EXTENSIONS | VERILOG_EXTENSIONS:
+                    continue
+                relative_path = (root / filename).relative_to(proj_dir).as_posix()
+                if relative_path in seen:
+                    continue
+                seen.add(relative_path)
+                if suffix in CHISEL_EXTENSIONS:
+                    chisel_files.append(relative_path)
+                else:
+                    verilog_files.append(relative_path)
     return sorted(chisel_files), sorted(verilog_files)
 
 
-def detect_chip_context(proj_dir: str | Path) -> ChipContext:
-    """Scan *proj_dir* once and deterministically select one hardware dialect."""
+def detect_chip_context(
+    proj_dir: str | Path,
+    submodules: object = (),
+) -> ChipContext:
+    """Scan the selected target scope and choose one hardware dialect."""
     project = Path(proj_dir).resolve()
     if not project.is_dir():
         raise ChipContextError(f"project directory does not exist: {project}")
-
-    chisel_files, verilog_files = _relative_samples(project)
+    normalized_scope = _normalize_scope(project, submodules)
+    chisel_files, verilog_files = _relative_samples(project, normalized_scope)
     evidence = DialectEvidence(
         chisel_count=len(chisel_files),
         verilog_count=len(verilog_files),
@@ -116,21 +183,22 @@ def detect_chip_context(proj_dir: str | Path) -> ChipContext:
             logging.warning(
                 "Chip dialect detection found both Chisel (%d file(s), e.g. %s) "
                 "and Verilog (%d file(s), e.g. %s); selecting Chisel for this run.",
-                len(chisel_files),
-                ", ".join(evidence.chisel_samples),
-                len(verilog_files),
-                ", ".join(evidence.verilog_samples),
+                len(chisel_files), ", ".join(evidence.chisel_samples),
+                len(verilog_files), ", ".join(evidence.verilog_samples),
             )
     elif verilog_files:
         dialect = "verilog"
     else:
         supported = ", ".join(sorted(CHISEL_EXTENSIONS | VERILOG_EXTENSIONS))
+        scope = (
+            f" (selected submodules: {', '.join(normalized_scope)})"
+            if normalized_scope else ""
+        )
         raise ChipContextError(
             "chip plugin found no Chisel or Verilog source files under "
-            f"{project}; expected one of: {supported}"
+            f"{project}{scope}; expected one of: {supported}"
         )
-
-    return ChipContext(dialect=dialect, evidence=evidence)
+    return ChipContext(dialect=dialect, evidence=evidence, submodules=normalized_scope)
 
 
 def _require_non_negative_int(value: object, field: str) -> int:
@@ -142,9 +210,7 @@ def _require_non_negative_int(value: object, field: str) -> int:
 
 
 def _require_string_list(value: object, field: str) -> tuple[str, ...]:
-    if not isinstance(value, list) or not all(
-        isinstance(item, str) for item in value
-    ):
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise ChipContextError(
             f"chip context field '{field}' must be a list of strings"
         )
@@ -159,31 +225,48 @@ def parse_chip_context(data: object) -> ChipContext:
     """Validate and parse the persisted chip context schema."""
     if not isinstance(data, dict):
         raise ChipContextError("chip context must be a JSON object")
-    if set(data) != {"schema_version", "dialect", "evidence"}:
+    if set(data) != {"schema_version", "dialect", "scope", "evidence"}:
         raise ChipContextError("chip context has missing or unsupported top-level fields")
     if data["schema_version"] != SCHEMA_VERSION:
         raise ChipContextError(
             "unsupported chip context schema_version: "
             f"{data['schema_version']!r}; expected {SCHEMA_VERSION}"
         )
-
     dialect = data["dialect"]
     if dialect not in {"chisel", "verilog"}:
         raise ChipContextError(f"unsupported chip dialect: {dialect!r}")
 
+    scope_data = data["scope"]
+    if not isinstance(scope_data, dict) or set(scope_data) != {"submodules"}:
+        raise ChipContextError("chip context scope has missing or unsupported fields")
+    raw_scope = scope_data["submodules"]
+    if not isinstance(raw_scope, list) or not all(
+        isinstance(item, str) and item for item in raw_scope
+    ):
+        raise ChipContextError("chip context scope.submodules must be a list of strings")
+    normalized_scope = tuple(str(PurePosixPath(item)) for item in raw_scope)
+    if list(normalized_scope) != raw_scope:
+        raise ChipContextError(
+            "chip context scope.submodules must contain normalized project-relative paths"
+        )
+    if any(
+        PurePosixPath(item).is_absolute()
+        or ".." in PurePosixPath(item).parts
+        or item in {"", "."}
+        for item in normalized_scope
+    ):
+        raise ChipContextError(
+            "chip context scope.submodules must contain safe relative paths"
+        )
+    if len(set(normalized_scope)) != len(normalized_scope):
+        raise ChipContextError("chip context scope.submodules must not contain duplicates")
+
     evidence_data = data["evidence"]
     expected_evidence_fields = {
-        "chisel_count",
-        "verilog_count",
-        "chisel_samples",
-        "verilog_samples",
+        "chisel_count", "verilog_count", "chisel_samples", "verilog_samples",
     }
-    if (
-        not isinstance(evidence_data, dict)
-        or set(evidence_data) != expected_evidence_fields
-    ):
+    if not isinstance(evidence_data, dict) or set(evidence_data) != expected_evidence_fields:
         raise ChipContextError("chip context evidence has missing or unsupported fields")
-
     evidence = DialectEvidence(
         chisel_count=_require_non_negative_int(
             evidence_data["chisel_count"], "evidence.chisel_count"
@@ -210,8 +293,11 @@ def parse_chip_context(data: object) -> ChipContext:
         raise ChipContextError(
             "Verilog dialect requires Verilog evidence and no Chisel evidence"
         )
-
-    return ChipContext(dialect=dialect, evidence=evidence)
+    return ChipContext(
+        dialect=dialect,
+        evidence=evidence,
+        submodules=normalized_scope,
+    )
 
 
 def write_chip_context(proj_dir: str | Path, context: ChipContext) -> Path:

--- a/plugins/chip/dialects/__init__.py
+++ b/plugins/chip/dialects/__init__.py
@@ -1,0 +1,5 @@
+"""Dialect strategies for the unified chip plugin."""
+
+from .base import DialectStrategy, get_dialect_strategy
+
+__all__ = ["DialectStrategy", "get_dialect_strategy"]

--- a/plugins/chip/dialects/base.py
+++ b/plugins/chip/dialects/base.py
@@ -8,7 +8,7 @@ from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
-from src.file_utils import _is_test_file
+from src.file_utils import _is_test_file, _is_under_submodules
 from src.languages.hardware import is_excluded_source_directory
 
 
@@ -49,7 +49,12 @@ class DialectStrategy:
             self.domain_context_workflow,
         )
 
-    def validate_phase_plan(self, phases_path: str | Path) -> list[str]:
+    def validate_phase_plan(
+        self,
+        phases_path: str | Path,
+        *,
+        submodules: tuple[str, ...] | list[str] = (),
+    ) -> list[str]:
         """Return dialect-specific errors for an otherwise valid phase plan."""
         path = Path(phases_path)
         with path.open("r", encoding="utf-8") as file:
@@ -91,6 +96,7 @@ class DialectStrategy:
                             raw_source,
                             location,
                             project_root,
+                            submodules=submodules,
                         )
                     )
 
@@ -109,7 +115,10 @@ class DialectStrategy:
                 + ", ".join(duplicates)
             )
 
-        expected_sources = self._discover_source_files(project_root)
+        expected_sources = self._discover_source_files(
+            project_root,
+            submodules=submodules,
+        )
         missing_sources = sorted(expected_sources - set(listed_sources))
         if missing_sources:
             sample = ", ".join(missing_sources[:10])
@@ -121,24 +130,34 @@ class DialectStrategy:
             )
         return errors
 
-    def _discover_source_files(self, project_root: Path) -> set[str]:
+    def _discover_source_files(
+        self,
+        project_root: Path,
+        *,
+        submodules: tuple[str, ...] | list[str] = (),
+    ) -> set[str]:
         """Return the complete in-scope source set for this dialect."""
         sources: set[str] = set()
-        for current_root, dirnames, filenames in os.walk(project_root):
-            dirnames[:] = sorted(
-                name
-                for name in dirnames
-                if not is_excluded_source_directory(name)
-            )
-            root = Path(current_root)
-            for filename in sorted(filenames):
-                path = root / filename
-                suffix = path.suffix.lower().lstrip(".")
-                if suffix not in self.extensions:
-                    continue
-                relative = path.relative_to(project_root).as_posix()
-                if not _is_test_file(relative):
-                    sources.add(relative)
+        roots = (
+            [project_root / submodule for submodule in submodules]
+            if submodules else [project_root]
+        )
+        for scan_root in roots:
+            for current_root, dirnames, filenames in os.walk(scan_root):
+                dirnames[:] = sorted(
+                    name
+                    for name in dirnames
+                    if not is_excluded_source_directory(name)
+                )
+                root = Path(current_root)
+                for filename in sorted(filenames):
+                    path = root / filename
+                    suffix = path.suffix.lower().lstrip(".")
+                    if suffix not in self.extensions:
+                        continue
+                    relative = path.relative_to(project_root).as_posix()
+                    if not _is_test_file(relative):
+                        sources.add(relative)
         return sources
 
     def _validate_source_path(
@@ -146,6 +165,8 @@ class DialectStrategy:
         raw_source: str,
         location: str,
         project_root: Path,
+        *,
+        submodules: tuple[str, ...] | list[str] = (),
     ) -> list[str]:
         normalized = raw_source.replace("\\", "/")
         pure_path = PurePosixPath(normalized)
@@ -157,6 +178,10 @@ class DialectStrategy:
             return [f"{location} must not be empty"]
 
         suffix = pure_path.suffix.lower().lstrip(".")
+        if submodules and not _is_under_submodules(normalized, submodules):
+            errors.append(
+                f"{location} {raw_source!r} is outside the selected submodule scope"
+            )
         if suffix not in self.extensions:
             errors.append(
                 f"{location} {raw_source!r} is not a {self.dialect} source; "

--- a/plugins/chip/dialects/base.py
+++ b/plugins/chip/dialects/base.py
@@ -1,0 +1,193 @@
+"""Shared Stage 1/2 routing contract for hardware dialects."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from src.file_utils import _is_test_file
+from src.languages.hardware import is_excluded_source_directory
+
+
+_PROMPTS_ROOT = Path(__file__).resolve().parents[1] / "prompts"
+
+
+@dataclass(frozen=True)
+class DialectStrategy:
+    """Static resources and phase-plan rules for one selected dialect."""
+
+    dialect: str
+    language: str
+    extensions: tuple[str, ...]
+
+    @property
+    def spec_form_id(self) -> str:
+        return f"chip-{self.dialect}"
+
+    @property
+    def phase_plan_workflow(self) -> Path:
+        return (
+            _PROMPTS_ROOT
+            / self.dialect
+            / "workflow_generate_phases.md"
+        )
+
+    @property
+    def domain_context_workflow(self) -> Path:
+        return (
+            _PROMPTS_ROOT
+            / self.dialect
+            / "workflow_generate_domain_context.md"
+        )
+
+    def required_resources(self) -> tuple[Path, ...]:
+        return (
+            self.phase_plan_workflow,
+            self.domain_context_workflow,
+        )
+
+    def validate_phase_plan(self, phases_path: str | Path) -> list[str]:
+        """Return dialect-specific errors for an otherwise valid phase plan."""
+        path = Path(phases_path)
+        with path.open("r", encoding="utf-8") as file:
+            data = json.load(file)
+
+        errors: list[str] = []
+        if data.get("languages") != [self.language]:
+            errors.append(
+                "languages must be exactly "
+                f"[{self.language!r}] for the selected {self.dialect} dialect"
+            )
+
+        raw_extensions = data.get("file_extensions")
+        expected_extensions = list(self.extensions)
+        if raw_extensions != expected_extensions:
+            errors.append(
+                "file_extensions must be exactly "
+                f"{expected_extensions!r} for the selected {self.dialect} dialect"
+            )
+
+        source_count = 0
+        listed_sources: list[str] = []
+        project_root = path.resolve().parent.parent
+        for phase_index, phase in enumerate(data.get("phases", [])):
+            for module_index, module in enumerate(phase.get("modules", [])):
+                for source_index, raw_source in enumerate(
+                    module.get("source_files", [])
+                ):
+                    if not isinstance(raw_source, str):
+                        continue
+                    source_count += 1
+                    listed_sources.append(raw_source.replace("\\", "/"))
+                    location = (
+                        f"phases[{phase_index}].modules[{module_index}]"
+                        f".source_files[{source_index}]"
+                    )
+                    errors.extend(
+                        self._validate_source_path(
+                            raw_source,
+                            location,
+                            project_root,
+                        )
+                    )
+
+        if source_count == 0:
+            errors.append(
+                f"phases.json must list at least one {self.dialect} source file"
+            )
+        duplicates = sorted(
+            source
+            for source, count in Counter(listed_sources).items()
+            if count > 1
+        )
+        if duplicates:
+            errors.append(
+                "source files must be listed at most once; duplicates: "
+                + ", ".join(duplicates)
+            )
+
+        expected_sources = self._discover_source_files(project_root)
+        missing_sources = sorted(expected_sources - set(listed_sources))
+        if missing_sources:
+            sample = ", ".join(missing_sources[:10])
+            remainder = len(missing_sources) - 10
+            suffix = f" (and {remainder} more)" if remainder > 0 else ""
+            errors.append(
+                f"phases.json omits {len(missing_sources)} non-test "
+                f"{self.dialect} source file(s): {sample}{suffix}"
+            )
+        return errors
+
+    def _discover_source_files(self, project_root: Path) -> set[str]:
+        """Return the complete in-scope source set for this dialect."""
+        sources: set[str] = set()
+        for current_root, dirnames, filenames in os.walk(project_root):
+            dirnames[:] = sorted(
+                name
+                for name in dirnames
+                if not is_excluded_source_directory(name)
+            )
+            root = Path(current_root)
+            for filename in sorted(filenames):
+                path = root / filename
+                suffix = path.suffix.lower().lstrip(".")
+                if suffix not in self.extensions:
+                    continue
+                relative = path.relative_to(project_root).as_posix()
+                if not _is_test_file(relative):
+                    sources.add(relative)
+        return sources
+
+    def _validate_source_path(
+        self,
+        raw_source: str,
+        location: str,
+        project_root: Path,
+    ) -> list[str]:
+        normalized = raw_source.replace("\\", "/")
+        pure_path = PurePosixPath(normalized)
+        errors: list[str] = []
+
+        if pure_path.is_absolute() or ".." in pure_path.parts:
+            return [f"{location} must be a project-relative path: {raw_source!r}"]
+        if not pure_path.parts or normalized in {"", "."}:
+            return [f"{location} must not be empty"]
+
+        suffix = pure_path.suffix.lower().lstrip(".")
+        if suffix not in self.extensions:
+            errors.append(
+                f"{location} {raw_source!r} is not a {self.dialect} source; "
+                f"expected one of {list(self.extensions)!r}"
+            )
+        if any(
+            is_excluded_source_directory(part)
+            for part in pure_path.parts[:-1]
+        ):
+            errors.append(
+                f"{location} {raw_source!r} is under an excluded source directory"
+            )
+        if _is_test_file(normalized):
+            errors.append(
+                f"{location} {raw_source!r} is a test/testbench source and must be excluded"
+            )
+        if not (project_root / Path(*pure_path.parts)).is_file():
+            errors.append(
+                f"{location} does not exist in the project: {raw_source!r}"
+            )
+        return errors
+
+
+def get_dialect_strategy(dialect: str) -> DialectStrategy:
+    """Return the immutable strategy for *dialect* or fail explicitly."""
+    if dialect == "chisel":
+        from .chisel import CHISEL_STRATEGY
+
+        return CHISEL_STRATEGY
+    if dialect == "verilog":
+        from .verilog import VERILOG_STRATEGY
+
+        return VERILOG_STRATEGY
+    raise ValueError(f"unsupported chip dialect strategy: {dialect!r}")

--- a/plugins/chip/dialects/chisel.py
+++ b/plugins/chip/dialects/chisel.py
@@ -1,0 +1,10 @@
+"""Chisel Stage 1/2 strategy."""
+
+from .base import DialectStrategy
+
+
+CHISEL_STRATEGY = DialectStrategy(
+    dialect="chisel",
+    language="chisel",
+    extensions=("scala", "sc"),
+)

--- a/plugins/chip/dialects/verilog.py
+++ b/plugins/chip/dialects/verilog.py
@@ -1,0 +1,10 @@
+"""Verilog/SystemVerilog Stage 1/2 strategy."""
+
+from .base import DialectStrategy
+
+
+VERILOG_STRATEGY = DialectStrategy(
+    dialect="verilog",
+    language="verilog",
+    extensions=("v", "sv", "svh"),
+)

--- a/plugins/chip/forms/__init__.py
+++ b/plugins/chip/forms/__init__.py
@@ -1,0 +1,6 @@
+"""Hardware specification forms selected by the chip plugin."""
+
+from .chisel import ChiselSpecForm
+from .verilog import VerilogSpecForm
+
+__all__ = ["ChiselSpecForm", "VerilogSpecForm"]

--- a/plugins/chip/forms/__init__.py
+++ b/plugins/chip/forms/__init__.py
@@ -1,6 +1,7 @@
 """Hardware specification forms selected by the chip plugin."""
 
+from .base import HardwareSpecForm
 from .chisel import ChiselSpecForm
 from .verilog import VerilogSpecForm
 
-__all__ = ["ChiselSpecForm", "VerilogSpecForm"]
+__all__ = ["ChiselSpecForm", "HardwareSpecForm", "VerilogSpecForm"]

--- a/plugins/chip/forms/base.py
+++ b/plugins/chip/forms/base.py
@@ -1,0 +1,79 @@
+"""C0 bootstrap contract for hardware specification forms."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NoReturn, Sequence
+
+from src.spec_forms import SpecArtifactPaths, SpecForm, SpecValidationResult
+
+
+class BootstrapHardwareSpecForm(SpecForm):
+    """Carry dialect identity until the complete C4 artifact form is added.
+
+    C0 needs a real SpecForm so configuration can finish before Stage 1. It does
+    not define the Stage 6 artifact contract early; any attempted generation
+    fails explicitly instead of silently using the software form.
+    """
+
+    schema_version = "V1"
+    dialect: str
+
+    @staticmethod
+    def _not_implemented() -> NoReturn:
+        raise RuntimeError(
+            "chip hardware specification generation is not available in the C0 "
+            "plugin skeleton; complete the C4 SpecForm implementation first"
+        )
+
+    def artifact_paths(self, unit_file: Path) -> SpecArtifactPaths:
+        del unit_file
+        self._not_implemented()
+
+    def is_artifact_path(self, path: Path) -> bool:
+        del path
+        self._not_implemented()
+
+    def validate(
+        self,
+        unit_file: Path,
+        expected_dependencies: Sequence[str] = (),
+    ) -> SpecValidationResult:
+        del unit_file, expected_dependencies
+        self._not_implemented()
+
+    def read_self_spec(self, unit_file: Path) -> str | None:
+        del unit_file
+        self._not_implemented()
+
+    def read_dependency_expectation(
+        self,
+        caller_file: Path,
+        callee_fqn: str,
+        aliases: Sequence[str] = (),
+    ) -> str | None:
+        del caller_file, callee_fqn, aliases
+        self._not_implemented()
+
+    def batch_intro(self, language: str) -> str:
+        del language
+        self._not_implemented()
+
+    def output_contract_prompt(self) -> str:
+        self._not_implemented()
+
+    def system_prompt_path(self, script_dir: Path) -> Path:
+        del script_dir
+        self._not_implemented()
+
+    def workflow_prompt_path(self, script_dir: Path) -> Path:
+        del script_dir
+        self._not_implemented()
+
+    def generation_instruction(self, batch_prompt_rel: str, attempt: int) -> str:
+        del batch_prompt_rel, attempt
+        self._not_implemented()
+
+    def trace_outputs(self, unit_files: Sequence[Path]) -> list[str]:
+        del unit_files
+        self._not_implemented()

--- a/plugins/chip/forms/base.py
+++ b/plugins/chip/forms/base.py
@@ -1,50 +1,277 @@
-"""C0 bootstrap contract for hardware specification forms."""
+"""Shared Markdown artifact contract for hardware specification forms."""
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
-from typing import NoReturn, Sequence
+from typing import Sequence
 
 from src.spec_forms import SpecArtifactPaths, SpecForm, SpecValidationResult
 
 
-class BootstrapHardwareSpecForm(SpecForm):
-    """Carry dialect identity until the complete C4 artifact form is added.
+_TAG_RE = re.compile(r"<(FG|FC|CK)\b([^>]*)>")
+_TAG_NAME_RE = re.compile(r"^-[A-Z0-9]+(?:-[A-Z0-9]+)*$")
+_SUBMODULE_HEADING_RE = re.compile(
+    r"^#\s+Submodule:\s*`?([^`\n]+?)`?\s*$",
+    re.MULTILINE,
+)
 
-    C0 needs a real SpecForm so configuration can finish before Stage 1. It does
-    not define the Stage 6 artifact contract early; any attempted generation
-    fails explicitly instead of silently using the software form.
-    """
+
+class HardwareSpecForm(SpecForm):
+    """Common standalone Markdown contract for one extracted hardware module."""
 
     schema_version = "V1"
     dialect: str
+    dependency_coverage_is_blocking = False
 
-    @staticmethod
-    def _not_implemented() -> NoReturn:
-        raise RuntimeError(
-            "chip hardware specification generation is not available in the C0 "
-            "plugin skeleton; complete the C4 SpecForm implementation first"
+    @property
+    def unit_noun(self) -> str:
+        return "module"
+
+    def batch_rules(self, language: str) -> Sequence[str]:
+        del language
+        return (
+            "Describe observable module behavior, interfaces, timing, reset, and protocol guarantees",
+            "Describe WHAT the hardware guarantees, NOT a line-by-line implementation transcript",
+            "Do NOT invent ports, parameters, submodules, widths, or cycle relationships",
+            "Every functional group and function point must contain machine-checkable coverage tags",
         )
 
     def artifact_paths(self, unit_file: Path) -> SpecArtifactPaths:
-        del unit_file
-        self._not_implemented()
+        unit_file = Path(unit_file)
+        return SpecArtifactPaths(
+            self_spec=unit_file.with_name(f"{unit_file.stem}_spec.md"),
+            dependency_info=unit_file.with_name(f"{unit_file.stem}_info.md"),
+        )
 
     def is_artifact_path(self, path: Path) -> bool:
-        del path
-        self._not_implemented()
+        return Path(path).name.endswith(("_spec.md", "_info.md"))
+
+    @staticmethod
+    def _read_markdown(path: Path) -> tuple[str | None, str | None]:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            return None, f"cannot read hardware artifact {path}: {exc}"
+        if not text.strip():
+            return None, f"hardware artifact is empty: {path}"
+        return text, None
+
+    @staticmethod
+    def _validate_coverage_tree(text: str, path: Path) -> list[str]:
+        errors: list[str] = []
+        groups: list[dict] = []
+        group_names: set[str] = set()
+        current_group: dict | None = None
+        current_point: dict | None = None
+
+        for line_number, raw_line in enumerate(text.splitlines(), start=1):
+            stripped = raw_line.strip()
+            for match in _TAG_RE.finditer(raw_line):
+                kind, body = match.group(1), match.group(2)
+                full_tag = match.group(0)
+                if not _TAG_NAME_RE.fullmatch(body):
+                    errors.append(
+                        f"{path.name}: line {line_number}: malformed {kind} tag "
+                        f"{full_tag!r}; expected <{kind}-NAME> using uppercase "
+                        "letters, digits, and dashes"
+                    )
+                    continue
+
+                name = body[1:]
+                if kind == "FG":
+                    if stripped != full_tag:
+                        errors.append(
+                            f"{path.name}: line {line_number}: <FG-{name}> must "
+                            "be on its own line"
+                        )
+                    if name in group_names:
+                        errors.append(
+                            f"{path.name}: line {line_number}: duplicate "
+                            f"functional-group tag <FG-{name}>"
+                        )
+                    group_names.add(name)
+                    current_group = {
+                        "name": name,
+                        "line": line_number,
+                        "points": [],
+                    }
+                    groups.append(current_group)
+                    current_point = None
+                    continue
+
+                if kind == "FC":
+                    if stripped != full_tag:
+                        errors.append(
+                            f"{path.name}: line {line_number}: <FC-{name}> must "
+                            "be on its own line"
+                        )
+                    if current_group is None:
+                        errors.append(
+                            f"{path.name}: line {line_number}: <FC-{name}> "
+                            "appears before any <FG-*> group"
+                        )
+                        continue
+                    if any(
+                        point["name"] == name
+                        for point in current_group["points"]
+                    ):
+                        errors.append(
+                            f"{path.name}: line {line_number}: duplicate "
+                            f"function-point tag <FC-{name}> in "
+                            f"<FG-{current_group['name']}>"
+                        )
+                    current_point = {
+                        "name": name,
+                        "line": line_number,
+                        "checks": set(),
+                    }
+                    current_group["points"].append(current_point)
+                    continue
+
+                if current_point is None:
+                    errors.append(
+                        f"{path.name}: line {line_number}: <CK-{name}> appears "
+                        "before any <FC-*> function point"
+                    )
+                    continue
+                if name in current_point["checks"]:
+                    errors.append(
+                        f"{path.name}: line {line_number}: duplicate check-point "
+                        f"tag <CK-{name}> in <FC-{current_point['name']}>"
+                    )
+                current_point["checks"].add(name)
+
+        if not groups:
+            errors.append(f"{path.name}: no <FG-*> functional groups found")
+        if "API" not in group_names:
+            errors.append(f"{path.name}: missing mandatory <FG-API> group")
+        for group in groups:
+            if not group["points"]:
+                errors.append(
+                    f"{path.name}: <FG-{group['name']}> at line "
+                    f"{group['line']} has no <FC-*> function point"
+                )
+            for point in group["points"]:
+                if not point["checks"]:
+                    errors.append(
+                        f"{path.name}: <FC-{point['name']}> at line "
+                        f"{point['line']} has no <CK-*> check point"
+                    )
+        return errors
+
+    @staticmethod
+    def _dependency_names(
+        dependency: str,
+        aliases: Sequence[str] = (),
+    ) -> tuple[str, ...]:
+        names = [dependency, dependency.rsplit("::", 1)[-1], *aliases]
+        names.extend(
+            alias.rsplit("::", 1)[-1]
+            for alias in aliases
+            if "::" in alias
+        )
+        return tuple(dict.fromkeys(name.strip() for name in names if name.strip()))
+
+    @staticmethod
+    def _validate_dependency_info(text: str, path: Path) -> list[str]:
+        """Validate the common shape of a hardware dependency-info artifact."""
+        errors: list[str] = []
+        matches = list(_SUBMODULE_HEADING_RE.finditer(text))
+        claims_leaf = "(no submodules)" in text.lower()
+        if not matches and not claims_leaf:
+            errors.append(
+                f"{path.name}: expected at least one '# Submodule: <Name>' "
+                "entry or the exact leaf marker '(no submodules)'"
+            )
+        if matches and claims_leaf:
+            errors.append(
+                f"{path.name}: cannot contain submodule entries and also claim "
+                "'(no submodules)'"
+            )
+
+        recorded_names: set[str] = set()
+        for index, match in enumerate(matches):
+            name = match.group(1).strip()
+            if name in recorded_names:
+                errors.append(
+                    f"{path.name}: duplicate '# Submodule: {name}' entry"
+                )
+            recorded_names.add(name)
+            end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+            if not text[match.end():end].strip():
+                errors.append(
+                    f"{path.name}: '# Submodule: {name}' has no expected "
+                    "behavioral specification"
+                )
+        return errors
+
+    @classmethod
+    def _find_dependency_section(
+        cls,
+        text: str,
+        dependency: str,
+        aliases: Sequence[str] = (),
+    ) -> str | None:
+        matches = list(_SUBMODULE_HEADING_RE.finditer(text))
+        candidates = set(cls._dependency_names(dependency, aliases))
+        for index, match in enumerate(matches):
+            recorded_name = match.group(1).strip()
+            if recorded_name not in candidates:
+                continue
+            end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+            return text[match.start():end].strip()
+        return None
 
     def validate(
         self,
         unit_file: Path,
         expected_dependencies: Sequence[str] = (),
     ) -> SpecValidationResult:
-        del unit_file, expected_dependencies
-        self._not_implemented()
+        paths = self.artifact_paths(unit_file)
+        errors: list[str] = []
+        warnings: list[str] = []
+
+        spec_text, spec_read_error = self._read_markdown(paths.self_spec)
+        if spec_read_error:
+            errors.append(spec_read_error)
+        elif spec_text is not None:
+            errors.extend(self._validate_coverage_tree(spec_text, paths.self_spec))
+
+        info_text, info_read_error = self._read_markdown(paths.dependency_info)
+        if info_read_error:
+            errors.append(info_read_error)
+        elif info_text is not None:
+            errors.extend(
+                self._validate_dependency_info(info_text, paths.dependency_info)
+            )
+            missing_dependencies = [
+                dependency
+                for dependency in expected_dependencies
+                if self._find_dependency_section(info_text, dependency) is None
+            ]
+            if missing_dependencies:
+                message = (
+                    f"{paths.dependency_info.name}: missing '# Submodule:' "
+                    "entries for expected direct dependencies: "
+                    + ", ".join(sorted(dict.fromkeys(missing_dependencies)))
+                )
+                if self.dependency_coverage_is_blocking:
+                    errors.append(message)
+                else:
+                    warnings.append(message)
+
+        return SpecValidationResult(
+            ready=not errors,
+            errors=tuple(errors),
+            warnings=tuple(warnings),
+        )
 
     def read_self_spec(self, unit_file: Path) -> str | None:
-        del unit_file
-        self._not_implemented()
+        text, _error = self._read_markdown(
+            self.artifact_paths(unit_file).self_spec
+        )
+        return text
 
     def read_dependency_expectation(
         self,
@@ -52,28 +279,72 @@ class BootstrapHardwareSpecForm(SpecForm):
         callee_fqn: str,
         aliases: Sequence[str] = (),
     ) -> str | None:
-        del caller_file, callee_fqn, aliases
-        self._not_implemented()
+        text, _error = self._read_markdown(
+            self.artifact_paths(caller_file).dependency_info
+        )
+        if text is None:
+            return None
+        return self._find_dependency_section(text, callee_fqn, aliases)
 
     def batch_intro(self, language: str) -> str:
-        del language
-        self._not_implemented()
+        return (
+            f"Hardware dialect: {language}. Write standalone sibling "
+            "_spec.md and _info.md files for every extracted module."
+        )
 
     def output_contract_prompt(self) -> str:
-        self._not_implemented()
+        source_term = "Scala/Chisel" if self.dialect == "chisel" else "Verilog/SystemVerilog"
+        return "\n".join((
+            "## OUTPUT FORMAT (two standalone Markdown files per module)",
+            "",
+            "For each extracted module `<ModuleName>.<ext>`, write BOTH sibling files:",
+            "- `<ModuleName>_spec.md`: the module's observable behavioral contract",
+            "- `<ModuleName>_info.md`: caller-driven expectations for direct submodules",
+            "",
+            "Do not modify the extracted source file. Follow the complete structure in "
+            "fm_agent/spec_prompts/system_prompt.md.",
+            "Every `_spec.md` must contain an <FG-API> group. Every <FG-*> must contain "
+            "an <FC-*>, and every <FC-*> must contain an <CK-*>.",
+            "Use '# Submodule: <ExactDeclaredName>' for every direct dependency in "
+            "`_info.md`; write '(no submodules)' only for a leaf module.",
+            f"Describe exact ports, widths/types, parameters, clock/reset behavior, and "
+            f"protocol semantics visible in the {source_term} input.",
+        ))
 
     def system_prompt_path(self, script_dir: Path) -> Path:
-        del script_dir
-        self._not_implemented()
+        return (
+            Path(script_dir)
+            / "plugins"
+            / "chip"
+            / "prompts"
+            / self.dialect
+            / "system_prompt.md"
+        )
 
     def workflow_prompt_path(self, script_dir: Path) -> Path:
-        del script_dir
-        self._not_implemented()
+        return (
+            Path(script_dir)
+            / "plugins"
+            / "chip"
+            / "prompts"
+            / "workflow_spec_step4_batch.md"
+        )
 
     def generation_instruction(self, batch_prompt_rel: str, attempt: int) -> str:
-        del batch_prompt_rel, attempt
-        self._not_implemented()
+        action = "Process" if attempt == 1 else "Continue processing"
+        retry = "" if attempt == 1 else (
+            " Re-check every module and repair any missing or invalid artifact; "
+            "skip only modules whose two artifacts already satisfy the contract."
+        )
+        return (
+            f"{action} the hardware specification batch at {batch_prompt_rel}. "
+            "Read it and fm_agent/spec_prompts/system_prompt.md, then write the "
+            "required sibling _spec.md and _info.md files without modifying source "
+            f"files.{retry}"
+        )
 
     def trace_outputs(self, unit_files: Sequence[Path]) -> list[str]:
-        del unit_files
-        self._not_implemented()
+        paths = [self.artifact_paths(unit_file) for unit_file in unit_files]
+        return [str(path.self_spec) for path in paths] + [
+            str(path.dependency_info) for path in paths
+        ]

--- a/plugins/chip/forms/chisel.py
+++ b/plugins/chip/forms/chisel.py
@@ -1,8 +1,23 @@
 """Chisel hardware specification form."""
 
+from typing import Sequence
+
 from .base import HardwareSpecForm
 
 
 class ChiselSpecForm(HardwareSpecForm):
     id = "chip-chisel"
     dialect = "chisel"
+
+    def batch_rules(self, language: str) -> Sequence[str]:
+        return (
+            *super().batch_rules(language),
+            "Treat Scala constructors, loops, conditionals, and generators as "
+            "elaboration-time behavior, not runtime cycles",
+            "Expand verification-relevant Bundle, Vec, Decoupled, Valid, enum, "
+            "and nested interface fields without inventing widths or directions",
+            "Keep ordinary Scala classes, objects, traits, parameters, and "
+            "helpers as context; do not turn them into hardware modules",
+            "Use exact declared module names in '# Submodule:' entries and fold "
+            "repeated instances into one dependency contract",
+        )

--- a/plugins/chip/forms/chisel.py
+++ b/plugins/chip/forms/chisel.py
@@ -1,8 +1,8 @@
-"""Chisel specification-form identity for run-scoped configuration."""
+"""Chisel hardware specification form."""
 
-from .base import BootstrapHardwareSpecForm
+from .base import HardwareSpecForm
 
 
-class ChiselSpecForm(BootstrapHardwareSpecForm):
+class ChiselSpecForm(HardwareSpecForm):
     id = "chip-chisel"
     dialect = "chisel"

--- a/plugins/chip/forms/chisel.py
+++ b/plugins/chip/forms/chisel.py
@@ -1,0 +1,8 @@
+"""Chisel specification-form identity for run-scoped configuration."""
+
+from .base import BootstrapHardwareSpecForm
+
+
+class ChiselSpecForm(BootstrapHardwareSpecForm):
+    id = "chip-chisel"
+    dialect = "chisel"

--- a/plugins/chip/forms/verilog.py
+++ b/plugins/chip/forms/verilog.py
@@ -20,6 +20,13 @@ class VerilogSpecForm(HardwareSpecForm):
             "Use exact declared module types, not instance labels, in "
             "'# Submodule:' entries and fold repeated instances into one "
             "dependency contract",
+            "Do not infer ready/valid transfers or other protocol behavior "
+            "from signal names; check the exact RTL control condition",
+            "State exact cycle counts only after accounting for counter load, "
+            "decrement, zero, and transition cycles; otherwise use TBD",
+            "If the RTL diverges from an intended protocol rule, describe the "
+            "intended contract and the source divergence without asserting "
+            "conflicting guarantees",
             "Cover every known direct module dependency in _info.md; missing "
             "Verilog dependency coverage blocks artifact completion",
         )

--- a/plugins/chip/forms/verilog.py
+++ b/plugins/chip/forms/verilog.py
@@ -1,0 +1,8 @@
+"""Verilog specification-form identity for run-scoped configuration."""
+
+from .base import BootstrapHardwareSpecForm
+
+
+class VerilogSpecForm(BootstrapHardwareSpecForm):
+    id = "chip-verilog"
+    dialect = "verilog"

--- a/plugins/chip/forms/verilog.py
+++ b/plugins/chip/forms/verilog.py
@@ -1,5 +1,7 @@
 """Verilog hardware specification form."""
 
+from typing import Sequence
+
 from .base import HardwareSpecForm
 
 
@@ -7,3 +9,17 @@ class VerilogSpecForm(HardwareSpecForm):
     id = "chip-verilog"
     dialect = "verilog"
     dependency_coverage_is_blocking = True
+
+    def batch_rules(self, language: str) -> Sequence[str]:
+        return (
+            *super().batch_rules(language),
+            "Preserve exact module, parameter, port, packed/unpacked width, "
+            "and clock/reset declarations without inferring missing values",
+            "Distinguish compile/preprocessor and generate-time configuration "
+            "from cycle-observable RTL behavior",
+            "Use exact declared module types, not instance labels, in "
+            "'# Submodule:' entries and fold repeated instances into one "
+            "dependency contract",
+            "Cover every known direct module dependency in _info.md; missing "
+            "Verilog dependency coverage blocks artifact completion",
+        )

--- a/plugins/chip/forms/verilog.py
+++ b/plugins/chip/forms/verilog.py
@@ -1,8 +1,9 @@
-"""Verilog specification-form identity for run-scoped configuration."""
+"""Verilog hardware specification form."""
 
-from .base import BootstrapHardwareSpecForm
+from .base import HardwareSpecForm
 
 
-class VerilogSpecForm(BootstrapHardwareSpecForm):
+class VerilogSpecForm(HardwareSpecForm):
     id = "chip-verilog"
     dialect = "verilog"
+    dependency_coverage_is_blocking = True

--- a/plugins/chip/plugin.json
+++ b/plugins/chip/plugin.json
@@ -2,5 +2,14 @@
   "name": "chip",
   "version": "V0.1",
   "configure_function": "configure",
-  "stages": {}
+  "stages": {
+    "generate_phase_plan": {
+      "type": "replace",
+      "replace_function": "generate_phase_plan"
+    },
+    "generate_domain_context": {
+      "type": "replace",
+      "replace_function": "generate_domain_context"
+    }
+  }
 }

--- a/plugins/chip/plugin.json
+++ b/plugins/chip/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "chip",
+  "version": "V0.1",
+  "configure_function": "configure",
+  "stages": {}
+}

--- a/plugins/chip/plugin.py
+++ b/plugins/chip/plugin.py
@@ -2,6 +2,7 @@
 
 from plugins.chip.detection import (
     detect_chip_context,
+    read_plugin_submodules,
     read_chip_context,
     validate_context_dialect,
     write_chip_context,
@@ -21,7 +22,8 @@ def configure(proj_dir: str) -> None:
     """Select one dialect once and configure its run-scoped SpecForm."""
     global _configured_dialect
     _configured_dialect = None
-    detected = detect_chip_context(proj_dir)
+    submodules = read_plugin_submodules(proj_dir)
+    detected = detect_chip_context(proj_dir, submodules)
     write_chip_context(proj_dir, detected)
 
     # Consume the persisted routing fact for configuration. Later stages must

--- a/plugins/chip/plugin.py
+++ b/plugins/chip/plugin.py
@@ -1,0 +1,30 @@
+"""Standard configure entry point for the unified chip plugin."""
+
+from plugins.chip.detection import (
+    detect_chip_context,
+    read_chip_context,
+    validate_context_dialect,
+    write_chip_context,
+)
+from plugins.chip.forms import ChiselSpecForm, VerilogSpecForm
+from src.spec_forms import configure_current_spec_generation
+
+
+def configure(proj_dir: str) -> None:
+    """Select one dialect once and configure its run-scoped SpecForm."""
+    detected = detect_chip_context(proj_dir)
+    write_chip_context(proj_dir, detected)
+
+    # Consume the persisted routing fact for configuration. Later stages must
+    # use this same reader rather than independently scanning the project.
+    context = read_chip_context(proj_dir)
+    spec_form = (
+        ChiselSpecForm()
+        if context.dialect == "chisel"
+        else VerilogSpecForm()
+    )
+    validate_context_dialect(context, spec_form.dialect)
+    configure_current_spec_generation(
+        spec_form=spec_form,
+        enable_reasoning=False,
+    )

--- a/plugins/chip/plugin.py
+++ b/plugins/chip/plugin.py
@@ -7,11 +7,20 @@ from plugins.chip.detection import (
     write_chip_context,
 )
 from plugins.chip.forms import ChiselSpecForm, VerilogSpecForm
+from plugins.chip.runner import (
+    generate_domain_context as run_generate_domain_context,
+    generate_phase_plan as run_generate_phase_plan,
+)
 from src.spec_forms import configure_current_spec_generation
+
+
+_configured_dialect: str | None = None
 
 
 def configure(proj_dir: str) -> None:
     """Select one dialect once and configure its run-scoped SpecForm."""
+    global _configured_dialect
+    _configured_dialect = None
     detected = detect_chip_context(proj_dir)
     write_chip_context(proj_dir, detected)
 
@@ -27,4 +36,30 @@ def configure(proj_dir: str) -> None:
     configure_current_spec_generation(
         spec_form=spec_form,
         enable_reasoning=False,
+    )
+    _configured_dialect = context.dialect
+
+
+def _require_configured_dialect() -> str:
+    if _configured_dialect is None:
+        raise RuntimeError(
+            "chip Stage 1/2 runner was invoked before configure() established "
+            "the run dialect"
+        )
+    return _configured_dialect
+
+
+def generate_phase_plan(proj_dir: str) -> None:
+    """Run Stage 1 with the dialect selected during configure()."""
+    run_generate_phase_plan(
+        proj_dir,
+        expected_dialect=_require_configured_dialect(),
+    )
+
+
+def generate_domain_context(proj_dir: str) -> None:
+    """Run Stage 2 with the dialect selected during configure()."""
+    run_generate_domain_context(
+        proj_dir,
+        expected_dialect=_require_configured_dialect(),
     )

--- a/plugins/chip/prompts/chisel/system_prompt.md
+++ b/plugins/chip/prompts/chisel/system_prompt.md
@@ -1,29 +1,132 @@
-# Chisel module specification rules
+# Chisel Module Specification Rules
 
 Write two standalone English Markdown documents beside every extracted Chisel
-module source. Never modify the source.
+module source. Never modify the extracted source or the original project source.
 
-- `<ModuleName>_spec.md` defines the intended observable contract of the module.
-- `<ModuleName>_info.md` defines what the module requires each direct submodule
-  to guarantee. Start every entry with `# Submodule: <ExactDeclaredName>`. A
-  true leaf module may use `(no submodules)`.
+- `<ExtractedStem>_spec.md` defines the intended observable contract of that
+  extracted hardware module.
+- `<ExtractedStem>_info.md` defines what the module requires each direct
+  submodule to guarantee.
 
-The specification must cover exact ports and Bundle fields, directions,
-widths/types, parameters and elaboration conditions, clock/reset behavior,
-handshake and protocol semantics, state transitions, timing relationships, and
-error behavior when applicable. Do not invent behavior that the source and
-domain context do not support, and do not describe an implementation bug as the
-intended contract.
+Use the exact extracted filename stem for both artifact names. The extracted
+stem can differ from the declared Scala name when declarations were
+canonicalized or deduplicated.
 
-Organize observable behavior as a coverage tree:
+## Behavioral boundary
 
-- Put `<FG-NAME>` on its own line for each functional group.
-- Put `<FC-NAME>` on its own line for each function point below that group.
-- Include at least one `<CK-NAME>` check point below every function point.
-- Names use only uppercase letters, digits, and dashes and are unique among
-  siblings.
-- Include an `<FG-API>` group covering the interfaces needed to drive, monitor,
-  and check the module.
+- Describe what the elaborated hardware guarantees, not a line-by-line account
+  of Chisel assignments or Scala control flow.
+- Treat constructor arguments, Scala conditionals/loops, generators, implicits,
+  and type-level computation as elaboration-time behavior. Describe their
+  observable effect on ports, widths, capacity, topology, or supported features;
+  do not present them as runtime clocked behavior.
+- Preserve exact port, Bundle field, parameter, and declared submodule names.
+- Expand verification-relevant `Bundle`, `Vec`, `Decoupled`, `Valid`, enum, and
+  nested interface fields. State direction, width/type, and handshake meaning
+  only when supported by the source or domain context.
+- Cover clock/reset behavior, state transitions, transaction boundaries,
+  ordering, backpressure, arbitration, latency, throughput, and error behavior
+  when they are observable and established.
+- Do not invent ports, widths, reset values, submodules, cycle relationships, or
+  protocol rules. Mark genuinely unresolved facts as `TBD`.
+- Describe intended correct behavior. An implementation defect is not part of
+  the intended contract.
+- Use precise, falsifiable English. Avoid claims such as "properly",
+  "correctly handles", "appropriate", or "as expected" unless the exact
+  condition and observable result are stated.
+- Cite relevant project-relative source locations and line numbers when they
+  are available.
 
-Each function point must state a falsifiable trigger, state/data effect, and
-observable result. Cite relevant source paths and lines when available.
+## `<ExtractedStem>_spec.md`
+
+Use this top-level structure. A section that does not apply must say `None`,
+`N/A`, or `TBD`; do not silently omit required information.
+
+```markdown
+# <DeclaredModuleName> Specification Document
+
+## Introduction
+## Terms and Abbreviations in Chisel Code
+## Chisel Source Files
+## Top-Level Interface Overview
+## Functional Description
+## Subcomponent Description
+## State Machines and Timing
+## Configuration Registers and Storage
+## Reset and Error Handling
+## Parameterization and Configurable Features
+## Verification Requirements and Coverage Suggestions
+```
+
+The interface overview must identify the declared module, all observable ports
+and nested fields, their directions and widths/types, and clock/reset semantics.
+The parameterization section must separate elaboration parameters from runtime
+configuration. The state/timing sections must state trigger, state/data effect,
+and observable result rather than transcribing implementation statements.
+
+### Coverage tree
+
+Organize all observable behavior as a machine-checkable FG/FC/CK tree:
+
+- Each functional group has a `###` heading followed by an `<FG-NAME>` tag on
+  its own line.
+- Each group contains at least one function point with a `####` heading followed
+  by an `<FC-NAME>` tag on its own line.
+- Each function point contains at least one check-point bullet carrying a
+  `<CK-NAME>` tag.
+- Names use only uppercase letters, digits, and dashes. Functional-group names
+  are document-unique, function-point names are unique within their group, and
+  check-point names are unique within their function point.
+- Every function point states a falsifiable trigger, state/data effect, and
+  observable result.
+- Include an `<FG-API>` group covering the drivers, monitors, reference-model
+  observations, and assertions needed to verify the module's interfaces.
+
+Example shape:
+
+```markdown
+### Interface API
+
+<FG-API>
+
+#### Request handshake
+
+<FC-REQUEST-HANDSHAKE>
+
+**Check points:**
+- <CK-BACKPRESSURE> When request valid is held while ready is low, no transfer
+  occurs and request information remains stable as required by the interface.
+```
+
+## `<ExtractedStem>_info.md`
+
+This document is caller-driven: derive each entry from how the parent drives,
+observes, and depends on the child, not from a summary of the child's own
+implementation.
+
+Start every direct dependency with exactly:
+
+```markdown
+# Submodule: <ExactDeclaredName>
+```
+
+Under the heading, state the interface, timing, reset, protocol, ordering, and
+data guarantees the parent requires. Use the declared Chisel module name, not an
+instance variable name or a file-qualified graph identifier. Include each known
+direct submodule once even when it is instantiated multiple times.
+
+If the module has no known direct submodules, write the exact marker
+`(no submodules)` and do not add a `# Submodule:` entry. Never combine the leaf
+marker with submodule entries. Dynamic elaboration may make source-derived
+dependency information incomplete; do not invent a dependency to compensate.
+
+## Final checks
+
+Before finishing each module, confirm that:
+
+1. Both sibling Markdown artifacts exist and the extracted source is unchanged.
+2. The spec contains `<FG-API>` and every FG contains an FC with at least one CK.
+3. Port, Bundle field, parameter, clock/reset, and protocol claims are supported.
+4. Every known direct submodule has one non-empty `# Submodule:` entry, or the
+   module is explicitly marked `(no submodules)`.
+5. Both documents are entirely in English.

--- a/plugins/chip/prompts/chisel/system_prompt.md
+++ b/plugins/chip/prompts/chisel/system_prompt.md
@@ -1,0 +1,29 @@
+# Chisel module specification rules
+
+Write two standalone English Markdown documents beside every extracted Chisel
+module source. Never modify the source.
+
+- `<ModuleName>_spec.md` defines the intended observable contract of the module.
+- `<ModuleName>_info.md` defines what the module requires each direct submodule
+  to guarantee. Start every entry with `# Submodule: <ExactDeclaredName>`. A
+  true leaf module may use `(no submodules)`.
+
+The specification must cover exact ports and Bundle fields, directions,
+widths/types, parameters and elaboration conditions, clock/reset behavior,
+handshake and protocol semantics, state transitions, timing relationships, and
+error behavior when applicable. Do not invent behavior that the source and
+domain context do not support, and do not describe an implementation bug as the
+intended contract.
+
+Organize observable behavior as a coverage tree:
+
+- Put `<FG-NAME>` on its own line for each functional group.
+- Put `<FC-NAME>` on its own line for each function point below that group.
+- Include at least one `<CK-NAME>` check point below every function point.
+- Names use only uppercase letters, digits, and dashes and are unique among
+  siblings.
+- Include an `<FG-API>` group covering the interfaces needed to drive, monitor,
+  and check the module.
+
+Each function point must state a falsifiable trigger, state/data effect, and
+observable result. Cite relevant source paths and lines when available.

--- a/plugins/chip/prompts/chisel/workflow_generate_domain_context.md
+++ b/plugins/chip/prompts/chisel/workflow_generate_domain_context.md
@@ -5,19 +5,51 @@ Read the finalized `fm_agent/phases.json`, then create only:
 - `fm_agent/spec_prompts/domain_context/engine_overview.txt`
 - one `fm_agent/spec_prompts/domain_context/phase_NN_types.txt` for every phase
 
-Do not modify `phases.json` or any project source.
+Do not modify `phases.json`, project sources, or files outside those output
+paths. Write all output in English.
 
-In `engine_overview.txt`, describe the hardware architecture, module hierarchy,
-data/control flow, clock and reset domains, protocols, and major elaboration
-conditions. In each phase file, document the Chisel modules and relevant
-Bundles, parameters, widths/types, directions, Decoupled or other handshake
-semantics, state transitions, timing guarantees, and invariants used by that
-phase.
+## `engine_overview.txt`
 
-Distinguish elaboration-time Scala behavior from observable hardware behavior.
-Do not invent widths, ports, submodules, cycle relationships, or protocol rules
-that the listed sources do not establish. Do not run sbt, CIRCT, firtool, or any
-other Chisel toolchain.
+Describe the project-wide hardware contract and architecture:
+
+- major hardware modules and their direct instantiation hierarchy;
+- data and control flow between modules;
+- clock and reset domains, including reset kind, polarity, and observable reset
+  behavior when the source establishes them;
+- Decoupled/ready-valid, Valid, memory, interrupt, bus, and custom protocol
+  conventions, including backpressure and ordering rules;
+- shared width, encoding, addressing, alignment, arbitration, and priority
+  conventions;
+- top-level constructor parameters and elaboration choices that change ports,
+  capacity, topology, or supported behavior;
+- cross-module invariants relevant to verification.
+
+State uncertainty explicitly. Do not infer a cycle relationship, reset value,
+port, width, or protocol guarantee that the sources do not establish.
+
+## `phase_NN_types.txt`
+
+For each phase, read every source file assigned to that phase and document the
+hardware modules plus the context declarations they use. Cover, where present:
+
+- module constructor parameters and their observable hardware effects;
+- top-level IO and nested `Bundle`, `Vec`, `Decoupled`, `Valid`, enum, and custom
+  interface fields with exact names, directions, widths/types, and encodings;
+- clock/reset expectations and clock-domain crossings;
+- registers, memories, queues, visible state machines, and reset values;
+- transaction triggers, handshake completion, backpressure, ordering, latency,
+  throughput, arbitration, flush/replay, and error behavior;
+- direct submodule relationships and the behavior each parent relies on;
+- elaboration conditions that add/remove modules, fields, widths, or features.
+
+Bundle, parameter, type, constant, and helper-only files are context, not
+independent hardware specification units. Clearly distinguish elaboration-time
+Scala behavior from behavior observable after the circuit has been elaborated.
+
+Do not run sbt, mill, Chisel generators, CIRCT, firtool, simulators, or any
+other project toolchain. Base the context only on the source and supplied domain
+knowledge.
 
 Before finishing, confirm that `engine_overview.txt` and every required
-`phase_NN_types.txt` exist and are non-empty.
+`phase_NN_types.txt` exist, are non-empty, are written in English, and match the
+final phase numbering and source-file assignments.

--- a/plugins/chip/prompts/chisel/workflow_generate_domain_context.md
+++ b/plugins/chip/prompts/chisel/workflow_generate_domain_context.md
@@ -1,0 +1,23 @@
+# Generate Chisel Domain Context
+
+Read the finalized `fm_agent/phases.json`, then create only:
+
+- `fm_agent/spec_prompts/domain_context/engine_overview.txt`
+- one `fm_agent/spec_prompts/domain_context/phase_NN_types.txt` for every phase
+
+Do not modify `phases.json` or any project source.
+
+In `engine_overview.txt`, describe the hardware architecture, module hierarchy,
+data/control flow, clock and reset domains, protocols, and major elaboration
+conditions. In each phase file, document the Chisel modules and relevant
+Bundles, parameters, widths/types, directions, Decoupled or other handshake
+semantics, state transitions, timing guarantees, and invariants used by that
+phase.
+
+Distinguish elaboration-time Scala behavior from observable hardware behavior.
+Do not invent widths, ports, submodules, cycle relationships, or protocol rules
+that the listed sources do not establish. Do not run sbt, CIRCT, firtool, or any
+other Chisel toolchain.
+
+Before finishing, confirm that `engine_overview.txt` and every required
+`phase_NN_types.txt` exist and are non-empty.

--- a/plugins/chip/prompts/chisel/workflow_generate_phases.md
+++ b/plugins/chip/prompts/chisel/workflow_generate_phases.md
@@ -3,11 +3,10 @@
 Write only `fm_agent/phases.json`. Do not edit project sources or create domain
 context files in this stage.
 
-Inspect the Chisel design and group its hardware modules into dependency-ordered
-phases. Treat top-level declarations extending `Module`, `RawModule`,
-`BlackBox`, `ExtModule`, or `MultiIOModule` as hardware units. Bundles, ordinary
-Scala classes/objects/traits, parameters, and helpers may inform grouping but
-must not become independent hardware units.
+Inspect the Chisel design and group its source files into dependency-ordered
+hardware phases. A phase is an architectural grouping, not a Scala compilation
+step. Use module instantiation, shared interfaces, and data/control flow to
+choose the grouping.
 
 The output must use this standard shape:
 
@@ -23,8 +22,8 @@ The output must use this standard shape:
       "description": "<hardware responsibility>",
       "modules": [
         {
-          "name": "<subsystem name>",
-          "description": "<module responsibilities and interfaces>",
+          "name": "<source group name>",
+          "description": "<hardware and context responsibilities>",
           "source_files": ["src/main/scala/example/Module.scala"]
         }
       ],
@@ -34,17 +33,38 @@ The output must use this standard shape:
 }
 ```
 
-Rules:
+## Chisel source model
+
+- Top-level declarations extending `Module`, `RawModule`, `BlackBox`,
+  `ExtModule`, or `MultiIOModule` are hardware specification units.
+- Bundles, ordinary Scala classes/objects/traits, parameters, type aliases, and
+  helpers are context. They must not be described as independent hardware
+  modules, but their source files still belong in the phase plan.
+- A single source file may declare several hardware modules. Keep that source
+  file in one source group; later stages extract the individual modules.
+- Distinguish Scala elaboration-time dependencies from runtime hardware data
+  flow. Use both when arranging phases, but do not claim that elaboration
+  executes in hardware cycles.
+
+## Required rules
 
 - `languages` must be exactly `["chisel"]`.
-- `file_extensions` must be exactly `["scala", "sc"]`.
-- Source paths are project-relative and each source file appears at most once.
-- Include only `.scala` and `.sc` sources that contribute Chisel hardware.
-- Exclude `src/test`, test/testbench trees, generated/build output, `fm_agent/`,
-  and all Verilog/SystemVerilog sources. Verilog blackboxes may be read for
-  context but are not independent specification units in this run.
+- `file_extensions` must be exactly `["scala", "sc"]`, even when the project
+  happens to use only one of the two extensions.
+- Include every in-scope, non-test `.scala` and `.sc` source file exactly once.
+  This includes files containing only Bundles, parameters, types, constants,
+  annotations, or helper code because hardware modules may require them as
+  context.
+- Source paths must be project-relative. Never list a file more than once.
+- Exclude `src/test`, test/spec/testbench trees and files, generated/build
+  output, hidden workspace directories, and `fm_agent/`.
+- Exclude every Verilog/SystemVerilog file. Blackbox RTL may be read as context,
+  but it is not a Chisel specification unit in this run.
 - Preserve dependency order: a phase may depend only on earlier phases.
-- Do not run the project, invoke sbt, elaborate Chisel, or install tools.
+- Every phase and source group must have a concrete hardware-oriented name and
+  description. Do not call a Bundle/helper source a hardware module.
+- Do not run the project, invoke sbt, elaborate Chisel, invoke CIRCT/firtool, or
+  install tools.
 
-Before finishing, parse the JSON and confirm that at least one Chisel source is
-listed.
+Before finishing, parse the JSON and confirm that every in-scope Chisel source
+is listed exactly once and at least one source file is present.

--- a/plugins/chip/prompts/chisel/workflow_generate_phases.md
+++ b/plugins/chip/prompts/chisel/workflow_generate_phases.md
@@ -1,0 +1,50 @@
+# Generate a Chisel Phase Plan
+
+Write only `fm_agent/phases.json`. Do not edit project sources or create domain
+context files in this stage.
+
+Inspect the Chisel design and group its hardware modules into dependency-ordered
+phases. Treat top-level declarations extending `Module`, `RawModule`,
+`BlackBox`, `ExtModule`, or `MultiIOModule` as hardware units. Bundles, ordinary
+Scala classes/objects/traits, parameters, and helpers may inform grouping but
+must not become independent hardware units.
+
+The output must use this standard shape:
+
+```json
+{
+  "project": "<project name>",
+  "languages": ["chisel"],
+  "file_extensions": ["scala", "sc"],
+  "phases": [
+    {
+      "phase": 1,
+      "name": "<phase name>",
+      "description": "<hardware responsibility>",
+      "modules": [
+        {
+          "name": "<subsystem name>",
+          "description": "<module responsibilities and interfaces>",
+          "source_files": ["src/main/scala/example/Module.scala"]
+        }
+      ],
+      "depends_on_phases": []
+    }
+  ]
+}
+```
+
+Rules:
+
+- `languages` must be exactly `["chisel"]`.
+- `file_extensions` must be exactly `["scala", "sc"]`.
+- Source paths are project-relative and each source file appears at most once.
+- Include only `.scala` and `.sc` sources that contribute Chisel hardware.
+- Exclude `src/test`, test/testbench trees, generated/build output, `fm_agent/`,
+  and all Verilog/SystemVerilog sources. Verilog blackboxes may be read for
+  context but are not independent specification units in this run.
+- Preserve dependency order: a phase may depend only on earlier phases.
+- Do not run the project, invoke sbt, elaborate Chisel, or install tools.
+
+Before finishing, parse the JSON and confirm that at least one Chisel source is
+listed.

--- a/plugins/chip/prompts/verilog/system_prompt.md
+++ b/plugins/chip/prompts/verilog/system_prompt.md
@@ -1,29 +1,147 @@
-# Verilog module specification rules
+# Verilog/SystemVerilog Module Specification Rules
 
-Write two standalone English Markdown documents beside every extracted Verilog
-or SystemVerilog module source. Never modify the source.
+Write two standalone English Markdown documents beside every extracted
+Verilog/SystemVerilog module source. Never modify the extracted source or the
+original project source.
 
-- `<ModuleName>_spec.md` defines the intended observable contract of the module.
-- `<ModuleName>_info.md` defines what the module requires each directly
-  instantiated module to guarantee. It must cover every known direct instance;
-  start every entry with `# Submodule: <ExactDeclaredName>`. A true leaf module
-  may use `(no submodules)`.
+- `<ExtractedStem>_spec.md` defines the intended observable contract of that
+  extracted hardware module.
+- `<ExtractedStem>_info.md` defines what the module requires each direct
+  instantiated module to guarantee.
 
-The specification must cover exact ports, directions and widths, parameters,
-relevant macros, clock/reset behavior, handshake and protocol semantics, state
-transitions, cycle relationships, and error behavior when applicable. Do not
-invent behavior that the source and domain context do not support, and do not
-describe an implementation bug as the intended contract.
+Use the exact extracted filename stem for both artifact names. The extracted
+stem can differ from the declared module name when declarations were
+canonicalized or deduplicated.
 
-Organize observable behavior as a coverage tree:
+## Behavioral boundary
 
-- Put `<FG-NAME>` on its own line for each functional group.
-- Put `<FC-NAME>` on its own line for each function point below that group.
-- Include at least one `<CK-NAME>` check point below every function point.
-- Names use only uppercase letters, digits, and dashes and are unique among
-  siblings.
-- Include an `<FG-API>` group covering the interfaces needed to drive, monitor,
-  and check the module.
+- Describe what the elaborated RTL guarantees, not a line-by-line account of
+  assignments, procedural blocks, continuous assignments, or generate code.
+- Treat preprocessor macros, parameter overrides, package configuration, and
+  `generate` conditions as compile/elaboration-time choices. Describe their
+  observable effect on ports, widths, capacity, topology, timing, or supported
+  features; do not present them as runtime clocked behavior.
+- Preserve exact declared module, parameter, port, interface, struct field, and
+  direct dependency names.
+- Record every observable port with its direction, packed/unpacked width or
+  type, signedness when relevant, and protocol meaning. Expand
+  verification-relevant interfaces, modports, arrays, structs, unions, enums,
+  and nested fields when the source establishes them.
+- Distinguish combinational behavior from edge-triggered sequential behavior.
+  Cover clock/reset domains, reset polarity and kind, state transitions,
+  transaction boundaries, ordering, backpressure, arbitration, latency,
+  throughput, and error behavior when observable and established.
+- Do not infer behavior from signal naming alone. Do not invent ports, widths,
+  signedness, reset values, submodules, cycle relationships, or protocol rules.
+  Mark genuinely unresolved facts as `TBD`.
+- Describe intended correct behavior. An implementation defect is not part of
+  the intended contract.
+- Use precise, falsifiable English. Avoid claims such as "properly",
+  "correctly handles", "appropriate", or "as expected" unless the exact
+  condition and observable result are stated.
+- Cite relevant project-relative source locations and line numbers when they
+  are available.
 
-Each function point must state a falsifiable trigger, state/data effect, and
-observable result. Cite relevant source paths and lines when available.
+## `<ExtractedStem>_spec.md`
+
+Use this top-level structure. A section that does not apply must say `None`,
+`N/A`, or `TBD`; do not silently omit required information.
+
+```markdown
+# <DeclaredModuleName> Specification Document
+
+## Introduction
+## Terms and Abbreviations in RTL Code
+## RTL Source Files
+## Top-Level Interface Overview
+## Functional Description
+## Subcomponent Description
+## State Machines and Timing
+## Configuration Registers and Storage
+## Reset and Error Handling
+## Parameterization and Configurable Features
+## Verification Requirements and Coverage Suggestions
+```
+
+The interface overview must identify the declared module and every observable
+port, including exact direction, width/type, signedness, and clock/reset
+semantics. The parameterization section must separate parameters, macros, and
+generate-time choices from runtime configuration. State/timing sections must
+state trigger, state/data effect, sampling edge or combinational condition, and
+observable result rather than transcribing RTL statements.
+
+### Coverage tree
+
+Organize all observable behavior as a machine-checkable FG/FC/CK tree:
+
+- Each functional group has a `###` heading followed by an `<FG-NAME>` tag on
+  its own line.
+- Each group contains at least one function point with a `####` heading followed
+  by an `<FC-NAME>` tag on its own line.
+- Each function point contains at least one check-point bullet carrying a
+  `<CK-NAME>` tag.
+- Names use only uppercase letters, digits, and dashes. Functional-group names
+  are document-unique, function-point names are unique within their group, and
+  check-point names are unique within their function point.
+- Every function point states a falsifiable trigger, state/data effect, and
+  observable result, including cycle relationships only when established.
+- Include an `<FG-API>` group covering the drivers, monitors, reference-model
+  observations, clock/reset control, and assertions needed to verify the
+  module's interfaces.
+
+Example shape:
+
+```markdown
+### Interface API
+
+<FG-API>
+
+#### Request handshake
+
+<FC-REQUEST-HANDSHAKE>
+
+**Check points:**
+- <CK-BACKPRESSURE> When request valid is held while ready is low, no transfer
+  occurs and request information remains stable as required by the interface.
+```
+
+## `<ExtractedStem>_info.md`
+
+This document is caller-driven: derive each entry from how the parent connects,
+drives, samples, and depends on the child, not from a summary of the child's own
+implementation.
+
+Start every known direct module dependency with exactly:
+
+```markdown
+# Submodule: <ExactDeclaredName>
+```
+
+Under the heading, state the ports, parameter assumptions, timing, reset,
+protocol, ordering, and data guarantees the parent requires. Use the exact
+declared module type, not an instance label, interface type, package name,
+filename, or file-qualified graph identifier. Include each direct module type
+once even when several instances or a generate loop instantiate it.
+
+Verilog dependency coverage is blocking: every direct module dependency
+provided in the batch context must have a non-empty matching entry. Do not omit
+a dependency merely because its implementation is external, encrypted, or not
+part of this run; describe the caller-visible requirement supported by the
+parent source and use `TBD` for facts the parent does not constrain.
+
+If the module has no known direct submodules, write the exact marker
+`(no submodules)` and do not add a `# Submodule:` entry. Never combine the leaf
+marker with submodule entries, and never invent a dependency.
+
+## Final checks
+
+Before finishing each module, confirm that:
+
+1. Both sibling Markdown artifacts exist and the extracted source is unchanged.
+2. The spec contains `<FG-API>` and every FG contains an FC with at least one CK.
+3. Module, parameter, port, width/type, clock/reset, and protocol claims are
+   supported by source or domain context.
+4. Every known direct instantiated module type has one non-empty
+   `# Submodule:` entry, or the module is explicitly marked `(no submodules)`.
+5. Repeated instances are folded into one module-type dependency contract.
+6. Both documents are entirely in English.

--- a/plugins/chip/prompts/verilog/system_prompt.md
+++ b/plugins/chip/prompts/verilog/system_prompt.md
@@ -34,8 +34,19 @@ canonicalized or deduplicated.
 - Do not infer behavior from signal naming alone. Do not invent ports, widths,
   signedness, reset values, submodules, cycle relationships, or protocol rules.
   Mark genuinely unresolved facts as `TBD`.
-- Describe intended correct behavior. An implementation defect is not part of
-  the intended contract.
+- A ready/valid-style name does not establish a transfer condition. Check the
+  exact control expression before claiming that a handshake accepts, rejects,
+  buffers, or drops data.
+- Derive exact cycle counts only after accounting for counter-load, decrement,
+  zero-detection, transition, and nonblocking-assignment cycles. A loaded value
+  such as `N-1` is not by itself proof of an `N-1` cycle interval. Use `TBD`
+  instead of an unverified formula.
+- State whether a runtime configuration input is latched once or read again at
+  later state transitions. Do not silently treat a live input as frame-stable.
+- Describe intended correct behavior. When the source diverges from that
+  contract, identify the source divergence as an implementation risk; do not
+  mix the intended rule and the observed divergent behavior into contradictory
+  guarantees.
 - Use precise, falsifiable English. Avoid claims such as "properly",
   "correctly handles", "appropriate", or "as expected" unless the exact
   condition and observable result are stated.

--- a/plugins/chip/prompts/verilog/system_prompt.md
+++ b/plugins/chip/prompts/verilog/system_prompt.md
@@ -1,0 +1,29 @@
+# Verilog module specification rules
+
+Write two standalone English Markdown documents beside every extracted Verilog
+or SystemVerilog module source. Never modify the source.
+
+- `<ModuleName>_spec.md` defines the intended observable contract of the module.
+- `<ModuleName>_info.md` defines what the module requires each directly
+  instantiated module to guarantee. It must cover every known direct instance;
+  start every entry with `# Submodule: <ExactDeclaredName>`. A true leaf module
+  may use `(no submodules)`.
+
+The specification must cover exact ports, directions and widths, parameters,
+relevant macros, clock/reset behavior, handshake and protocol semantics, state
+transitions, cycle relationships, and error behavior when applicable. Do not
+invent behavior that the source and domain context do not support, and do not
+describe an implementation bug as the intended contract.
+
+Organize observable behavior as a coverage tree:
+
+- Put `<FG-NAME>` on its own line for each functional group.
+- Put `<FC-NAME>` on its own line for each function point below that group.
+- Include at least one `<CK-NAME>` check point below every function point.
+- Names use only uppercase letters, digits, and dashes and are unique among
+  siblings.
+- Include an `<FG-API>` group covering the interfaces needed to drive, monitor,
+  and check the module.
+
+Each function point must state a falsifiable trigger, state/data effect, and
+observable result. Cite relevant source paths and lines when available.

--- a/plugins/chip/prompts/verilog/workflow_generate_domain_context.md
+++ b/plugins/chip/prompts/verilog/workflow_generate_domain_context.md
@@ -5,17 +5,58 @@ Read the finalized `fm_agent/phases.json`, then create only:
 - `fm_agent/spec_prompts/domain_context/engine_overview.txt`
 - one `fm_agent/spec_prompts/domain_context/phase_NN_types.txt` for every phase
 
-Do not modify `phases.json` or any project source.
+Do not modify `phases.json`, project sources, or files outside those output
+paths. Write all output in English.
 
-In `engine_overview.txt`, describe the RTL architecture, module hierarchy,
-data/control flow, clock and reset domains, interfaces, and major protocols. In
-each phase file, document modules, ports, directions, widths, parameters,
-relevant macros and typedefs, instantiated children, state transitions, cycle
-relationships, handshake rules, and invariants used by that phase.
+## `engine_overview.txt`
 
-Separate compile/elaboration configuration from observable RTL behavior. Do not
-invent widths, ports, instances, timing guarantees, or protocol rules that the
-listed sources do not establish. Do not run simulations or synthesis.
+Describe the project-wide RTL contract and architecture:
+
+- major modules and their direct instantiation hierarchy, using module types
+  rather than instance labels;
+- data and control flow between modules;
+- clock and reset domains, including synchronous/asynchronous behavior,
+  polarity, and observable reset state when established by the source;
+- ready/valid, request/response, streaming, memory, interrupt, bus, and custom
+  protocol conventions, including backpressure and ordering rules;
+- shared width, encoding, addressing, alignment, arbitration, priority, and
+  error conventions;
+- top-level parameters, macros, and generate choices that alter ports, widths,
+  capacity, topology, timing, or supported features;
+- cross-module invariants relevant to verification.
+
+State uncertainty explicitly. Do not infer a cycle relationship, reset value,
+port, width, instance, or protocol guarantee that the sources do not establish.
+
+## `phase_NN_types.txt`
+
+For each phase, read every source file assigned to that phase and document the
+design modules plus the context declarations they use. Cover, where present:
+
+- module parameters and local parameters, their defaults/overrides, and their
+  observable hardware effects;
+- exact port names, directions, packed/unpacked widths, signedness, interface
+  modports, structs/unions/enums, arrays, and relevant package typedefs;
+- clock/reset expectations, multiple clock domains, and clock-domain crossings;
+- registers, memories, queues, visible state machines, and established reset
+  values;
+- combinational versus sequential behavior and transaction trigger, handshake,
+  backpressure, ordering, latency, throughput, arbitration, flush/replay, and
+  error rules;
+- direct instantiated module types, parameter overrides, port connections, and
+  the behavior each parent relies on;
+- preprocessor macros, include/header context, package imports, interfaces, and
+  `generate` conditions that change the elaborated design.
+
+Package, interface, header, macro, typedef, parameter, and helper-only files are
+context, not independent module specification units. Clearly separate
+compile/preprocessor and generate-time configuration from behavior observable
+after RTL elaboration.
+
+Do not run preprocessors, compilers, linters, simulators, synthesis,
+elaboration, Verible, Verilator, Icarus Verilog, Yosys, or any project
+toolchain. Base the context only on source and supplied domain knowledge.
 
 Before finishing, confirm that `engine_overview.txt` and every required
-`phase_NN_types.txt` exist and are non-empty.
+`phase_NN_types.txt` exist, are non-empty, are written in English, and match the
+final phase numbering and source-file assignments.

--- a/plugins/chip/prompts/verilog/workflow_generate_domain_context.md
+++ b/plugins/chip/prompts/verilog/workflow_generate_domain_context.md
@@ -1,0 +1,21 @@
+# Generate Verilog/SystemVerilog Domain Context
+
+Read the finalized `fm_agent/phases.json`, then create only:
+
+- `fm_agent/spec_prompts/domain_context/engine_overview.txt`
+- one `fm_agent/spec_prompts/domain_context/phase_NN_types.txt` for every phase
+
+Do not modify `phases.json` or any project source.
+
+In `engine_overview.txt`, describe the RTL architecture, module hierarchy,
+data/control flow, clock and reset domains, interfaces, and major protocols. In
+each phase file, document modules, ports, directions, widths, parameters,
+relevant macros and typedefs, instantiated children, state transitions, cycle
+relationships, handshake rules, and invariants used by that phase.
+
+Separate compile/elaboration configuration from observable RTL behavior. Do not
+invent widths, ports, instances, timing guarantees, or protocol rules that the
+listed sources do not establish. Do not run simulations or synthesis.
+
+Before finishing, confirm that `engine_overview.txt` and every required
+`phase_NN_types.txt` exist and are non-empty.

--- a/plugins/chip/prompts/verilog/workflow_generate_phases.md
+++ b/plugins/chip/prompts/verilog/workflow_generate_phases.md
@@ -3,10 +3,10 @@
 Write only `fm_agent/phases.json`. Do not edit project sources or create domain
 context files in this stage.
 
-Inspect the RTL design and group design modules into dependency-ordered phases.
-Top-level `module` declarations are hardware units. Packages, interfaces,
-headers, macros, typedef-only files, and helpers may provide context but must not
-be represented as independent modules when they contain no design module.
+Inspect the RTL design and group its source files into dependency-ordered
+hardware phases. A phase is an architectural grouping, not a compiler, lint,
+simulation, or synthesis step. Use module instantiation, shared interfaces, and
+data/control flow to choose the grouping.
 
 The output must use this standard shape:
 
@@ -33,17 +33,39 @@ The output must use this standard shape:
 }
 ```
 
-Rules:
+## Verilog/SystemVerilog source model
+
+- Every `module` declaration is a hardware specification unit. A source file
+  may declare several modules; keep the file in one source group because later
+  stages extract the individual modules.
+- Packages, interfaces, headers, macros, parameters, typedefs, and helper-only
+  files are context. Do not describe them as independent design modules, but
+  their source files still belong in the phase plan when they are in scope.
+- A module type is distinct from its instance labels. Repeated instances of one
+  module type express one module-level dependency.
+- Preprocessor choices, parameter overrides, and `generate` constructs select
+  elaborated RTL structure. Do not present them as runtime clock cycles.
+
+## Required rules
 
 - `languages` must be exactly `["verilog"]`.
-- `file_extensions` must be exactly `["v", "sv", "svh"]`.
-- Source paths are project-relative and each source file appears at most once.
-- Include only `.v`, `.sv`, and `.svh` design sources.
-- Exclude testbench, simulation, test, generated/build output, and `fm_agent/`
-  trees, and exclude all Scala/Chisel sources.
+- `file_extensions` must be exactly `["v", "sv", "svh"]`, even when the
+  project happens to use only a subset of those extensions.
+- Include every in-scope, non-test `.v`, `.sv`, and `.svh` source file exactly
+  once. This includes package, interface, macro, typedef, include/header, and
+  helper-only files because design modules may require them as context.
+- Source paths must be project-relative. Never list a file more than once.
+- Exclude testbench, test, verification, and simulation trees and files;
+  generated/build output; hidden workspace directories; and `fm_agent/`.
+- Exclude every Scala/Chisel source. Mixed-language analysis is not part of this
+  run.
 - Preserve module-instantiation dependency order: a phase may depend only on
   earlier phases.
-- Do not run simulations, synthesis, or install tools.
+- Every phase and source group must have a concrete hardware-oriented name and
+  description. Do not call a package, interface, header, or helper a module.
+- Do not run compilers, preprocessors, linters, simulators, synthesis,
+  elaboration, Verible, Verilator, Icarus Verilog, Yosys, or install tools.
 
-Before finishing, parse the JSON and confirm that at least one Verilog or
-SystemVerilog source is listed.
+Before finishing, parse the JSON and confirm that every in-scope Verilog or
+SystemVerilog source is listed exactly once and at least one source file is
+present.

--- a/plugins/chip/prompts/verilog/workflow_generate_phases.md
+++ b/plugins/chip/prompts/verilog/workflow_generate_phases.md
@@ -1,0 +1,49 @@
+# Generate a Verilog/SystemVerilog Phase Plan
+
+Write only `fm_agent/phases.json`. Do not edit project sources or create domain
+context files in this stage.
+
+Inspect the RTL design and group design modules into dependency-ordered phases.
+Top-level `module` declarations are hardware units. Packages, interfaces,
+headers, macros, typedef-only files, and helpers may provide context but must not
+be represented as independent modules when they contain no design module.
+
+The output must use this standard shape:
+
+```json
+{
+  "project": "<project name>",
+  "languages": ["verilog"],
+  "file_extensions": ["v", "sv", "svh"],
+  "phases": [
+    {
+      "phase": 1,
+      "name": "<phase name>",
+      "description": "<hardware responsibility>",
+      "modules": [
+        {
+          "name": "<subsystem name>",
+          "description": "<module responsibilities and interfaces>",
+          "source_files": ["rtl/module.sv"]
+        }
+      ],
+      "depends_on_phases": []
+    }
+  ]
+}
+```
+
+Rules:
+
+- `languages` must be exactly `["verilog"]`.
+- `file_extensions` must be exactly `["v", "sv", "svh"]`.
+- Source paths are project-relative and each source file appears at most once.
+- Include only `.v`, `.sv`, and `.svh` design sources.
+- Exclude testbench, simulation, test, generated/build output, and `fm_agent/`
+  trees, and exclude all Scala/Chisel sources.
+- Preserve module-instantiation dependency order: a phase may depend only on
+  earlier phases.
+- Do not run simulations, synthesis, or install tools.
+
+Before finishing, parse the JSON and confirm that at least one Verilog or
+SystemVerilog source is listed.

--- a/plugins/chip/prompts/workflow_spec_step4_batch.md
+++ b/plugins/chip/prompts/workflow_spec_step4_batch.md
@@ -1,0 +1,9 @@
+# Hardware specification batch workflow
+
+Read the batch prompt named in the instruction and
+`fm_agent/spec_prompts/system_prompt.md`. For every listed module, read the
+extracted source and any caller expectations, then write both requested sibling
+Markdown artifacts.
+
+Do not modify source files. Describe intended, observable hardware behavior and
+repair every validation issue included in a retry instruction.

--- a/plugins/chip/runner.py
+++ b/plugins/chip/runner.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from functools import partial
 from pathlib import Path
 
 from plugins.chip.detection import (
+    ChipContext,
     read_chip_context,
     validate_context_dialect,
 )
@@ -25,7 +27,7 @@ class ChipRunnerError(RuntimeError):
 def _load_strategy(
     proj_dir: str | Path,
     expected_dialect: str,
-) -> DialectStrategy:
+) -> tuple[ChipContext, DialectStrategy]:
     context = read_chip_context(proj_dir)
     validate_context_dialect(context, expected_dialect)
     strategy = get_dialect_strategy(context.dialect)
@@ -35,7 +37,7 @@ def _load_strategy(
         raise ChipRunnerError(
             f"chip {context.dialect} Stage 1/2 resources are missing: {rendered}"
         )
-    return strategy
+    return context, strategy
 
 
 def generate_phase_plan(
@@ -45,14 +47,18 @@ def generate_phase_plan(
 ) -> None:
     """Generate and dialect-check the standard ``fm_agent/phases.json``."""
     project = Path(proj_dir).resolve()
-    strategy = _load_strategy(project, expected_dialect)
+    context, strategy = _load_strategy(project, expected_dialect)
     work_dir = project / "fm_agent"
     _run_generate_phases(
         str(project),
         str(work_dir),
         str(_REPOSITORY_ROOT),
         workflow_source=strategy.phase_plan_workflow,
-        phase_plan_validator=strategy.validate_phase_plan,
+        submodules=context.submodules,
+        phase_plan_validator=partial(
+            strategy.validate_phase_plan,
+            submodules=context.submodules,
+        ),
     )
 
 
@@ -63,13 +69,16 @@ def generate_domain_context(
 ) -> None:
     """Generate standard domain-context files for the persisted dialect."""
     project = Path(proj_dir).resolve()
-    strategy = _load_strategy(project, expected_dialect)
+    context, strategy = _load_strategy(project, expected_dialect)
     phases_path = project / "fm_agent" / "phases.json"
     if not phases_path.is_file():
         raise ChipRunnerError(
             f"chip Stage 2 requires Stage 1 output at {phases_path}"
         )
-    phase_errors = strategy.validate_phase_plan(phases_path)
+    phase_errors = strategy.validate_phase_plan(
+        phases_path,
+        submodules=context.submodules,
+    )
     if phase_errors:
         raise ChipRunnerError(
             "chip Stage 2 refused a phase plan that does not match the "

--- a/plugins/chip/runner.py
+++ b/plugins/chip/runner.py
@@ -1,0 +1,83 @@
+"""Shared Stage 1/2 runner for the unified chip plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from plugins.chip.detection import (
+    read_chip_context,
+    validate_context_dialect,
+)
+from plugins.chip.dialects import DialectStrategy, get_dialect_strategy
+from src.pipeline_setup import (
+    _run_generate_domain_context,
+    _run_generate_phases,
+)
+
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+class ChipRunnerError(RuntimeError):
+    """Raised when the persisted routing fact cannot drive Stage 1/2."""
+
+
+def _load_strategy(
+    proj_dir: str | Path,
+    expected_dialect: str,
+) -> DialectStrategy:
+    context = read_chip_context(proj_dir)
+    validate_context_dialect(context, expected_dialect)
+    strategy = get_dialect_strategy(context.dialect)
+    missing = [path for path in strategy.required_resources() if not path.is_file()]
+    if missing:
+        rendered = ", ".join(str(path) for path in missing)
+        raise ChipRunnerError(
+            f"chip {context.dialect} Stage 1/2 resources are missing: {rendered}"
+        )
+    return strategy
+
+
+def generate_phase_plan(
+    proj_dir: str,
+    *,
+    expected_dialect: str,
+) -> None:
+    """Generate and dialect-check the standard ``fm_agent/phases.json``."""
+    project = Path(proj_dir).resolve()
+    strategy = _load_strategy(project, expected_dialect)
+    work_dir = project / "fm_agent"
+    _run_generate_phases(
+        str(project),
+        str(work_dir),
+        str(_REPOSITORY_ROOT),
+        workflow_source=strategy.phase_plan_workflow,
+        phase_plan_validator=strategy.validate_phase_plan,
+    )
+
+
+def generate_domain_context(
+    proj_dir: str,
+    *,
+    expected_dialect: str,
+) -> None:
+    """Generate standard domain-context files for the persisted dialect."""
+    project = Path(proj_dir).resolve()
+    strategy = _load_strategy(project, expected_dialect)
+    phases_path = project / "fm_agent" / "phases.json"
+    if not phases_path.is_file():
+        raise ChipRunnerError(
+            f"chip Stage 2 requires Stage 1 output at {phases_path}"
+        )
+    phase_errors = strategy.validate_phase_plan(phases_path)
+    if phase_errors:
+        raise ChipRunnerError(
+            "chip Stage 2 refused a phase plan that does not match the "
+            f"persisted {strategy.dialect} dialect: {'; '.join(phase_errors)}"
+        )
+    _run_generate_domain_context(
+        str(project),
+        str(project / "fm_agent"),
+        str(_REPOSITORY_ROOT),
+        workflow_source=strategy.domain_context_workflow,
+    )

--- a/src/extract.py
+++ b/src/extract.py
@@ -4,12 +4,14 @@ import re
 import sys
 import shutil
 import logging
+from pathlib import Path
 
-from src.file_utils import is_file_ready, _is_test_file
+from src.file_utils import _is_test_file
 from src.languages.codegraph import canonicalize
 from src.languages.registry import (
     batch_extract_all, function_spans_for_file, BackendUnavailableError,
 )
+from src.spec_forms import SOFTWARE_SPEC_FORM
 
 LANG_CONFIG = {
     "cpp": {
@@ -677,7 +679,7 @@ def _function_spans(filepath, lang_key, proj_dir=None):
 
 def run_extraction(
     proj_dir, work_dir=None, force=False, verbose=False,
-    return_unavailable_backends=False,
+    return_unavailable_backends=False, *, spec_form=SOFTWARE_SPEC_FORM,
 ):
     """Run function extraction on a project directory.
 
@@ -687,7 +689,9 @@ def run_extraction(
 
     Returns (written_count, skipped_count). When
     ``return_unavailable_backends`` is true, appends the languages whose
-    semantic full-project extraction backend failed.
+    semantic full-project extraction backend failed. On resume, ``spec_form``
+    determines whether an existing extracted unit has complete artifacts and
+    must be preserved.
     """
     if work_dir is None:
         work_dir = proj_dir
@@ -775,9 +779,13 @@ def run_extraction(
             # maps "/" -> "_", and falls back to "_function" for empty names.
             out_file = os.path.join(out_dir, _safe_filename(func_name, ext))
 
-            # Skip only when the extracted file already has valid .spec.json and
-            # .info.json sidecars.
-            if not force and os.path.exists(out_file) and is_file_ready(out_file):
+            # Preserve an extracted unit when the active form reports complete
+            # artifacts. This keeps resumed source and specs from diverging.
+            if (
+                not force
+                and os.path.exists(out_file)
+                and spec_form.validate(Path(out_file)).ready
+            ):
                 if verbose:
                     print(f"  SKIP (specced): {os.path.relpath(out_file, proj_dir)}")
                 skipped += 1

--- a/src/extract.py
+++ b/src/extract.py
@@ -119,6 +119,21 @@ LANG_CONFIG = {
         },
         "body": "external",
     },
+    "chisel": {
+        "comment_prefix": "//",
+        "skip_prefixes": ("//", "/*", "*", "package", "import"),
+        "skip_keywords_line": (),
+        "keywords": {
+            "abstract", "case", "catch", "class", "def", "do", "else",
+            "extends", "final", "finally", "for", "if", "implicit",
+            "import", "lazy", "match", "new", "object", "override",
+            "package", "private", "protected", "return", "sealed",
+            "super", "this", "throw", "trait", "try", "type", "val",
+            "var", "while", "with", "yield",
+        },
+        # Chisel extraction is owned exclusively by its registered handler.
+        "body": "external",
+    },
     "cuda": {
         "comment_prefix": "//",
         "skip_prefixes": ("//", "#", "using", "typedef"),
@@ -160,6 +175,7 @@ EXT_TO_LANG = {
     "js": "javascript", "jsx": "javascript",
     "cu": "cuda", "cuh": "cuda",
     "ets": "arkts",
+    "scala": "chisel", "sc": "chisel",
 }
 
 # ---------------------------------------------------------------------------
@@ -724,6 +740,7 @@ def run_extraction(
     output_base = os.path.join(work_dir, "extracted_functions")
     written = 0
     skipped = 0
+    handled_empty = 0
     errors = []
 
     for src_rel in source_files:
@@ -739,7 +756,7 @@ def run_extraction(
             continue
 
         # Detect language from file extension
-        ext = src_rel.rsplit('.', 1)[-1] if '.' in src_rel else ''
+        ext = src_rel.rsplit('.', 1)[-1].lower() if '.' in src_rel else ''
         lang_key = EXT_TO_LANG.get(ext)
         if not lang_key:
             logging.warning(f"Unsupported file extension '.{ext}' for {src_rel}, skipping.")
@@ -756,12 +773,20 @@ def run_extraction(
         out_dir = os.path.join(output_base, src_dir, dir_name) if src_dir else os.path.join(output_base, dir_name)
 
         registry_key = os.path.normcase(os.path.normpath(src_path))
-        if registry_key in registry_funcs:
+        handled_by_registry = registry_key in registry_funcs
+        if handled_by_registry:
             funcs = registry_funcs[registry_key]
         else:
             funcs = extract_functions_from_file(src_path, lang_key)
         if not funcs:
-            logging.warning(f"No functions extracted from {src_rel}")
+            if handled_by_registry:
+                handled_empty += 1
+                logging.info(
+                    "No analysis units in handled source file %s",
+                    src_rel,
+                )
+            else:
+                logging.warning(f"No functions extracted from {src_rel}")
             continue
 
         os.makedirs(out_dir, exist_ok=True)
@@ -800,7 +825,16 @@ def run_extraction(
     print(f"Extraction complete: {written} written, {skipped} skipped.")
 
     if written == 0 and skipped == 0:
-        logging.error("Nothing was extracted — check phases.json source_files paths.")
+        if handled_empty:
+            logging.info(
+                "Extraction completed with %d handled source file(s) containing "
+                "no analysis units.",
+                handled_empty,
+            )
+        else:
+            logging.error(
+                "Nothing was extracted — check phases.json source_files paths."
+            )
         return (
             (written, skipped, unavailable_backends)
             if return_unavailable_backends else (written, skipped)
@@ -842,7 +876,7 @@ def _validate_extraction(extracted_dir, registry_langs=None):
     failures = []
     for root, _, files in os.walk(extracted_dir):
         for fname in files:
-            ext = fname.rsplit('.', 1)[-1] if '.' in fname else ''
+            ext = fname.rsplit('.', 1)[-1].lower() if '.' in fname else ''
             lang_key = EXT_TO_LANG.get(ext)
             if not lang_key:
                 continue

--- a/src/extract.py
+++ b/src/extract.py
@@ -134,6 +134,22 @@ LANG_CONFIG = {
         # Chisel extraction is owned exclusively by its registered handler.
         "body": "external",
     },
+    "verilog": {
+        "comment_prefix": "//",
+        "skip_prefixes": ("//", "/*", "*", "`"),
+        "skip_keywords_line": (),
+        "keywords": {
+            "always", "always_comb", "always_ff", "always_latch", "and",
+            "assign", "begin", "buf", "case", "do", "else", "end",
+            "endcase", "endfunction", "endgenerate", "endmodule",
+            "endpackage", "endtask", "for", "forever", "function",
+            "generate", "if", "initial", "module", "nand", "nor", "not",
+            "or", "package", "parameter", "primitive", "repeat", "task",
+            "wait", "while", "xnor", "xor",
+        },
+        # Verilog module extraction is owned by its registered handler.
+        "body": "external",
+    },
     "cuda": {
         "comment_prefix": "//",
         "skip_prefixes": ("//", "#", "using", "typedef"),
@@ -176,6 +192,7 @@ EXT_TO_LANG = {
     "cu": "cuda", "cuh": "cuda",
     "ets": "arkts",
     "scala": "chisel", "sc": "chisel",
+    "v": "verilog", "sv": "verilog", "svh": "verilog",
 }
 
 # ---------------------------------------------------------------------------

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -2,31 +2,10 @@ import json
 import os
 import re
 
-
-# This module is also copied by the current full pipeline and imported as a
-# standalone helper from ``fm_agent/spec_prompts``. Source-package imports use
-# the canonical SoftwareSpecForm; the fallback preserves that copied runtime
-# until batch prompt generation moves in-process in the next refactor stage.
-if __package__:
-    from .spec_forms import SOFTWARE_SPEC_FORM
-else:
-    SOFTWARE_SPEC_FORM = None
+from .spec_forms import SOFTWARE_SPEC_FORM
 
 
 _METADATA_SIDECAR_SUFFIXES = (".spec.json", ".info.json")
-
-_SPEC_FIELDS = {
-    "signature",
-    "pre_condition",
-    "post_condition",
-}
-
-_CALLEE_FIELDS = {
-    "name",
-    "signature",
-    "pre_condition",
-    "post_condition",
-}
 
 _ALL_BUGS_GAP_FIELDS = {
     "spec_claim",
@@ -84,55 +63,17 @@ def collect_file_names(input_dir, output_path="file_list.json"):
 
 def _is_valid_spec_json(data):
     """Check that .spec.json contains exactly the supported fields."""
-    if SOFTWARE_SPEC_FORM is not None:
-        return SOFTWARE_SPEC_FORM.is_valid_spec_data(data)
-    if not isinstance(data, dict):
-        return False
-    if set(data) != _SPEC_FIELDS:
-        return False
-    return all(isinstance(data[field], str) for field in _SPEC_FIELDS)
+    return SOFTWARE_SPEC_FORM.is_valid_spec_data(data)
 
 
 def _is_valid_info_json(data):
     """Check that .info.json contains exactly the supported fields."""
-    if SOFTWARE_SPEC_FORM is not None:
-        return SOFTWARE_SPEC_FORM.is_valid_info_data(data)
-    if not isinstance(data, dict) or set(data) != {"callees"}:
-        return False
-
-    callees = data["callees"]
-    if not isinstance(callees, list):
-        return False
-
-    for callee in callees:
-        if not isinstance(callee, dict) or set(callee) != _CALLEE_FIELDS:
-            return False
-        if not all(isinstance(callee[field], str) for field in _CALLEE_FIELDS):
-            return False
-
-    return True
+    return SOFTWARE_SPEC_FORM.is_valid_info_data(data)
 
 
 def is_file_ready(file_path):
     """Return whether both metadata sidecars contain valid new-format JSON."""
-    if SOFTWARE_SPEC_FORM is not None:
-        return SOFTWARE_SPEC_FORM.validate(file_path).ready
-
-    spec_path = f"{file_path}.spec.json"
-    info_path = f"{file_path}.info.json"
-
-    if not os.path.isfile(spec_path) or not os.path.isfile(info_path):
-        return False
-
-    try:
-        with open(spec_path, "r", encoding="utf-8") as file:
-            spec = json.load(file)
-        with open(info_path, "r", encoding="utf-8") as file:
-            info = json.load(file)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return False
-
-    return _is_valid_spec_json(spec) and _is_valid_info_json(info)
+    return SOFTWARE_SPEC_FORM.validate(file_path).ready
 
 
 # Directories that typically contain test code

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -118,6 +118,12 @@ _TEST_FILE_PATTERNS = [
 _CHISEL_TEST_FILE_PATTERN = re.compile(
     r"^.*(?:Spec|Test|Tester)\.(?:scala|sc)$"
 )
+_VERILOG_TEST_FILE_PATTERN = re.compile(
+    r"^(?:tb_.+|testbench(?:_.+)?|.+_(?:tb|test|testbench))"
+    r"\.(?:v|sv|svh)$",
+    re.IGNORECASE,
+)
+_VERILOG_TEST_DIR_NAMES = frozenset({"tb", "sim", "testbench"})
 
 
 # Project-relative paths that must never be treated as test files, even when
@@ -494,6 +500,13 @@ def _is_test_file(rel_path):
         if in_main_source_tree:
             return False
         return bool(_CHISEL_TEST_FILE_PATTERN.match(parts[-1]))
+    if extension in {".v", ".sv", ".svh"}:
+        if any(
+            part.lower() in _VERILOG_TEST_DIR_NAMES
+            for part in parts[:-1]
+        ):
+            return True
+        return bool(_VERILOG_TEST_FILE_PATTERN.match(parts[-1]))
     # Check filename against test patterns
     basename = parts[-1]
     for pat in _TEST_FILE_PATTERNS:

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from pathlib import Path
 
 from .spec_forms import SOFTWARE_SPEC_FORM
 
@@ -35,6 +36,38 @@ def _is_metadata_sidecar(file_path):
     return str(file_path).endswith(_METADATA_SIDECAR_SUFFIXES)
 
 
+def _normalized_file_path(file_path):
+    """Return a stable comparison key for a local file path."""
+    return os.path.normcase(
+        os.path.abspath(os.path.normpath(os.fspath(file_path)))
+    )
+
+
+def _exclude_spec_artifacts(file_paths, spec_form=SOFTWARE_SPEC_FORM):
+    """Exclude configured spec artifacts from a collection of analysis units.
+
+    ``SpecForm`` exposes a forward mapping from a unit to its artifacts, so the
+    full candidate collection is needed to identify custom artifact paths.  The
+    fixed software suffix check remains for compatibility with orphaned legacy
+    sidecars whose original unit is no longer present.
+    """
+    file_paths = list(file_paths)
+    configured_artifacts = set()
+    for file_path in file_paths:
+        artifacts = spec_form.artifact_paths(Path(file_path))
+        configured_artifacts.add(_normalized_file_path(artifacts.self_spec))
+        configured_artifacts.add(
+            _normalized_file_path(artifacts.dependency_info)
+        )
+
+    return [
+        file_path
+        for file_path in file_paths
+        if not _is_metadata_sidecar(file_path)
+        and _normalized_file_path(file_path) not in configured_artifacts
+    ]
+
+
 def _write_file_names(file_names, output_path):
     """Write sorted, de-duplicated file names to output_path."""
     file_names = sorted(dict.fromkeys(file_names))
@@ -45,19 +78,25 @@ def _write_file_names(file_names, output_path):
     return file_names
 
 
-def collect_file_names(input_dir, output_path="file_list.json"):
+def collect_file_names(
+    input_dir,
+    output_path="file_list.json",
+    *,
+    spec_form=SOFTWARE_SPEC_FORM,
+):
     """Collect all file names under input_dir and write them to a JSON file.
 
     Each entry contains the relative path starting from input_dir.
     """
-    file_names = []
+    file_paths = []
     for root, _, files in os.walk(input_dir):
         for fname in files:
-            if _is_metadata_sidecar(fname):
-                continue
             full_path = os.path.join(root, fname)
-            rel_path = os.path.relpath(full_path, input_dir)
-            file_names.append(rel_path)
+            file_paths.append(full_path)
+    file_names = [
+        os.path.relpath(file_path, input_dir)
+        for file_path in _exclude_spec_artifacts(file_paths, spec_form)
+    ]
     return _write_file_names(file_names, output_path)
 
 
@@ -342,7 +381,13 @@ def _json_file_is_valid(path):
         return False
 
 
-def _get_phase_files(phases_data, phase_num, input_dir):
+def _get_phase_files(
+    phases_data,
+    phase_num,
+    input_dir,
+    *,
+    spec_form=SOFTWARE_SPEC_FORM,
+):
     """Return relative paths of extracted function files for a given phase."""
     phase = next(p for p in phases_data["phases"] if p["phase"] == phase_num)
     phase_files = []
@@ -364,12 +409,20 @@ def _get_phase_files(phases_data, phase_num, input_dir):
                 for root, _dirs, fnames in os.walk(extracted_dir):
                     for fname in sorted(fnames):
                         fpath = os.path.join(root, fname)
-                        if os.path.isfile(fpath) and not _is_metadata_sidecar(fname):
-                            phase_files.append(os.path.relpath(fpath, input_dir))
-    return phase_files
+                        if os.path.isfile(fpath):
+                            phase_files.append(fpath)
+    return [
+        os.path.relpath(file_path, input_dir)
+        for file_path in _exclude_spec_artifacts(phase_files, spec_form)
+    ]
 
 
-def _get_all_phase_files(phases_data, input_dir):
+def _get_all_phase_files(
+    phases_data,
+    input_dir,
+    *,
+    spec_form=SOFTWARE_SPEC_FORM,
+):
     """Return extracted function files reachable from all phases in phases.json."""
     phase_files = []
     seen = set()
@@ -377,7 +430,12 @@ def _get_all_phase_files(phases_data, input_dir):
         phase_num = phase_info.get("phase")
         if phase_num is None:
             continue
-        for rel in _get_phase_files(phases_data, phase_num, input_dir):
+        for rel in _get_phase_files(
+            phases_data,
+            phase_num,
+            input_dir,
+            spec_form=spec_form,
+        ):
             if rel not in seen:
                 seen.add(rel)
                 phase_files.append(rel)

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -3,6 +3,16 @@ import os
 import re
 
 
+# This module is also copied by the current full pipeline and imported as a
+# standalone helper from ``fm_agent/spec_prompts``. Source-package imports use
+# the canonical SoftwareSpecForm; the fallback preserves that copied runtime
+# until batch prompt generation moves in-process in the next refactor stage.
+if __package__:
+    from .spec_forms import SOFTWARE_SPEC_FORM
+else:
+    SOFTWARE_SPEC_FORM = None
+
+
 _METADATA_SIDECAR_SUFFIXES = (".spec.json", ".info.json")
 
 _SPEC_FIELDS = {
@@ -74,6 +84,8 @@ def collect_file_names(input_dir, output_path="file_list.json"):
 
 def _is_valid_spec_json(data):
     """Check that .spec.json contains exactly the supported fields."""
+    if SOFTWARE_SPEC_FORM is not None:
+        return SOFTWARE_SPEC_FORM.is_valid_spec_data(data)
     if not isinstance(data, dict):
         return False
     if set(data) != _SPEC_FIELDS:
@@ -83,6 +95,8 @@ def _is_valid_spec_json(data):
 
 def _is_valid_info_json(data):
     """Check that .info.json contains exactly the supported fields."""
+    if SOFTWARE_SPEC_FORM is not None:
+        return SOFTWARE_SPEC_FORM.is_valid_info_data(data)
     if not isinstance(data, dict) or set(data) != {"callees"}:
         return False
 
@@ -101,6 +115,9 @@ def _is_valid_info_json(data):
 
 def is_file_ready(file_path):
     """Return whether both metadata sidecars contain valid new-format JSON."""
+    if SOFTWARE_SPEC_FORM is not None:
+        return SOFTWARE_SPEC_FORM.validate(file_path).ready
+
     spec_path = f"{file_path}.spec.json"
     info_path = f"{file_path}.info.json"
 

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -3,6 +3,7 @@ import os
 import re
 from pathlib import Path
 
+from .languages.hardware import is_excluded_source_directory
 from .spec_forms import SOFTWARE_SPEC_FORM
 
 
@@ -113,6 +114,10 @@ _TEST_FILE_PATTERNS = [
     re.compile(r'^.*\.test\.(?:ets)$'),    # ArkTS: foo.test.ets
     re.compile(r'^.*_(?:SUITE|tests?)\.erl$'),  # Erlang: Common Test / EUnit
 ]
+
+_CHISEL_TEST_FILE_PATTERN = re.compile(
+    r"^.*(?:Spec|Test|Tester)\.(?:scala|sc)$"
+)
 
 
 # Project-relative paths that must never be treated as test files, even when
@@ -443,11 +448,17 @@ def _iter_project_source_files(proj_dir, submodules=None):
 
     for scan_root in scan_roots:
         for root, dirs, files in os.walk(scan_root):
-            # Skip hidden dirs and common non-source dirs
-            dirs[:] = [d for d in dirs if not d.startswith('.') and d not in
-                       {'node_modules', '__pycache__', 'venv', '.venv', 'fm_agent'}]
+            dirs[:] = [
+                directory
+                for directory in dirs
+                if not is_excluded_source_directory(directory)
+            ]
             for fname in files:
-                ext = fname.rsplit('.', 1)[-1] if '.' in fname else ''
+                ext = (
+                    fname.rsplit('.', 1)[-1].lower()
+                    if '.' in fname
+                    else ''
+                )
                 if ext not in source_exts:
                     continue
                 rel = os.path.relpath(os.path.join(root, fname), proj_dir)
@@ -473,6 +484,16 @@ def _is_test_file(rel_path):
     for part in parts[:-1]:
         if part.lower() in _TEST_DIR_NAMES:
             return True
+    extension = Path(parts[-1]).suffix.lower()
+    if extension in {".scala", ".sc"}:
+        lower_parts = [part.lower() for part in parts[:-1]]
+        in_main_source_tree = any(
+            lower_parts[index:index + 2] == ["src", "main"]
+            for index in range(len(lower_parts) - 1)
+        )
+        if in_main_source_tree:
+            return False
+        return bool(_CHISEL_TEST_FILE_PATTERN.match(parts[-1]))
     # Check filename against test patterns
     basename = parts[-1]
     for pat in _TEST_FILE_PATTERNS:

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -36,35 +36,13 @@ def _is_metadata_sidecar(file_path):
     return str(file_path).endswith(_METADATA_SIDECAR_SUFFIXES)
 
 
-def _normalized_file_path(file_path):
-    """Return a stable comparison key for a local file path."""
-    return os.path.normcase(
-        os.path.abspath(os.path.normpath(os.fspath(file_path)))
-    )
-
-
 def _exclude_spec_artifacts(file_paths, spec_form=SOFTWARE_SPEC_FORM):
-    """Exclude configured spec artifacts from a collection of analysis units.
-
-    ``SpecForm`` exposes a forward mapping from a unit to its artifacts, so the
-    full candidate collection is needed to identify custom artifact paths.  The
-    fixed software suffix check remains for compatibility with orphaned legacy
-    sidecars whose original unit is no longer present.
-    """
-    file_paths = list(file_paths)
-    configured_artifacts = set()
-    for file_path in file_paths:
-        artifacts = spec_form.artifact_paths(Path(file_path))
-        configured_artifacts.add(_normalized_file_path(artifacts.self_spec))
-        configured_artifacts.add(
-            _normalized_file_path(artifacts.dependency_info)
-        )
-
+    """Exclude artifacts owned by the configured specification form."""
     return [
         file_path
         for file_path in file_paths
         if not _is_metadata_sidecar(file_path)
-        and _normalized_file_path(file_path) not in configured_artifacts
+        and not spec_form.is_artifact_path(Path(file_path))
     ]
 
 

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -342,7 +342,10 @@ def generate_batch_prompts(
                 prompt_funcs = [
                     fn
                     for fn in fn_batch
-                    if not spec_form.validate(work_dir / fn["file"]).ready
+                    if not spec_form.validate(
+                        work_dir / fn["file"],
+                        expected_dependencies=fn.get("all_callees", ()),
+                    ).ready
                 ]
                 skipped_functions += len(fn_batch) - len(prompt_funcs)
             out_path = output_dir / filename

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -202,11 +202,13 @@ def build_prompt(
             lines.append(f"- {path}")
     lines.append("")
     lines.append("## KEY RULES")
-    lines.append("- Describe WHAT the function guarantees, NOT HOW it implements it")
-    lines.append("- Do NOT name internal helper calls, loop structure, or data layout decisions")
-    lines.append("- Do NOT enumerate members of sets - describe the GOVERNING RULE")
-    lines.append("- Specs describe INTENDED CORRECT behavior per the domain (see domain files)")
-    lines.append(f"- ALL files below exist in {fm_agent_prefix}extracted_functions/ - read and process each one")
+    for rule in spec_form.batch_rules(sample_lang):
+        lines.append(f"- {rule}")
+    unit_noun = spec_form.unit_noun
+    lines.append(
+        f"- ALL {unit_noun} files below exist in "
+        f"{fm_agent_prefix}extracted_functions/ - read and process each one"
+    )
 
     caller_specs: List[Tuple[str, str]] = []
     caller_expectations: Dict[str, List[Tuple[str, str]]] = {}
@@ -261,18 +263,36 @@ def build_prompt(
 
     if is_cycle:
         lines.append("## CYCLE LAYER GUIDANCE")
-        lines.append("These functions call each other (mutual recursion / circular dependencies).")
-        lines.append(
-            'Ask: "What is true after this function returns, regardless of which caller invoked it and which code path executed?" '
-            "That invariant is your post-condition."
-        )
-        lines.append("")
-        lines.append("DISPATCH FUNCTION TEST: If your spec has N bullets where N equals the number")
-        lines.append("of switch arms / dispatch cases, you are transcribing the implementation.")
-        lines.append("A dispatch function's contract is the invariant that holds ACROSS ALL cases.")
+        if unit_noun == "function":
+            lines.append(
+                "These functions call each other (mutual recursion / circular dependencies)."
+            )
+            lines.append(
+                'Ask: "What is true after this function returns, regardless of which caller invoked it and which code path executed?" '
+                "That invariant is your post-condition."
+            )
+            lines.append("")
+            lines.append("DISPATCH FUNCTION TEST: If your spec has N bullets where N equals the number")
+            lines.append("of switch arms / dispatch cases, you are transcribing the implementation.")
+            lines.append("A dispatch function's contract is the invariant that holds ACROSS ALL cases.")
+        else:
+            lines.append(
+                f"These {unit_noun}s have circular dependencies within this layer."
+            )
+            lines.append(
+                f'Ask: "What observable contract must this {unit_noun} satisfy, '
+                'regardless of which dependency path is active?"'
+            )
+            lines.append("")
+            lines.append(
+                "Describe the stable contract across the cycle, not a transcript "
+                "of individual dependency paths."
+            )
         lines.append("")
 
-    lines.append(f"## FUNCTIONS ({len(functions)} total - process ALL)")
+    lines.append(
+        f"## {unit_noun.upper()}S ({len(functions)} total - process ALL)"
+    )
     for idx, fn in enumerate(functions, start=1):
         fn_name = fn["name"]
         caller_key = phase_callers_key(fn, phase)

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -54,6 +54,32 @@ COMMENT_PREFIX_BY_LANG = {
 }
 
 
+def extension_language_map(
+    languages: Sequence[str],
+    file_extensions: Sequence[str],
+) -> dict[str, str]:
+    """Map phase-plan extensions to languages without truncating silently.
+
+    A single configured language may own any number of extensions (for
+    example, Chisel owns ``scala`` and ``sc``). Multi-language plans retain the
+    positional mapping and must provide exactly one language per extension.
+    """
+    normalized_extensions = [
+        extension.lower().lstrip(".") for extension in file_extensions
+    ]
+    if len(languages) == 1:
+        return {
+            extension: languages[0]
+            for extension in normalized_extensions
+        }
+    if len(languages) > 1 and len(languages) != len(normalized_extensions):
+        raise ValueError(
+            "phases.json languages and file_extensions must have equal lengths "
+            "when more than one language is configured"
+        )
+    return dict(zip(normalized_extensions, languages))
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate spec batch prompts for one phase/layer range.")
     parser.add_argument("--phase", type=int, required=True, help="Phase number, e.g. 3")
@@ -286,7 +312,7 @@ def generate_batch_prompts(
     project = phases_json["project"]
     languages = phases_json.get("languages", [])
     exts = phases_json.get("file_extensions", [])
-    ext_to_lang = {ext.lower().lstrip("."): lang for ext, lang in zip(exts, languages)}
+    ext_to_lang = extension_language_map(languages, exts)
 
     topdown_path = (
         work_dir

--- a/src/generate_batch_prompts.py
+++ b/src/generate_batch_prompts.py
@@ -2,17 +2,17 @@
 
 import argparse
 import json
-import re
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
-try:
-    # When imported as part of the src package (e.g. incremental_reasoner).
-    from .file_utils import is_file_ready
+# Keep the source-tree CLI usable without making the pipeline copy this module
+# into each target project. Package imports use the canonical domain helper and
+# specification contract; direct execution retains the small path-only helper.
+if __package__:
     from .domain_knowledge import list_staged_domain_knowledge_relpaths
-except ImportError:
-    # When run directly from the source tree, file_utils.py sits beside this script.
-    from file_utils import is_file_ready
+    from .spec_forms import SOFTWARE_SPEC_FORM, SpecForm
+else:
+    from spec_forms import SOFTWARE_SPEC_FORM, SpecForm
 
     def list_staged_domain_knowledge_relpaths(work_dir, prefix="fm_agent"):
         knowledge_dir = Path(work_dir) / "spec_prompts" / "domain_context" / "user_knowledge"
@@ -64,7 +64,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--resume",
         action="store_true",
-        help="Skip functions already specced (file_utils.is_file_ready) when building batches",
+        help="Skip functions whose software specification artifacts are already valid",
     )
     return parser.parse_args()
 
@@ -82,47 +82,14 @@ def parse_layers_spec(layers_spec: str) -> Tuple[int, int]:
     return start, end
 
 
-def _spec_json_path(filepath: Path) -> Path:
-    """Return the spec sidecar next to one extracted function file."""
-    return Path(str(filepath) + ".spec.json")
-
-
-def _info_json_path(filepath: Path) -> Path:
-    """Return the info sidecar next to one extracted function file."""
-    return Path(str(filepath) + ".info.json")
-
-
 def extract_spec_block(filepath: Path) -> Optional[str]:
-    """Read .spec.json and rebuild reasoner-facing spec text."""
-    spec_path = _spec_json_path(filepath)
-
-    try:
-        with spec_path.open("r", encoding="utf-8") as file:
-            spec = json.load(file)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
-
-    if not isinstance(spec, dict):
-        return None
-
-    return (
-        f"{spec.get('signature', '')}\n\n"
-        f"Pre-condition:\n{spec.get('pre_condition', '')}\n\n"
-        f"Post-condition:\n{spec.get('post_condition', '')}"
-    )
+    """Compatibility adapter for incremental software reasoning."""
+    return SOFTWARE_SPEC_FORM.read_self_spec(filepath)
 
 
 def extract_info_block(filepath: Path) -> Optional[dict]:
-    """Read the adjacent .info.json object when it is usable."""
-    info_path = _info_json_path(filepath)
-
-    try:
-        with info_path.open("r", encoding="utf-8") as file:
-            info = json.load(file)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
-
-    return info if isinstance(info, dict) else None
+    """Compatibility adapter for incremental software reasoning."""
+    return SOFTWARE_SPEC_FORM.read_info_data(filepath)
 
 
 def extract_callee_spec_from_info(
@@ -130,40 +97,12 @@ def extract_callee_spec_from_info(
     callee_fqn: str,
     aliases: Optional[Sequence[str]] = None,
 ) -> Optional[dict]:
-    """Return the callee object matching the requested FQN or edge aliases."""
-    names = _callee_match_names(callee_fqn, aliases or ())
-    callees = info_dict.get("callees", [])
-    if not isinstance(callees, list):
-        return None
-
-    for callee in callees:
-        if not isinstance(callee, dict):
-            continue
-        name = callee.get("name", "")
-        if not isinstance(name, str):
-            continue
-        if any(_info_line_mentions_name(name, candidate) for candidate in names):
-            return callee
-    return None
-
-
-def _callee_match_names(callee_fqn: str, aliases: Sequence[str]) -> List[str]:
-    names = [callee_fqn, callee_fqn.split("::")[-1]]
-    for alias in aliases:
-        if not alias:
-            continue
-        names.append(alias)
-        if "::" in alias:
-            names.append(alias.rsplit("::", 1)[-1])
-    return list(dict.fromkeys(names))
-
-
-def _info_line_mentions_name(first_line: str, name: str) -> bool:
-    if not name:
-        return False
-    if "::" in name:
-        return name in first_line
-    return bool(re.search(rf"(?<![A-Za-z0-9_]){re.escape(name)}(?:\s*\(|\b)", first_line))
+    """Compatibility adapter for incremental software reasoning."""
+    return SOFTWARE_SPEC_FORM.find_dependency_entry(
+        info_dict,
+        callee_fqn,
+        aliases or (),
+    )
 
 
 def chunked(items: List[dict], size: int) -> List[List[dict]]:
@@ -213,6 +152,7 @@ def build_prompt(
     work_dir: Path,
     fm_agent_prefix: str,
     ext_to_lang: Dict[str, str],
+    spec_form: SpecForm,
 ) -> str:
     lines: List[str] = []
     sample_lang = "unknown"
@@ -221,10 +161,7 @@ def build_prompt(
 
     lines.append(f"You are generating behavioral specifications for Phase {phase}, Layer {layer_idx}.")
     lines.append("")
-    lines.append(
-        f"Language: {sample_lang}. "
-        "Write specifications to adjacent .spec.json and .info.json files."
-    )
+    lines.append(spec_form.batch_intro(sample_lang))
     lines.append("")
     lines.append(f"Read {fm_agent_prefix}spec_prompts/system_prompt.md FIRST for the mandatory spec format rules.")
     lines.append(f"Read: {fm_agent_prefix}spec_prompts/domain_context/engine_overview.txt")
@@ -261,21 +198,15 @@ def build_prompt(
             if not caller_meta:
                 continue
             caller_file = work_dir / caller_meta["file"]
-            spec_block = extract_spec_block(caller_file)
+            spec_block = spec_form.read_self_spec(caller_file)
             if spec_block and (caller_name, spec_block) not in caller_specs:
                 caller_specs.append((caller_name, spec_block))
-            info_dict = extract_info_block(caller_file)
-            if not info_dict:
-                continue
-            entry = extract_callee_spec_from_info(
-                info_dict, fn_name, info_names_by_caller.get(caller_name, [])
+            entry_text = spec_form.read_dependency_expectation(
+                caller_file,
+                fn_name,
+                info_names_by_caller.get(caller_name, []),
             )
-            if entry:
-                entry_text = (
-                    f"{entry.get('signature', '')}\n"
-                    f"  Pre-condition: {entry.get('pre_condition', '')}\n"
-                    f"  Post-condition: {entry.get('post_condition', '')}"
-                )
+            if entry_text:
                 caller_expectations.setdefault(fn_name, []).append(
                     (caller_name, entry_text)
                 )
@@ -328,44 +259,7 @@ def build_prompt(
             lines.append("  Earlier-layer callers: (none)")
 
     lines.append("")
-    lines.append("## SPEC FORMAT (write JSON files; do NOT modify source files)")
-    lines.append("")
-    lines.append(
-        "For each function file `<function-file>`, "
-        "write TWO JSON files in the SAME directory. "
-        "`<function-file>` includes its original extension "
-        "(for example, `foo.py` must produce `foo.py.spec.json` "
-        "and `foo.py.info.json`):"
-    )
-    lines.append("")
-    lines.append("`<function-file>.spec.json`:")
-    lines.append("```json")
-    lines.append(
-        '{"signature": "<FunctionName>(<params>) -> <ReturnType>", '
-        '"pre_condition": "...", "post_condition": "..."}'
-    )
-    lines.append("```")
-    lines.append("")
-    lines.append("`<function-file>.info.json`:")
-    lines.append("```json")
-    lines.append(
-        '{"callees": [{"name": "<callee_name>", "signature": "...", '
-        '"pre_condition": "...", "post_condition": "..."}]}'
-    )
-    lines.append("```")
-    lines.append("")
-    lines.append('If the function has no callees: write `{"callees": []}` to the .info.json file.')
-    lines.append("")
-    lines.append("## PROCESS")
-    lines.append("For each function:")
-    lines.append("1. Read the extracted file")
-    lines.append("2. Read caller expectations above - what do callers NEED from this function?")
-    lines.append("3. Write a behavioral spec describing WHAT it guarantees (not HOW)")
-    lines.append(
-        "4. Write the COMPLETE .spec.json and .info.json objects next to the "
-        "UNCHANGED source file"
-    )
-    lines.append("5. Use the Write tool to save both JSON files")
+    lines.extend(spec_form.output_contract_prompt().splitlines())
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -374,6 +268,7 @@ def generate_batch_prompts(
     phase: int,
     layers_spec: str,
     *,
+    spec_form: SpecForm,
     batch_size: int = 2,
     output_dir: Optional[Path] = None,
     resume: bool = False,
@@ -384,7 +279,6 @@ def generate_batch_prompts(
         raise ValueError("--batch-size must be > 0")
 
     work_dir = Path(work_dir)
-    # fm_agent_prefix is the relative path from the project root to work_dir
     repo_root = work_dir.parent
     fm_agent_prefix = str(work_dir.relative_to(repo_root)) + "/"
 
@@ -394,13 +288,19 @@ def generate_batch_prompts(
     exts = phases_json.get("file_extensions", [])
     ext_to_lang = {ext.lower().lstrip("."): lang for ext, lang in zip(exts, languages)}
 
-    topdown_path = work_dir / "spec_prompts" / f"phase_{phase:02d}_topdown_layers.json"
+    topdown_path = (
+        work_dir
+        / "spec_prompts"
+        / f"phase_{phase:02d}_topdown_layers.json"
+    )
     topdown = read_json(topdown_path)
     layers = topdown.get("layers", [])
     total_layers = len(layers)
     start_layer, end_layer = parse_layers_spec(layers_spec)
     if start_layer < 0 or end_layer >= total_layers:
-        raise ValueError(f"layer range {layers_spec} out of bounds [0, {total_layers - 1}]")
+        raise ValueError(
+            f"layer range {layers_spec} out of bounds [0, {total_layers - 1}]"
+        )
 
     output_dir = Path(output_dir) if output_dir is not None else (
         work_dir / "spec_prompts" / f"batch_prompts_{project}_phase{phase:02d}"
@@ -439,7 +339,11 @@ def generate_batch_prompts(
             # done — but the manifest below still records the full batch.
             prompt_funcs = fn_batch
             if resume:
-                prompt_funcs = [fn for fn in fn_batch if not is_file_ready(work_dir / fn["file"])]
+                prompt_funcs = [
+                    fn
+                    for fn in fn_batch
+                    if not spec_form.validate(work_dir / fn["file"]).ready
+                ]
                 skipped_functions += len(fn_batch) - len(prompt_funcs)
             out_path = output_dir / filename
             # On resume, a batch whose functions are all already specced has no
@@ -458,6 +362,7 @@ def generate_batch_prompts(
                     work_dir,
                     fm_agent_prefix,
                     ext_to_lang,
+                    spec_form,
                 )
                 write_targets.append((out_path, content))
             else:
@@ -518,12 +423,13 @@ def generate_batch_prompts(
 
 
 def main() -> int:
-    """Run the source-tree command-line adapter."""
+    """Run the software-only source-tree CLI adapter."""
     args = parse_args()
     generate_batch_prompts(
         work_dir=Path.cwd() / "fm_agent",
         phase=args.phase,
         layers_spec=args.layers,
+        spec_form=SOFTWARE_SPEC_FORM,
         batch_size=args.batch_size,
         output_dir=Path(args.output_dir) if args.output_dir else None,
         resume=args.resume,

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -7,8 +7,9 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 from src.extract import EXT_TO_LANG, LANG_CONFIG
-from src.file_utils import _is_metadata_sidecar
+from src.file_utils import _exclude_spec_artifacts
 from src.languages.registry import call_edges_all
+from src.spec_forms import SOFTWARE_SPEC_FORM
 
 
 # ---------------------------------------------------------------------------
@@ -26,7 +27,12 @@ def _load_phases(proj_dir):
 # 1.2 Collect files per phase
 # ---------------------------------------------------------------------------
 
-def _collect_phase_files(proj_dir, phase_data):
+def _collect_phase_files(
+    proj_dir,
+    phase_data,
+    *,
+    spec_form=SOFTWARE_SPEC_FORM,
+):
     """For a phase, collect all extracted function file paths.
 
     Returns list of (file_path, module_name) tuples.
@@ -57,10 +63,20 @@ def _collect_phase_files(proj_dir, phase_data):
             for root, _dirs, fnames in os.walk(func_dir):
                 for fname in fnames:
                     fpath = os.path.join(root, fname)
-                    if os.path.isfile(fpath) and not _is_metadata_sidecar(fname):
+                    if os.path.isfile(fpath):
                         results.append((fpath, module_name))
 
-    return results
+    included_paths = set(
+        _exclude_spec_artifacts(
+            (file_path for file_path, _module_name in results),
+            spec_form,
+        )
+    )
+    return [
+        (file_path, module_name)
+        for file_path, module_name in results
+        if file_path in included_paths
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -650,13 +666,20 @@ def _compute_layers(phase_fqns, callees_map, callers_map):
 # Main entry point
 # ---------------------------------------------------------------------------
 
-def generate_topdown_layers(proj_dir, phase_numbers=None, extra_call_edges=None):
+def generate_topdown_layers(
+    proj_dir,
+    phase_numbers=None,
+    extra_call_edges=None,
+    *,
+    spec_form=SOFTWARE_SPEC_FORM,
+):
     """Generate topdown layer JSON files for the specified phases (or all phases).
 
     Args:
         proj_dir: project root directory
         phase_numbers: list of phase numbers to process, or None for all
         extra_call_edges: optional iterable of supplemental caller/callee edges
+        spec_form: active specification form used to exclude artifact files
 
     Returns:
         list of output file paths written
@@ -669,7 +692,11 @@ def generate_topdown_layers(proj_dir, phase_numbers=None, extra_call_edges=None)
     # Build global stem->FQN mapping across ALL phases for all_callees
     global_stem_to_fqns = defaultdict(set)
     for pi in phases_data["phases"]:
-        for filepath, _ in _collect_phase_files(proj_dir, pi):
+        for filepath, _ in _collect_phase_files(
+            proj_dir,
+            pi,
+            spec_form=spec_form,
+        ):
             fqn = _file_to_fqn(filepath, proj_dir)
             stem = fqn.split("::")[-1]
             global_stem_to_fqns[stem].add(fqn)
@@ -684,7 +711,11 @@ def generate_topdown_layers(proj_dir, phase_numbers=None, extra_call_edges=None)
             continue
 
         # 1.2 Collect files
-        phase_files = _collect_phase_files(proj_dir, phase_info)
+        phase_files = _collect_phase_files(
+            proj_dir,
+            phase_info,
+            spec_form=spec_form,
+        )
         if not phase_files:
             logging.warning(f"Phase {phase_num} ({phase_name}): no extracted files found, skipping.")
             continue

--- a/src/generate_topdown_layers.py
+++ b/src/generate_topdown_layers.py
@@ -134,7 +134,7 @@ _COMMON_EXTRA_KEYWORDS = {
 def _detect_lang_from_ext(filepath):
     """Detect the language key from a file's extension."""
     base = os.path.basename(filepath)
-    ext = base.rsplit(".", 1)[-1] if "." in base else ""
+    ext = base.rsplit(".", 1)[-1].lower() if "." in base else ""
     return EXT_TO_LANG.get(ext)
 
 

--- a/src/languages/chisel.py
+++ b/src/languages/chisel.py
@@ -1,16 +1,25 @@
-"""Conservative source-backed Chisel language service.
+"""Chisel language service with direct CIRCT and source fallback backends.
 
 Chisel is embedded in Scala, but FM-Agent analysis units are hardware modules,
 not arbitrary Scala declarations. This handler owns Scala-aware declaration
 scanning, module classification, source spans, and module-instantiation edges.
-CIRCT enrichment is intentionally left to the later C2 integration.
+When configured with elaborated FIRRTL, a direct CIRCT pass provides the
+authoritative module graph. Source scanning remains available as a conservative
+fallback when the optional toolchain cannot run.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import os
 import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+import threading
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -55,6 +64,24 @@ _PACKAGE_RE = re.compile(
     re.MULTILINE,
 )
 
+_CIRCT_INPUT_ENV = "FM_AGENT_CHISEL_CIRCT_INPUT"
+_CIRCT_COMMAND_ENV = "FM_AGENT_CHISEL_CIRCT_COMMAND"
+_CIRCT_PLUGIN_ENV = "FM_AGENT_CHISEL_CIRCT_PLUGIN"
+_CIRCT_TIMEOUT_ENV = "FM_AGENT_CHISEL_CIRCT_TIMEOUT_SECONDS"
+_CIRCT_GRAPH_FILENAME = "chisel_circt_module_graph.json"
+_CIRCT_SCHEMA_VERSION = 1
+_DEFAULT_CIRCT_TIMEOUT_SECONDS = 180
+_PLUGIN_FILENAMES = (
+    "libFMAgentChiselCirctPlugin.so",
+    "FMAgentChiselCirctPlugin.so",
+    "libFMAgentChiselCirctPlugin.dylib",
+    "FMAgentChiselCirctPlugin.dylib",
+)
+
+_CIRCT_CACHE: dict[tuple[str, str], "CirctGraph | None"] = {}
+_CIRCT_DIAGNOSTICS: set[tuple[str, str]] = set()
+_CIRCT_CACHE_LOCK = threading.Lock()
+
 
 @dataclass(frozen=True)
 class ChiselUnit:
@@ -72,11 +99,36 @@ class ChiselUnit:
 
 
 @dataclass(frozen=True)
+class CirctModule:
+    """One module record emitted directly by the CIRCT pass."""
+
+    name: str
+    symbol: str
+    kind: str
+    location_file: str | None = None
+    location_line: int | None = None
+    location_column: int | None = None
+
+
+@dataclass(frozen=True)
+class CirctGraph:
+    """Validated direct-pass module graph."""
+
+    top: str | None
+    modules: tuple[CirctModule, ...]
+    edges: dict[str, tuple[str, ...]]
+    source: str = "direct-pass"
+
+
+@dataclass(frozen=True)
 class ChiselAnalysis:
     """One project scan, including handled-empty files."""
 
     files: tuple[str, ...]
+    declarations: tuple[ChiselUnit, ...]
     modules: tuple[ChiselUnit, ...]
+    circt_graph: CirctGraph | None = None
+    circt_units_by_symbol: dict[str, tuple[ChiselUnit, ...]] | None = None
 
 
 def _project_root(proj_dir: str | Path) -> Path:
@@ -87,6 +139,367 @@ def _project_root(proj_dir: str | Path) -> Path:
 def _work_dir(proj_dir: str | Path) -> Path:
     root = Path(os.path.abspath(proj_dir))
     return root if root.name == "fm_agent" else root / "fm_agent"
+
+
+def _circt_timeout_seconds() -> int:
+    raw = os.environ.get(
+        _CIRCT_TIMEOUT_ENV,
+        str(_DEFAULT_CIRCT_TIMEOUT_SECONDS),
+    )
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        logging.warning(
+            "Invalid %s=%r; using %d seconds",
+            _CIRCT_TIMEOUT_ENV,
+            raw,
+            _DEFAULT_CIRCT_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_CIRCT_TIMEOUT_SECONDS
+
+
+def _circt_command() -> list[str]:
+    raw = os.environ.get(_CIRCT_COMMAND_ENV, "firtool").strip() or "firtool"
+    command = shlex.split(raw, posix=os.name != "nt")
+    return command or ["firtool"]
+
+
+def _input_format(path: Path) -> str:
+    lowered = path.name.lower()
+    if lowered.endswith(".fir"):
+        return "fir"
+    if lowered.endswith(".mlir"):
+        return "mlir"
+    raise RuntimeError(
+        f"unsupported CIRCT input format for {path}; expected .fir or .mlir"
+    )
+
+
+def _escape_pass_option(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _graph_pipeline(output_path: Path) -> str:
+    escaped = _escape_pass_option(str(output_path))
+    return (
+        "firrtl.circuit("
+        f'fm-agent-emit-chisel-module-graph{{output-file="{escaped}"}}'
+        ")"
+    )
+
+
+def _normalize_circt_graph(data: object) -> CirctGraph | None:
+    if not isinstance(data, dict):
+        return None
+    if data.get("schema_version") != _CIRCT_SCHEMA_VERSION:
+        return None
+    modules_data = data.get("modules")
+    edges_data = data.get("edges")
+    if not isinstance(modules_data, list) or not isinstance(edges_data, dict):
+        return None
+
+    modules = []
+    symbols = set()
+    for item in modules_data:
+        if not isinstance(item, dict):
+            return None
+        name = item.get("name")
+        symbol = item.get("symbol", name)
+        kind = item.get("kind", "module")
+        if not all(
+            isinstance(value, str) and value
+            for value in (name, symbol, kind)
+        ):
+            return None
+        if symbol in symbols:
+            return None
+        symbols.add(symbol)
+        location = item.get("location")
+        if location is not None and not isinstance(location, dict):
+            return None
+        location = location or {}
+        location_file = location.get("file")
+        location_line = location.get("line")
+        location_column = location.get("column")
+        if location_file is not None and not isinstance(location_file, str):
+            return None
+        for value in (location_line, location_column):
+            if value is not None and (type(value) is not int or value < 0):
+                return None
+        modules.append(
+            CirctModule(
+                name=name,
+                symbol=symbol,
+                kind=kind,
+                location_file=location_file,
+                location_line=location_line,
+                location_column=location_column,
+            )
+        )
+    if not modules:
+        return None
+
+    edges = {}
+    for caller, callees in edges_data.items():
+        if not isinstance(caller, str) or not isinstance(callees, list):
+            return None
+        if not all(isinstance(callee, str) for callee in callees):
+            return None
+        edges[caller] = tuple(sorted(set(callees)))
+
+    top = data.get("top")
+    source = data.get("source", "direct-pass")
+    if top is not None and not isinstance(top, str):
+        return None
+    if not isinstance(source, str):
+        return None
+    return CirctGraph(
+        top=top,
+        modules=tuple(modules),
+        edges=edges,
+        source=source,
+    )
+
+
+def _circt_graph_data(graph: CirctGraph) -> dict[str, object]:
+    return {
+        "schema_version": _CIRCT_SCHEMA_VERSION,
+        "top": graph.top,
+        "modules": [
+            {
+                "name": module.name,
+                "symbol": module.symbol,
+                "kind": module.kind,
+                "location": (
+                    {
+                        "file": module.location_file,
+                        "line": module.location_line,
+                        "column": module.location_column,
+                    }
+                    if module.location_file is not None
+                    else None
+                ),
+            }
+            for module in graph.modules
+        ],
+        "edges": {
+            caller: list(callees)
+            for caller, callees in sorted(graph.edges.items())
+        },
+        "source": graph.source,
+    }
+
+
+class _CirctBackend:
+    """Discover and invoke firtool with the direct module-graph pass."""
+
+    def __init__(self, proj_dir: str | Path, source_files: tuple[str, ...]):
+        self.project = _project_root(proj_dir)
+        self.work_dir = _work_dir(proj_dir)
+        self.source_files = source_files
+
+    @property
+    def input_path(self) -> Path | None:
+        raw = os.environ.get(_CIRCT_INPUT_ENV, "").strip()
+        if not raw:
+            return None
+        path = Path(raw)
+        if not path.is_absolute():
+            path = self.project / path
+        return Path(os.path.abspath(path))
+
+    @property
+    def graph_path(self) -> Path:
+        return self.work_dir / _CIRCT_GRAPH_FILENAME
+
+    def _plugin_candidates(self):
+        raw = os.environ.get(_CIRCT_PLUGIN_ENV, "").strip()
+        if raw:
+            configured = Path(raw)
+            if not configured.is_absolute():
+                configured = self.project / configured
+            yield configured
+
+        repository = Path(__file__).resolve().parents[2]
+        tool_root = repository / "tools" / "chisel-circt" / "build"
+        for directory in (tool_root / "lib", tool_root / "plugin", tool_root):
+            for filename in _PLUGIN_FILENAMES:
+                yield directory / filename
+        local_lib = Path.home() / ".local" / "lib"
+        for filename in _PLUGIN_FILENAMES:
+            yield local_lib / filename
+
+    @property
+    def plugin_path(self) -> Path | None:
+        configured = os.environ.get(_CIRCT_PLUGIN_ENV, "").strip()
+        if configured:
+            path = Path(configured)
+            if not path.is_absolute():
+                path = self.project / path
+            path = Path(os.path.abspath(path))
+            return path if path.is_file() else None
+        return next(
+            (Path(os.path.abspath(path)) for path in self._plugin_candidates() if path.is_file()),
+            None,
+        )
+
+    def _fingerprint(self, input_path: Path, plugin_path: Path) -> str:
+        def record(path: Path) -> tuple[str, int, int]:
+            stat = path.stat()
+            return (str(path), stat.st_size, stat.st_mtime_ns)
+
+        payload = {
+            "command": _circt_command(),
+            "input": record(input_path),
+            "plugin": record(plugin_path),
+            "sources": [record(Path(path)) for path in self.source_files],
+        }
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def _load_persisted(self, fingerprint: str) -> CirctGraph | None:
+        try:
+            with self.graph_path.open("r", encoding="utf-8") as file:
+                data = json.load(file)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict) or data.get("project_fingerprint") != fingerprint:
+            return None
+        return _normalize_circt_graph(data)
+
+    def _persist(self, graph: CirctGraph, fingerprint: str) -> None:
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        document = {
+            **_circt_graph_data(graph),
+            "status": "success",
+            "backend": "llvm/circt",
+            "circt_command": _circt_command(),
+            "circt_plugin": str(self.plugin_path),
+            "project_fingerprint": fingerprint,
+        }
+        temporary = self.graph_path.with_suffix(".json.tmp")
+        try:
+            with temporary.open("w", encoding="utf-8") as file:
+                json.dump(document, file, indent=2, ensure_ascii=False)
+                file.write("\n")
+            temporary.replace(self.graph_path)
+        except OSError:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    def _run(self, input_path: Path, plugin_path: Path) -> CirctGraph:
+        command = _circt_command()
+        executable = command[0]
+        if shutil.which(executable) is None and not Path(executable).is_file():
+            raise RuntimeError(f"CIRCT command was not found: {executable}")
+
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        descriptor, output_name = tempfile.mkstemp(
+            prefix=".chisel_circt_graph.",
+            suffix=".json",
+            dir=self.work_dir,
+        )
+        os.close(descriptor)
+        output_path = Path(output_name)
+        output_path.unlink(missing_ok=True)
+        argv = [
+            *command,
+            str(input_path),
+            f"--format={_input_format(input_path)}",
+            "--disable-output",
+            f"--load-pass-plugin={plugin_path}",
+            f"--high-firrtl-pass-plugin={_graph_pipeline(output_path)}",
+        ]
+        try:
+            completed = subprocess.run(
+                argv,
+                cwd=self.project,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=_circt_timeout_seconds(),
+            )
+            del completed
+            try:
+                with output_path.open("r", encoding="utf-8") as file:
+                    data = json.load(file)
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise RuntimeError(
+                    "CIRCT pass did not produce a valid JSON graph"
+                ) from exc
+            graph = _normalize_circt_graph(data)
+            if graph is None:
+                raise RuntimeError("CIRCT pass produced an unsupported graph schema")
+            return graph
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"CIRCT graph command timed out after {_circt_timeout_seconds()}s"
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            detail = f": {stderr}" if stderr else ""
+            raise RuntimeError(f"CIRCT graph command failed{detail}") from exc
+        finally:
+            output_path.unlink(missing_ok=True)
+
+    def graph_or_none(self) -> CirctGraph | None:
+        input_path = self.input_path
+        if input_path is None:
+            return None
+        cache_key: tuple[str, str] | None = None
+        try:
+            if not input_path.is_file():
+                raise RuntimeError(f"CIRCT input path does not exist: {input_path}")
+            plugin_path = self.plugin_path
+            if plugin_path is None:
+                raise RuntimeError(
+                    "FM-Agent Chisel CIRCT plugin was not found; set "
+                    f"{_CIRCT_PLUGIN_ENV}"
+                )
+            fingerprint = self._fingerprint(input_path, plugin_path)
+            cache_key = (str(self.project), fingerprint)
+            with _CIRCT_CACHE_LOCK:
+                if cache_key in _CIRCT_CACHE:
+                    return _CIRCT_CACHE[cache_key]
+
+            graph = self._load_persisted(fingerprint)
+            if graph is None:
+                graph = self._run(input_path, plugin_path)
+                try:
+                    self._persist(graph, fingerprint)
+                except OSError as exc:
+                    logging.warning(
+                        "Unable to persist the direct CIRCT Chisel graph: %s",
+                        exc,
+                    )
+            with _CIRCT_CACHE_LOCK:
+                _CIRCT_CACHE[cache_key] = graph
+            return graph
+        except Exception as exc:
+            if cache_key is not None:
+                with _CIRCT_CACHE_LOCK:
+                    _CIRCT_CACHE[cache_key] = None
+            diagnostic_key = (str(self.project), str(exc))
+            with _CIRCT_CACHE_LOCK:
+                first_report = diagnostic_key not in _CIRCT_DIAGNOSTICS
+                _CIRCT_DIAGNOSTICS.add(diagnostic_key)
+            if first_report:
+                logging.warning(
+                    "Direct CIRCT Chisel analysis unavailable; using source "
+                    "fallback: %s",
+                    exc,
+                )
+            return None
+
+
+def _clear_circt_cache_for_tests() -> None:
+    with _CIRCT_CACHE_LOCK:
+        _CIRCT_CACHE.clear()
+        _CIRCT_DIAGNOSTICS.clear()
 
 
 def _iter_chisel_files(proj_dir: str | Path):
@@ -400,8 +813,136 @@ def _analyze_sources(proj_dir: str | Path) -> ChiselAnalysis:
             logging.warning("Unable to read Chisel source %s: %s", path, exc)
     return ChiselAnalysis(
         files=tuple(files),
+        declarations=tuple(declarations),
         modules=_module_units(declarations),
     )
+
+
+def _resolve_circt_location(
+    project: Path,
+    location_file: str | None,
+    source_files: tuple[str, ...],
+) -> str | None:
+    if not location_file:
+        return None
+    location = Path(location_file)
+    candidates = []
+    if location.is_absolute():
+        candidates.append(Path(os.path.abspath(location)))
+    else:
+        candidates.extend([
+            Path(os.path.abspath(project / location)),
+            Path(os.path.abspath(project / str(location).lstrip("./"))),
+        ])
+    source_set = set(source_files)
+    for candidate in candidates:
+        if str(candidate) in source_set:
+            return str(candidate)
+
+    basename_matches = [
+        path for path in source_files if Path(path).name == location.name
+    ]
+    return basename_matches[0] if len(basename_matches) == 1 else None
+
+
+def _match_circt_module(
+    project: Path,
+    module: CirctModule,
+    analysis: ChiselAnalysis,
+) -> ChiselUnit | None:
+    declarations = [
+        unit for unit in analysis.declarations if unit.kind == "class"
+    ]
+    resolved_file = _resolve_circt_location(
+        project,
+        module.location_file,
+        analysis.files,
+    )
+    if resolved_file is not None:
+        same_file = [
+            unit for unit in declarations if unit.abs_path == resolved_file
+        ]
+        exact_name = [unit for unit in same_file if unit.name == module.name]
+        if len(exact_name) == 1:
+            return exact_name[0]
+        if module.location_line is not None:
+            target = max(0, module.location_line - 1)
+            containing = [
+                unit
+                for unit in same_file
+                if unit.span is not None
+                and unit.span[0] <= target <= unit.span[1]
+            ]
+            if len(containing) == 1:
+                return containing[0]
+            if same_file:
+                return min(
+                    same_file,
+                    key=lambda unit: abs((unit.span or (0, 0))[0] - target),
+                )
+
+    exact_name = [unit for unit in declarations if unit.name == module.name]
+    return exact_name[0] if len(exact_name) == 1 else None
+
+
+def _apply_circt_graph(
+    proj_dir: str | Path,
+    analysis: ChiselAnalysis,
+    graph: CirctGraph,
+) -> ChiselAnalysis:
+    project = _project_root(proj_dir)
+    by_symbol: dict[str, list[ChiselUnit]] = defaultdict(list)
+    matched_units = set()
+    unmatched = []
+    for module in graph.modules:
+        unit = _match_circt_module(project, module, analysis)
+        if unit is None:
+            unmatched.append(module.symbol)
+            continue
+        matched_units.add(unit)
+        by_symbol[module.symbol].append(unit)
+        if module.name != module.symbol:
+            by_symbol[module.name].append(unit)
+
+    if not matched_units:
+        logging.warning(
+            "Direct CIRCT graph contained %d module(s), but none mapped to "
+            "Chisel source declarations; using source fallback",
+            len(graph.modules),
+        )
+        return analysis
+
+    if unmatched:
+        logging.warning(
+            "Direct CIRCT graph has %d generated or unmapped module(s); "
+            "they will not become specification units: %s",
+            len(unmatched),
+            ", ".join(sorted(unmatched)[:5]),
+        )
+
+    selected = tuple(
+        unit for unit in analysis.declarations if unit in matched_units
+    )
+    return ChiselAnalysis(
+        files=analysis.files,
+        declarations=analysis.declarations,
+        modules=selected,
+        circt_graph=graph,
+        circt_units_by_symbol={
+            symbol: tuple(dict.fromkeys(units))
+            for symbol, units in by_symbol.items()
+        },
+    )
+
+
+def _analyze(proj_dir: str | Path) -> ChiselAnalysis:
+    analysis = _analyze_sources(proj_dir)
+    if not analysis.files:
+        return analysis
+    graph = _CirctBackend(proj_dir, analysis.files).graph_or_none()
+    if graph is None:
+        return analysis
+    return _apply_circt_graph(proj_dir, analysis, graph)
 
 
 def _deduped_records(
@@ -430,7 +971,7 @@ def _deduped_records(
 
 def batch_extract(proj_dir: str) -> dict[str, list[tuple[str, str]]]:
     """Return module units, retaining empty lists for handled Chisel files."""
-    return _deduped_records(_analyze_sources(proj_dir), spans=False)
+    return _deduped_records(_analyze(proj_dir), spans=False)
 
 
 def function_spans(proj_dir: str, filepath: str):
@@ -438,7 +979,7 @@ def function_spans(proj_dir: str, filepath: str):
     path = Path(os.path.abspath(filepath))
     if path.suffix.lower() not in CHISEL_EXTENSIONS or not path.is_file():
         return None
-    analysis = _analyze_sources(proj_dir)
+    analysis = _analyze(proj_dir)
     records = _deduped_records(analysis, spans=True)
     return records.get(str(path), [])
 
@@ -538,8 +1079,49 @@ def _resolve_target(
     return []
 
 
+def _direct_circt_edges(analysis: ChiselAnalysis) -> dict[str, set[str]]:
+    graph = analysis.circt_graph
+    units_by_symbol = analysis.circt_units_by_symbol or {}
+    if graph is None:
+        return {}
+
+    fqn_by_unit = {
+        unit: fqn for fqn, unit in _source_units_with_fqns(analysis.modules)
+    }
+    edges: dict[str, set[str]] = defaultdict(set)
+    unmapped_edges = 0
+    for caller_symbol, callee_symbols in graph.edges.items():
+        callers = units_by_symbol.get(caller_symbol, ())
+        for callee_symbol in callee_symbols:
+            callees = units_by_symbol.get(callee_symbol, ())
+            if not callers or not callees:
+                unmapped_edges += 1
+                continue
+            for caller in callers:
+                for callee in callees:
+                    caller_fqn = fqn_by_unit.get(caller)
+                    callee_fqn = fqn_by_unit.get(callee)
+                    if (
+                        caller_fqn is not None
+                        and callee_fqn is not None
+                        and caller_fqn != callee_fqn
+                    ):
+                        edges[caller_fqn].add(callee_fqn)
+    if unmapped_edges:
+        logging.warning(
+            "Ignored %d direct CIRCT edge(s) whose source specification unit "
+            "could not be mapped",
+            unmapped_edges,
+        )
+    return dict(edges)
+
+
 def call_edges(proj_dir: str) -> dict[str, set[str]]:
     """Return conservative module-instantiation edges for Chisel units."""
+    analysis = _analyze(proj_dir)
+    if analysis.circt_graph is not None:
+        return _direct_circt_edges(analysis)
+
     extracted = _extracted_modules(proj_dir)
     if extracted:
         units_with_fqns = [
@@ -548,7 +1130,7 @@ def call_edges(proj_dir: str) -> dict[str, set[str]]:
         ]
     else:
         units_with_fqns = _source_units_with_fqns(
-            _analyze_sources(proj_dir).modules
+            analysis.modules
         )
 
     by_name: dict[str, list[tuple[str, ChiselUnit]]] = defaultdict(list)

--- a/src/languages/chisel.py
+++ b/src/languages/chisel.py
@@ -1,0 +1,577 @@
+"""Conservative source-backed Chisel language service.
+
+Chisel is embedded in Scala, but FM-Agent analysis units are hardware modules,
+not arbitrary Scala declarations. This handler owns Scala-aware declaration
+scanning, module classification, source spans, and module-instantiation edges.
+CIRCT enrichment is intentionally left to the later C2 integration.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.file_utils import _is_test_file
+from src.languages.codegraph import canonicalize
+from src.languages.hardware import (
+    CHISEL_EXTENSIONS,
+    is_excluded_source_directory,
+)
+
+
+_MODULE_ROOTS = frozenset({
+    "Module",
+    "RawModule",
+    "BlackBox",
+    "ExtModule",
+    "MultiIOModule",
+})
+_MODIFIER = (
+    r"(?:"
+    r"(?:private|protected)(?:\[[\w.]+\])?"
+    r"|final|sealed|abstract|implicit|lazy|override|case"
+    r")"
+)
+_DECLARATION_RE = re.compile(
+    r"^(?:" + _MODIFIER + r"\s+)*"
+    r"(?P<kind>class|object|trait|def)\s+"
+    r"(?P<name>[A-Za-z_$][\w$]*)"
+)
+_LOCAL_DECLARATION_RE = re.compile(
+    r"\b(?:class|object|trait)\s+([A-Za-z_$][\w$]*)"
+)
+_NEW_MODULE_RE = re.compile(
+    r"\bnew\s+"
+    r"(?P<name>[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)"
+)
+_DYNAMIC_MODULE_RE = re.compile(r"\bModule\s*\((?!\s*new\b)")
+_PACKAGE_RE = re.compile(
+    r"^\s*package\s+([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)"
+    r"\s*(?:\{)?\s*$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class ChiselUnit:
+    """One top-level Scala declaration and its source metadata."""
+
+    abs_path: str
+    rel_path: str
+    source: str
+    kind: str
+    name: str
+    parent: str | None
+    span: tuple[int, int] | None
+    package: str | None = None
+    fqn: str | None = None
+
+
+@dataclass(frozen=True)
+class ChiselAnalysis:
+    """One project scan, including handled-empty files."""
+
+    files: tuple[str, ...]
+    modules: tuple[ChiselUnit, ...]
+
+
+def _project_root(proj_dir: str | Path) -> Path:
+    root = Path(os.path.abspath(proj_dir))
+    return root.parent if root.name == "fm_agent" else root
+
+
+def _work_dir(proj_dir: str | Path) -> Path:
+    root = Path(os.path.abspath(proj_dir))
+    return root if root.name == "fm_agent" else root / "fm_agent"
+
+
+def _iter_chisel_files(proj_dir: str | Path):
+    project = _project_root(proj_dir)
+    if not project.is_dir():
+        return
+    for current_root, dirnames, filenames in os.walk(project):
+        dirnames[:] = sorted(
+            name
+            for name in dirnames
+            if not is_excluded_source_directory(name)
+        )
+        root = Path(current_root)
+        for filename in sorted(filenames):
+            path = root / filename
+            if path.suffix.lower() not in CHISEL_EXTENSIONS:
+                continue
+            rel_path = path.relative_to(project).as_posix()
+            if _is_test_file(rel_path):
+                continue
+            yield path, rel_path
+
+
+def _skip_quoted(text: str, index: int, quote: str) -> int:
+    index += 1
+    while index < len(text):
+        if text[index] == "\n":
+            return index
+        if text[index] == "\\":
+            index += 2
+            continue
+        if text[index] == quote:
+            return index + 1
+        index += 1
+    return index
+
+
+def _skip_character(text: str, index: int) -> int:
+    """Skip a Scala character literal without consuming legacy symbols."""
+    if (
+        index + 3 < len(text)
+        and text[index + 1] == "\\"
+        and text[index + 3] == "'"
+    ):
+        return index + 4
+    if index + 2 < len(text) and text[index + 2] == "'":
+        return index + 3
+    return index + 1
+
+
+def mask_non_code(text: str) -> str:
+    """Mask Scala comments and string/character literals, preserving layout."""
+    masked = list(text)
+    index = 0
+    block_depth = 0
+    in_triple = False
+
+    while index < len(text):
+        char = text[index]
+        following = text[index + 1] if index + 1 < len(text) else ""
+
+        if in_triple:
+            if text[index:index + 3] == '\"\"\"':
+                masked[index:index + 3] = "   "
+                in_triple = False
+                index += 3
+            else:
+                if char != "\n":
+                    masked[index] = " "
+                index += 1
+            continue
+
+        if block_depth:
+            if char == "/" and following == "*":
+                masked[index:index + 2] = "  "
+                block_depth += 1
+                index += 2
+            elif char == "*" and following == "/":
+                masked[index:index + 2] = "  "
+                block_depth -= 1
+                index += 2
+            else:
+                if char != "\n":
+                    masked[index] = " "
+                index += 1
+            continue
+
+        if char == "/" and following == "/":
+            while index < len(text) and text[index] != "\n":
+                masked[index] = " "
+                index += 1
+            continue
+        if char == "/" and following == "*":
+            masked[index:index + 2] = "  "
+            block_depth += 1
+            index += 2
+            continue
+        if text[index:index + 3] == '\"\"\"':
+            masked[index:index + 3] = "   "
+            in_triple = True
+            index += 3
+            continue
+        if char == '"':
+            end = _skip_quoted(text, index, char)
+            for position in range(index, min(end, len(text))):
+                if masked[position] != "\n":
+                    masked[position] = " "
+            index = end
+            continue
+        if char == "'":
+            end = _skip_character(text, index)
+            for position in range(index, min(end, len(text))):
+                if masked[position] != "\n":
+                    masked[position] = " "
+            index = end
+            continue
+        index += 1
+
+    return "".join(masked)
+
+
+def _line_depths(masked_lines: list[str]) -> list[int]:
+    depths = []
+    depth = 0
+    for line in masked_lines:
+        depths.append(depth)
+        depth += line.count("{") - line.count("}")
+    return depths
+
+
+def _matching_block_end(
+    masked_lines: list[str],
+    start_line: int,
+) -> int:
+    depth = 0
+    opened = False
+    for line_index in range(start_line, len(masked_lines)):
+        for char in masked_lines[line_index]:
+            if char == "{":
+                depth += 1
+                opened = True
+            elif char == "}":
+                depth -= 1
+                if opened and depth == 0:
+                    return line_index
+    return len(masked_lines) - 1
+
+
+def _package_block_line(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith("package ") and stripped.endswith("{")
+
+
+def _signature_end(masked_lines: list[str], start_line: int) -> int:
+    parens = 0
+    brackets = 0
+    saw_extends = False
+    for line_index in range(start_line, len(masked_lines)):
+        stripped = masked_lines[line_index].strip()
+        if not stripped and line_index > start_line:
+            continue
+        parens += stripped.count("(") - stripped.count(")")
+        brackets += stripped.count("[") - stripped.count("]")
+        saw_extends = saw_extends or "extends" in stripped
+        if "{" in stripped and parens <= 0 and brackets <= 0:
+            return line_index
+        if parens > 0 or brackets > 0:
+            continue
+        if stripped.endswith(("extends", "with", ",")):
+            continue
+        next_line = next(
+            (
+                masked_lines[index].strip()
+                for index in range(line_index + 1, len(masked_lines))
+                if masked_lines[index].strip()
+            ),
+            "",
+        )
+        if next_line.startswith(("(", "extends ", "with ")):
+            continue
+        if next_line == "{":
+            return line_index + 1
+        if saw_extends or line_index == start_line:
+            return line_index
+    return len(masked_lines) - 1
+
+
+def _declaration_end(masked_lines: list[str], start_line: int) -> int:
+    signature_end = _signature_end(masked_lines, start_line)
+    signature = " ".join(masked_lines[start_line:signature_end + 1])
+    if "{" not in signature:
+        return signature_end
+    return _matching_block_end(masked_lines, start_line)
+
+
+def _parent_from_signature(signature: str) -> str | None:
+    match = re.search(
+        r"\bextends\s+([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)",
+        signature,
+    )
+    return match.group(1).rsplit(".", 1)[-1] if match else None
+
+
+def _package_name(masked_text: str) -> str | None:
+    packages = _PACKAGE_RE.findall(masked_text)
+    return ".".join(packages) if packages else None
+
+
+def _declarations(path: Path, rel_path: str) -> list[ChiselUnit]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    source_lines = text.splitlines()
+    masked_text = mask_non_code(text)
+    masked_lines = masked_text.splitlines()
+    depths = _line_depths(masked_lines)
+    package_blocks: list[tuple[int, int]] = []
+    units = []
+    line_index = 0
+
+    while line_index < len(masked_lines):
+        package_blocks = [
+            block for block in package_blocks if line_index <= block[1]
+        ]
+        in_package_top = any(
+            depths[line_index] == depth and line_index <= end
+            for depth, end in package_blocks
+        )
+        if depths[line_index] != 0 and not in_package_top:
+            line_index += 1
+            continue
+
+        stripped = masked_lines[line_index].lstrip()
+        if _package_block_line(masked_lines[line_index]):
+            package_blocks.append(
+                (
+                    depths[line_index] + 1,
+                    _matching_block_end(masked_lines, line_index),
+                )
+            )
+            line_index += 1
+            continue
+        if stripped.startswith(("package ", "import ")):
+            line_index += 1
+            continue
+
+        match = _DECLARATION_RE.match(stripped)
+        if match is None:
+            line_index += 1
+            continue
+
+        end_line = _declaration_end(masked_lines, line_index)
+        signature_end = _signature_end(masked_lines, line_index)
+        signature = " ".join(
+            masked_lines[line_index:signature_end + 1]
+        )
+        units.append(
+            ChiselUnit(
+                abs_path=os.path.abspath(path),
+                rel_path=rel_path,
+                source="\n".join(source_lines[line_index:end_line + 1]) + "\n",
+                kind=match.group("kind"),
+                name=match.group("name"),
+                parent=_parent_from_signature(signature),
+                span=(line_index, end_line),
+                package=_package_name(masked_text),
+            )
+        )
+        line_index = end_line + 1
+
+    return units
+
+
+def _module_units(units: list[ChiselUnit]) -> tuple[ChiselUnit, ...]:
+    declarations_by_name: dict[str, list[int]] = defaultdict(list)
+    for index, unit in enumerate(units):
+        if unit.kind == "class":
+            declarations_by_name[unit.name].append(index)
+
+    resolved: dict[int, bool] = {}
+    visiting: set[int] = set()
+
+    def is_module(index: int) -> bool:
+        if index in resolved:
+            return resolved[index]
+        if index in visiting:
+            return False
+        visiting.add(index)
+        unit = units[index]
+        result = unit.kind == "class" and unit.parent in _MODULE_ROOTS
+        if unit.kind == "class" and unit.parent and not result:
+            result = any(
+                is_module(parent_index)
+                for parent_index in declarations_by_name.get(unit.parent, ())
+            )
+        visiting.remove(index)
+        resolved[index] = result
+        return result
+
+    return tuple(
+        unit for index, unit in enumerate(units) if is_module(index)
+    )
+
+
+def _analyze_sources(proj_dir: str | Path) -> ChiselAnalysis:
+    files = []
+    declarations = []
+    for path, rel_path in _iter_chisel_files(proj_dir):
+        files.append(os.path.abspath(path))
+        try:
+            declarations.extend(_declarations(path, rel_path))
+        except OSError as exc:
+            logging.warning("Unable to read Chisel source %s: %s", path, exc)
+    return ChiselAnalysis(
+        files=tuple(files),
+        modules=_module_units(declarations),
+    )
+
+
+def _deduped_records(
+    analysis: ChiselAnalysis,
+    *,
+    spans: bool,
+) -> dict[str, list[tuple]]:
+    grouped: dict[str, list[tuple]] = {
+        path: [] for path in analysis.files
+    }
+    counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for unit in analysis.modules:
+        name = canonicalize(unit.name)
+        count = counts[unit.abs_path][name]
+        counts[unit.abs_path][name] += 1
+        deduped = name if count == 0 else f"{name}_{count}"
+        if spans:
+            if unit.span is not None:
+                grouped[unit.abs_path].append(
+                    (deduped, unit.span[0], unit.span[1])
+                )
+        else:
+            grouped[unit.abs_path].append((deduped, unit.source))
+    return grouped
+
+
+def batch_extract(proj_dir: str) -> dict[str, list[tuple[str, str]]]:
+    """Return module units, retaining empty lists for handled Chisel files."""
+    return _deduped_records(_analyze_sources(proj_dir), spans=False)
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return module spans; Chisel files with no modules are handled-empty."""
+    path = Path(os.path.abspath(filepath))
+    if path.suffix.lower() not in CHISEL_EXTENSIONS or not path.is_file():
+        return None
+    analysis = _analyze_sources(proj_dir)
+    records = _deduped_records(analysis, spans=True)
+    return records.get(str(path), [])
+
+
+def _source_unit_fqn(unit: ChiselUnit, extracted_name: str | None = None) -> str:
+    source_path = Path(unit.rel_path)
+    dashed = f"{source_path.stem}-{source_path.suffix.lstrip('.')}"
+    parts = [
+        *source_path.parent.parts,
+        dashed,
+        canonicalize(extracted_name or unit.name),
+    ]
+    return "::".join(part for part in parts if part not in {"", "."})
+
+
+def _source_units_with_fqns(
+    modules: tuple[ChiselUnit, ...],
+) -> list[tuple[str, ChiselUnit]]:
+    counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    result = []
+    for unit in modules:
+        name = canonicalize(unit.name)
+        count = counts[unit.abs_path][name]
+        counts[unit.abs_path][name] += 1
+        extracted_name = name if count == 0 else f"{name}_{count}"
+        result.append((_source_unit_fqn(unit, extracted_name), unit))
+    return result
+
+
+def _extracted_unit_fqn(relative_path: Path) -> str:
+    return "::".join(relative_path.with_suffix("").parts)
+
+
+def _extracted_modules(proj_dir: str | Path) -> tuple[ChiselUnit, ...]:
+    extracted_root = _work_dir(proj_dir) / "extracted_functions"
+    if not extracted_root.is_dir():
+        return ()
+    units = []
+    for path in sorted(extracted_root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in CHISEL_EXTENSIONS:
+            continue
+        relative_path = path.relative_to(extracted_root)
+        declarations = _declarations(path, relative_path.as_posix())
+        for unit in declarations:
+            if unit.kind != "class":
+                continue
+            units.append(
+                ChiselUnit(
+                    abs_path=unit.abs_path,
+                    rel_path=unit.rel_path,
+                    source=unit.source,
+                    kind=unit.kind,
+                    name=unit.name,
+                    parent=unit.parent,
+                    span=unit.span,
+                    package=unit.package,
+                    fqn=_extracted_unit_fqn(relative_path),
+                )
+            )
+    return tuple(units)
+
+
+def _local_declaration_names(source: str, own_name: str) -> set[str]:
+    names = set(_LOCAL_DECLARATION_RE.findall(mask_non_code(source)))
+    names.discard(own_name)
+    return names
+
+
+def _instantiated_names(source: str) -> set[str]:
+    return {
+        match.group("name")
+        for match in _NEW_MODULE_RE.finditer(mask_non_code(source))
+    }
+
+
+def _resolve_target(
+    reference: str,
+    candidates: list[tuple[str, ChiselUnit]],
+) -> list[str]:
+    if len(candidates) <= 1:
+        return [fqn for fqn, _unit in candidates]
+    qualifier, separator, _name = reference.rpartition(".")
+    if separator:
+        qualified = [
+            fqn
+            for fqn, unit in candidates
+            if unit.package == qualifier
+            or (unit.package and unit.package.endswith("." + qualifier))
+        ]
+        if len(qualified) == 1:
+            return qualified
+    logging.warning(
+        "Skipping ambiguous Chisel module reference %s; candidates: %s",
+        reference,
+        ", ".join(sorted(fqn for fqn, _unit in candidates)),
+    )
+    return []
+
+
+def call_edges(proj_dir: str) -> dict[str, set[str]]:
+    """Return conservative module-instantiation edges for Chisel units."""
+    extracted = _extracted_modules(proj_dir)
+    if extracted:
+        units_with_fqns = [
+            (unit.fqn or _extracted_unit_fqn(Path(unit.rel_path)), unit)
+            for unit in extracted
+        ]
+    else:
+        units_with_fqns = _source_units_with_fqns(
+            _analyze_sources(proj_dir).modules
+        )
+
+    by_name: dict[str, list[tuple[str, ChiselUnit]]] = defaultdict(list)
+    for fqn, unit in units_with_fqns:
+        by_name[unit.name].append((fqn, unit))
+
+    edges: dict[str, set[str]] = defaultdict(set)
+    for caller_fqn, caller in units_with_fqns:
+        shadowed = _local_declaration_names(caller.source, caller.name)
+        if _DYNAMIC_MODULE_RE.search(mask_non_code(caller.source)):
+            logging.warning(
+                "Chisel source fallback could not resolve one or more dynamic "
+                "Module(...) constructions in %s",
+                caller_fqn,
+            )
+        for reference in _instantiated_names(caller.source):
+            simple_name = reference.rsplit(".", 1)[-1]
+            if simple_name in shadowed:
+                continue
+            for callee_fqn in _resolve_target(
+                reference,
+                by_name.get(simple_name, []),
+            ):
+                if callee_fqn != caller_fqn:
+                    edges[caller_fqn].add(callee_fqn)
+    return dict(edges)

--- a/src/languages/hardware.py
+++ b/src/languages/hardware.py
@@ -1,0 +1,32 @@
+"""Shared source-discovery rules for hardware language handlers and plugins."""
+
+from __future__ import annotations
+
+
+CHISEL_EXTENSIONS = frozenset({".scala", ".sc"})
+VERILOG_EXTENSIONS = frozenset({".v", ".sv", ".svh"})
+
+SOURCE_SCAN_EXCLUDED_DIRECTORY_NAMES = frozenset({
+    ".git",
+    ".hg",
+    ".svn",
+    ".idea",
+    ".vscode",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "venv",
+    "fm_agent",
+    "target",
+    "build",
+    "out",
+    "dist",
+})
+
+
+def is_excluded_source_directory(name: str) -> bool:
+    """Return whether a nested directory is outside hardware source scans."""
+    return (
+        name.startswith(".")
+        or name in SOURCE_SCAN_EXCLUDED_DIRECTORY_NAMES
+    )

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -13,6 +13,7 @@ from src.languages import javascript as _javascript
 from src.languages import typescript as _typescript
 from src.languages import arkts as _arkts
 from src.languages import erlang as _erlang
+from src.languages import chisel as _chisel
 
 from src.languages.base import BackendUnavailableError as _BackendUnavailableError
 
@@ -30,7 +31,9 @@ class LanguageHandler:
 
     Each function handles its own backend (e.g. codegraph) internally.
     batch_extract returns ``None`` when a semantic backend cannot safely
-    extract its sources, distinct from a successful empty dict. call_edges
+    extract its sources, distinct from a successful empty dict. A handler may
+    retain ``filepath: []`` entries to mark supported files with no analysis
+    units as handled and prevent a generic fallback. call_edges
     returns an empty dict when its backend is unavailable; function_spans
     returns None so the caller can fall back to the regex extractor for that
     file, or raises BackendUnavailableError for languages where a regex
@@ -65,6 +68,7 @@ REGISTRY: dict = {
     "typescript": LanguageHandler(batch_extract=_typescript.batch_extract, call_edges=_typescript.call_edges, function_spans=_typescript.function_spans, split_blocks=_typescript.split_blocks, remove_comments=_typescript.remove_comments),
     "arkts":      LanguageHandler(batch_extract=_arkts.batch_extract,      call_edges=_arkts.call_edges,      function_spans=_arkts.function_spans, remove_comments=_arkts.remove_comments),
     "erlang":     LanguageHandler(batch_extract=_erlang.batch_extract,     call_edges=_erlang.call_edges,     function_spans=_erlang.function_spans, incremental_source_extract=_erlang.extract_functions_from_sources),
+    "chisel":     LanguageHandler(batch_extract=_chisel.batch_extract,     call_edges=_chisel.call_edges,     function_spans=_chisel.function_spans),
 }
 
 

--- a/src/languages/registry.py
+++ b/src/languages/registry.py
@@ -14,6 +14,7 @@ from src.languages import typescript as _typescript
 from src.languages import arkts as _arkts
 from src.languages import erlang as _erlang
 from src.languages import chisel as _chisel
+from src.languages import verilog as _verilog
 
 from src.languages.base import BackendUnavailableError as _BackendUnavailableError
 
@@ -69,6 +70,7 @@ REGISTRY: dict = {
     "arkts":      LanguageHandler(batch_extract=_arkts.batch_extract,      call_edges=_arkts.call_edges,      function_spans=_arkts.function_spans, remove_comments=_arkts.remove_comments),
     "erlang":     LanguageHandler(batch_extract=_erlang.batch_extract,     call_edges=_erlang.call_edges,     function_spans=_erlang.function_spans, incremental_source_extract=_erlang.extract_functions_from_sources),
     "chisel":     LanguageHandler(batch_extract=_chisel.batch_extract,     call_edges=_chisel.call_edges,     function_spans=_chisel.function_spans),
+    "verilog":    LanguageHandler(batch_extract=_verilog.batch_extract,    call_edges=_verilog.call_edges,    function_spans=_verilog.function_spans),
 }
 
 

--- a/src/languages/verilog.py
+++ b/src/languages/verilog.py
@@ -1,0 +1,500 @@
+"""Verilog/SystemVerilog language service with optional Verible parsing.
+
+The analysis unit is a top-level ``module``. Verible is preferred when its
+syntax-tree schema is recognized; a conservative source scanner keeps module
+extraction and instance edges available without external tooling.
+"""
+
+from __future__ import annotations
+
+import bisect
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.file_utils import _is_test_file
+from src.languages.codegraph import canonicalize
+from src.languages.hardware import (
+    VERILOG_EXTENSIONS,
+    is_excluded_source_directory,
+)
+
+
+_VERIBLE_DISABLE_ENV = "FM_AGENT_NO_VERIBLE"
+_VERIBLE_TIMEOUT_SECONDS = 120
+_MODULE_OPEN_RE = re.compile(
+    r"\bmodule\s+(?:(?:automatic|static)\s+)?"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_$]*)"
+)
+_ENDMODULE_RE = re.compile(r"\bendmodule\b")
+_INSTANTIATION_RE = re.compile(
+    r"^[ \t]*(?:\(\*.*?\*\)[ \t]*)*"
+    r"(?P<type>[A-Za-z_][A-Za-z0-9_$]*)"
+    r"(?:\s*#\s*\(|\s+[A-Za-z_][A-Za-z0-9_$]*"
+    r"\s*(?:\[[^\]]*\]\s*)*\()",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class VerilogUnit:
+    """One top-level module and its source metadata."""
+
+    abs_path: str
+    rel_path: str
+    source: str
+    name: str
+    span: tuple[int, int]
+    fqn: str | None = None
+
+
+@dataclass(frozen=True)
+class VerilogAnalysis:
+    """One project scan, retaining files that contain no modules."""
+
+    files: tuple[str, ...]
+    modules: tuple[VerilogUnit, ...]
+
+
+def _project_root(proj_dir: str | Path) -> Path:
+    root = Path(os.path.abspath(proj_dir))
+    return root.parent if root.name == "fm_agent" else root
+
+
+def _work_dir(proj_dir: str | Path) -> Path:
+    root = Path(os.path.abspath(proj_dir))
+    return root if root.name == "fm_agent" else root / "fm_agent"
+
+
+def _iter_verilog_files(proj_dir: str | Path):
+    project = _project_root(proj_dir)
+    if not project.is_dir():
+        return
+    for current_root, dirnames, filenames in os.walk(project):
+        dirnames[:] = sorted(
+            name
+            for name in dirnames
+            if not is_excluded_source_directory(name)
+        )
+        root = Path(current_root)
+        for filename in sorted(filenames):
+            path = root / filename
+            if path.suffix.lower() not in VERILOG_EXTENSIONS:
+                continue
+            rel_path = path.relative_to(project).as_posix()
+            if _is_test_file(rel_path):
+                continue
+            yield path, rel_path
+
+
+def mask_non_code(text: str) -> str:
+    """Mask comments and strings while preserving offsets and newlines."""
+    result = list(text)
+    index = 0
+    while index < len(text):
+        current = text[index]
+        following = text[index + 1] if index + 1 < len(text) else ""
+        if current == "/" and following == "/":
+            while index < len(text) and text[index] != "\n":
+                result[index] = " "
+                index += 1
+            continue
+        if current == "/" and following == "*":
+            result[index] = result[index + 1] = " "
+            index += 2
+            while index < len(text):
+                if text[index:index + 2] == "*/":
+                    result[index] = result[index + 1] = " "
+                    index += 2
+                    break
+                if text[index] != "\n":
+                    result[index] = " "
+                index += 1
+            continue
+        if current == '"':
+            result[index] = " "
+            index += 1
+            while index < len(text):
+                if text[index] == "\\":
+                    if text[index] != "\n":
+                        result[index] = " "
+                    if index + 1 < len(text) and text[index + 1] != "\n":
+                        result[index + 1] = " "
+                    index += 2
+                    continue
+                if text[index] == '"':
+                    result[index] = " "
+                    index += 1
+                    break
+                if text[index] != "\n":
+                    result[index] = " "
+                index += 1
+            continue
+        index += 1
+    return "".join(result)
+
+
+def _verible_binary() -> str | None:
+    if os.environ.get(_VERIBLE_DISABLE_ENV):
+        return None
+    return shutil.which("verible-verilog-syntax")
+
+
+def _run_verible_tree(text: str) -> dict | None:
+    binary = _verible_binary()
+    if binary is None:
+        return None
+    try:
+        completed = subprocess.run(
+            [binary, "--printtree", "--export_json", "-"],
+            input=text,
+            capture_output=True,
+            encoding="utf-8",
+            timeout=_VERIBLE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0 or not completed.stdout.strip():
+        return None
+    try:
+        document = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(document, dict) or not document:
+        return None
+    first = next(iter(document.values()))
+    if not isinstance(first, dict):
+        return None
+    tree = first.get("tree")
+    return tree if isinstance(tree, dict) else None
+
+
+def _children(node: object) -> list:
+    if not isinstance(node, dict):
+        return []
+    children = node.get("children")
+    return children if isinstance(children, list) else []
+
+
+def _first_descendant(node: object, tag: str) -> dict | None:
+    for child in _children(node):
+        if not isinstance(child, dict):
+            continue
+        if child.get("tag") == tag:
+            return child
+        found = _first_descendant(child, tag)
+        if found is not None:
+            return found
+    return None
+
+
+def _first_identifier(node: object) -> tuple[str | None, str | None]:
+    if not isinstance(node, dict):
+        return None, None
+    tag = node.get("tag")
+    if tag in {"SymbolIdentifier", "EscapedIdentifier"}:
+        value = node.get("text")
+        if isinstance(value, str):
+            return tag, value
+    for child in _children(node):
+        child_tag, value = _first_identifier(child)
+        if value is not None:
+            return child_tag, value
+    return None, None
+
+
+def _node_byte_span(node: object) -> tuple[int | None, int | None]:
+    start = None
+    end = None
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        if not isinstance(current, dict):
+            continue
+        current_start = current.get("start")
+        current_end = current.get("end")
+        if isinstance(current_start, int) and isinstance(current_end, int):
+            start = current_start if start is None else min(start, current_start)
+            end = current_end if end is None else max(end, current_end)
+        stack.extend(_children(current))
+    return start, end
+
+
+def _top_level_modules(tree: object) -> list[dict]:
+    modules = []
+
+    def walk(node: object) -> None:
+        if isinstance(node, list):
+            for child in node:
+                walk(child)
+            return
+        if not isinstance(node, dict):
+            return
+        if node.get("tag") == "kModuleDeclaration":
+            modules.append(node)
+            return
+        for child in _children(node):
+            walk(child)
+
+    walk(tree)
+    return modules
+
+
+def _line_start_offsets(text: str) -> list[int]:
+    """Return UTF-8 byte offsets used by Verible's JSON tree."""
+    encoded = text.encode("utf-8")
+    return [0, *(match.end() for match in re.finditer(b"\n", encoded))]
+
+
+def _character_line_start_offsets(text: str) -> list[int]:
+    """Return Python character offsets used by the source scanner."""
+    return [0, *(match.end() for match in re.finditer("\n", text))]
+
+
+def _extract_via_verible(text: str) -> list[tuple[str, int, int]] | None:
+    tree = _run_verible_tree(text)
+    if tree is None:
+        return None
+    module_nodes = _top_level_modules(tree)
+    if not module_nodes:
+        # An empty list is not trusted because Verible tags can change between
+        # versions; the source scanner decides whether the file is truly empty.
+        return None
+    starts = _line_start_offsets(text)
+    modules = []
+    for node in module_nodes:
+        header = _first_descendant(node, "kModuleHeader")
+        tag, name = _first_identifier(header)
+        if not name:
+            continue
+        if tag == "EscapedIdentifier":
+            logging.warning(
+                "Skipping escaped Verilog module name %s; it cannot form a "
+                "portable analysis-unit path",
+                name,
+            )
+            continue
+        start_byte, end_byte = _node_byte_span(node)
+        if start_byte is None or end_byte is None:
+            continue
+        start_line = bisect.bisect_right(starts, start_byte) - 1
+        end_line = bisect.bisect_right(
+            starts, max(start_byte, end_byte - 1)
+        ) - 1
+        modules.append((name, start_line, end_line))
+    return modules or None
+
+
+def _extract_via_source(text: str) -> list[tuple[str, int, int]]:
+    masked = mask_non_code(text)
+    starts = _character_line_start_offsets(text)
+    modules = []
+    cursor = 0
+    while True:
+        opening = _MODULE_OPEN_RE.search(masked, cursor)
+        if opening is None:
+            break
+        closing = _ENDMODULE_RE.search(masked, opening.end())
+        end_offset = closing.end() if closing is not None else len(masked)
+        start_line = bisect.bisect_right(starts, opening.start()) - 1
+        end_line = bisect.bisect_right(
+            starts, max(opening.start(), end_offset - 1)
+        ) - 1
+        modules.append((opening.group("name"), start_line, end_line))
+        cursor = end_offset
+    return modules
+
+
+def _module_spans(text: str) -> list[tuple[str, int, int]]:
+    return _extract_via_verible(text) or _extract_via_source(text)
+
+
+def _analyze_sources(proj_dir: str | Path) -> VerilogAnalysis:
+    files = []
+    modules = []
+    for path, rel_path in _iter_verilog_files(proj_dir):
+        absolute = str(path.absolute())
+        files.append(absolute)
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logging.warning("Unable to read Verilog source %s: %s", path, exc)
+            continue
+        lines = text.splitlines(keepends=True)
+        for name, start, end in _module_spans(text):
+            modules.append(
+                VerilogUnit(
+                    abs_path=absolute,
+                    rel_path=rel_path,
+                    source="".join(lines[start:end + 1]),
+                    name=name,
+                    span=(start, end),
+                )
+            )
+    return VerilogAnalysis(files=tuple(files), modules=tuple(modules))
+
+
+def _source_unit_fqn(unit: VerilogUnit, extracted_name: str | None = None) -> str:
+    path = Path(unit.rel_path)
+    source_directory = f"{path.stem}-{path.suffix.lstrip('.')}"
+    parts = [*path.parent.parts, source_directory, canonicalize(extracted_name or unit.name)]
+    return "::".join(part for part in parts if part not in {"", "."})
+
+
+def _units_with_fqns(
+    modules: tuple[VerilogUnit, ...],
+) -> list[tuple[str, VerilogUnit]]:
+    counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    result = []
+    for unit in modules:
+        name = canonicalize(unit.name)
+        count = counts[unit.abs_path][name]
+        counts[unit.abs_path][name] += 1
+        extracted_name = name if count == 0 else f"{name}_{count}"
+        result.append((_source_unit_fqn(unit, extracted_name), unit))
+    return result
+
+
+def _records(
+    analysis: VerilogAnalysis,
+    *,
+    spans: bool,
+) -> dict[str, list[tuple]]:
+    grouped: dict[str, list[tuple]] = {path: [] for path in analysis.files}
+    for fqn, unit in _units_with_fqns(analysis.modules):
+        extracted_name = fqn.rsplit("::", 1)[-1]
+        if spans:
+            grouped[unit.abs_path].append(
+                (extracted_name, unit.span[0], unit.span[1])
+            )
+        else:
+            grouped[unit.abs_path].append((extracted_name, unit.source))
+    return grouped
+
+
+def batch_extract(proj_dir: str) -> dict[str, list[tuple[str, str]]]:
+    """Return module units, retaining empty lists for handled RTL files."""
+    return _records(_analyze_sources(proj_dir), spans=False)
+
+
+def function_spans(proj_dir: str, filepath: str):
+    """Return module spans; supported files without modules are handled-empty."""
+    path = Path(os.path.abspath(filepath))
+    if path.suffix.lower() not in VERILOG_EXTENSIONS or not path.is_file():
+        return None
+    return _records(_analyze_sources(proj_dir), spans=True).get(str(path), [])
+
+
+def _extracted_modules(proj_dir: str | Path) -> tuple[VerilogUnit, ...]:
+    root = _work_dir(proj_dir) / "extracted_functions"
+    if not root.is_dir():
+        return ()
+    modules = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in VERILOG_EXTENSIONS:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        relative = path.relative_to(root)
+        spans = _module_spans(text)
+        if len(spans) != 1:
+            continue
+        name, start, end = spans[0]
+        modules.append(
+            VerilogUnit(
+                abs_path=str(path.absolute()),
+                rel_path=relative.as_posix(),
+                source=text,
+                name=name,
+                span=(start, end),
+                fqn="::".join(relative.with_suffix("").parts),
+            )
+        )
+    return tuple(modules)
+
+
+def _verible_instantiations(
+    text: str,
+    known_names: set[str],
+) -> set[str] | None:
+    tree = _run_verible_tree(text)
+    if tree is None or not _top_level_modules(tree):
+        return None
+    found = set()
+
+    def walk(node: object) -> None:
+        if isinstance(node, list):
+            for child in node:
+                walk(child)
+            return
+        if not isinstance(node, dict):
+            return
+        if node.get("tag") == "kInstantiationBase":
+            instantiation_type = _first_descendant(node, "kInstantiationType")
+            _tag, name = _first_identifier(instantiation_type)
+            if name in known_names:
+                found.add(name)
+        for child in _children(node):
+            walk(child)
+
+    walk(tree)
+    # A non-empty result demonstrates that the expected Verible tags are still
+    # valid. For an empty result, use the stable scanner so partial tag drift
+    # cannot silently erase real instance edges.
+    return found or None
+
+
+def _source_instantiations(text: str, known_names: set[str]) -> set[str]:
+    return {
+        match.group("type")
+        for match in _INSTANTIATION_RE.finditer(mask_non_code(text))
+        if match.group("type") in known_names
+    }
+
+
+def _instantiated_names(text: str, known_names: set[str]) -> set[str]:
+    via_verible = _verible_instantiations(text, known_names)
+    if via_verible is not None:
+        return via_verible
+    return _source_instantiations(text, known_names)
+
+
+def call_edges(proj_dir: str) -> dict[str, set[str]]:
+    """Return module-type instantiation edges with module-level deduplication."""
+    extracted = _extracted_modules(proj_dir)
+    if extracted:
+        units_with_fqns = [(unit.fqn or "", unit) for unit in extracted]
+    else:
+        analysis = _analyze_sources(proj_dir)
+        units_with_fqns = _units_with_fqns(analysis.modules)
+
+    by_name: dict[str, list[tuple[str, VerilogUnit]]] = defaultdict(list)
+    for fqn, unit in units_with_fqns:
+        by_name[unit.name].append((fqn, unit))
+
+    edges: dict[str, set[str]] = defaultdict(set)
+    known_names = set(by_name)
+    for caller_fqn, caller in units_with_fqns:
+        for reference in _instantiated_names(caller.source, known_names):
+            candidates = by_name[reference]
+            if len(candidates) != 1:
+                logging.warning(
+                    "Skipping ambiguous Verilog module reference %s from %s; "
+                    "candidates: %s",
+                    reference,
+                    caller_fqn,
+                    ", ".join(sorted(fqn for fqn, _unit in candidates)),
+                )
+                continue
+            callee_fqn = candidates[0][0]
+            if callee_fqn != caller_fqn:
+                edges[caller_fqn].add(callee_fqn)
+    return dict(edges)

--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -863,13 +863,23 @@ def _ensure_source_files_in_phases(phases_json, required_source_files):
     }
 
 
-def _prepare_workflow_file(proj_dir, work_dir, script_dir, workflow_filename):
+def _prepare_workflow_file(
+    proj_dir,
+    work_dir,
+    script_dir,
+    workflow_filename,
+    workflow_source=None,
+):
     """Copy a workflow markdown into ``work_dir`` and rewrite the
     ``source_files`` instruction so it points at the concrete project root,
     telling the agent to record paths relative to it (and not prefixed with the
     project directory name).
     """
-    workflow_src = os.path.join(script_dir, "md", workflow_filename)
+    workflow_src = (
+        os.fspath(workflow_source)
+        if workflow_source is not None
+        else os.path.join(script_dir, "md", workflow_filename)
+    )
     workflow_dst = os.path.join(work_dir, workflow_filename)
     shutil.copy2(workflow_src, workflow_dst)
     proj_dir_abs = os.path.abspath(proj_dir)
@@ -900,22 +910,44 @@ def _prepare_workflow_file(proj_dir, work_dir, script_dir, workflow_filename):
         _f.write(md)
 
 
-def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
-                         resume=False, submodules=None):
+def _run_generate_phases(
+    proj_dir,
+    work_dir,
+    script_dir,
+    is_incremental=False,
+    resume=False,
+    submodules=None,
+    workflow_source=None,
+    phase_plan_validator=None,
+):
     """Stage 1: generate phase.json — input target code, output phases.json."""
     phases_json = os.path.join(work_dir, "phases.json")
     prev_mtime = os.path.getmtime(phases_json) if os.path.exists(phases_json) else None
 
-    phase_plan_errors = (
-        _phase_plan_schema_errors(phases_json)
-        if os.path.exists(phases_json)
-        else []
+    def _validation_errors():
+        if not os.path.exists(phases_json):
+            return ["phases.json is missing"]
+        errors = _phase_plan_schema_errors(phases_json)
+        if not errors and phase_plan_validator is not None:
+            errors.extend(phase_plan_validator(phases_json))
+        return errors
+
+    phase_plan_errors = _validation_errors() if os.path.exists(phases_json) else []
+    _resume_skip = (
+        resume
+        and _phase_plan_complete(work_dir)
+        and not phase_plan_errors
     )
-    _resume_skip = resume and _phase_plan_complete(work_dir)
     if _resume_skip:
         print("[Pipeline] Stage 1/6: RESUME — phases.json found, skipping phase plan generation.")
 
-    _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_phases.md")
+    _prepare_workflow_file(
+        proj_dir,
+        work_dir,
+        script_dir,
+        "workflow_generate_phases.md",
+        workflow_source=workflow_source,
+    )
 
     fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
                     "It is a workspace for storing your output files only. "
@@ -988,11 +1020,7 @@ def _run_generate_phases(proj_dir, work_dir, script_dir, is_incremental=False,
         except subprocess.CalledProcessError as e:
             logging.warning(f"Stage 1 attempt {attempt}: opencode exited with code {e.returncode}")
 
-        phase_plan_errors = (
-            _phase_plan_schema_errors(phases_json)
-            if os.path.exists(phases_json)
-            else ["phases.json is missing"]
-        )
+        phase_plan_errors = _validation_errors()
 
         phase_plan_ready = False
         if not phase_plan_errors:
@@ -1087,7 +1115,13 @@ def _post_process_phases(proj_dir, work_dir, required_source_files=None,
     return phases_modified
 
 
-def _run_generate_domain_context(proj_dir, work_dir, script_dir, resume=False):
+def _run_generate_domain_context(
+    proj_dir,
+    work_dir,
+    script_dir,
+    resume=False,
+    workflow_source=None,
+):
     """Stage 2: generate domain context — input phases.json, output domain context
     files for each phase.
     """
@@ -1095,7 +1129,13 @@ def _run_generate_domain_context(proj_dir, work_dir, script_dir, resume=False):
     if _resume_skip:
         print("[Pipeline] Stage 2/6: RESUME — domain context files found, skipping domain context generation.")
 
-    _prepare_workflow_file(proj_dir, work_dir, script_dir, "workflow_generate_domain_context.md")
+    _prepare_workflow_file(
+        proj_dir,
+        work_dir,
+        script_dir,
+        "workflow_generate_domain_context.md",
+        workflow_source=workflow_source,
+    )
 
     fm_reminder = ("IMPORTANT: The fm_agent/ directory is NOT part of the project source code. "
                     "It is a workspace for storing your output files only. "

--- a/src/spec_forms/__init__.py
+++ b/src/spec_forms/__init__.py
@@ -1,0 +1,12 @@
+"""Specification artifact contracts used by the pipeline."""
+
+from .base import SpecArtifactPaths, SpecForm, SpecValidationResult
+from .software import SOFTWARE_SPEC_FORM, SoftwareSpecForm
+
+__all__ = [
+    "SOFTWARE_SPEC_FORM",
+    "SoftwareSpecForm",
+    "SpecArtifactPaths",
+    "SpecForm",
+    "SpecValidationResult",
+]

--- a/src/spec_forms/__init__.py
+++ b/src/spec_forms/__init__.py
@@ -1,6 +1,7 @@
 """Specification artifact contracts used by the pipeline."""
 
 from .base import SpecArtifactPaths, SpecForm, SpecValidationResult
+from .config import SpecGenerationConfig
 from .software import SOFTWARE_SPEC_FORM, SoftwareSpecForm
 
 __all__ = [
@@ -8,5 +9,6 @@ __all__ = [
     "SoftwareSpecForm",
     "SpecArtifactPaths",
     "SpecForm",
+    "SpecGenerationConfig",
     "SpecValidationResult",
 ]

--- a/src/spec_forms/__init__.py
+++ b/src/spec_forms/__init__.py
@@ -1,7 +1,10 @@
 """Specification artifact contracts used by the pipeline."""
 
 from .base import SpecArtifactPaths, SpecForm, SpecValidationResult
-from .config import SpecGenerationConfig
+from .config import (
+    SpecGenerationConfig,
+    configure_current_spec_generation,
+)
 from .software import SOFTWARE_SPEC_FORM, SoftwareSpecForm
 
 __all__ = [
@@ -11,4 +14,5 @@ __all__ = [
     "SpecForm",
     "SpecGenerationConfig",
     "SpecValidationResult",
+    "configure_current_spec_generation",
 ]

--- a/src/spec_forms/base.py
+++ b/src/spec_forms/base.py
@@ -46,3 +46,24 @@ class SpecForm(ABC):
         expected_dependencies: Sequence[str] = (),
     ) -> SpecValidationResult:
         """Check artifact completeness without modifying the artifacts."""
+
+    @abstractmethod
+    def read_self_spec(self, unit_file: Path) -> str | None:
+        """Return caller-facing self-spec context, or ``None`` if unreadable."""
+
+    @abstractmethod
+    def read_dependency_expectation(
+        self,
+        caller_file: Path,
+        callee_fqn: str,
+        aliases: Sequence[str] = (),
+    ) -> str | None:
+        """Return one caller's expectation for a callee, if recorded."""
+
+    @abstractmethod
+    def batch_intro(self, language: str) -> str:
+        """Render the form-specific introduction for a batch prompt."""
+
+    @abstractmethod
+    def output_contract_prompt(self) -> str:
+        """Render the form-specific output contract for a batch prompt."""

--- a/src/spec_forms/base.py
+++ b/src/spec_forms/base.py
@@ -1,0 +1,48 @@
+"""Base contract for one specification artifact form."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class SpecArtifactPaths:
+    """The self-spec and dependency-info artifacts for one analysis unit."""
+
+    self_spec: Path
+    dependency_info: Path
+
+
+@dataclass(frozen=True)
+class SpecValidationResult:
+    """Side-effect-free result of checking one unit's spec artifacts."""
+
+    ready: bool
+    errors: tuple[str, ...] = ()
+
+
+class SpecForm(ABC):
+    """Describe the artifacts produced by one specification form.
+
+    Project analysis, unit extraction, dependency discovery, orchestration,
+    reasoning, and candidate validation deliberately remain outside this
+    contract.
+    """
+
+    id: str
+    schema_version: str
+
+    @abstractmethod
+    def artifact_paths(self, unit_file: Path) -> SpecArtifactPaths:
+        """Return the specification artifacts adjacent to ``unit_file``."""
+
+    @abstractmethod
+    def validate(
+        self,
+        unit_file: Path,
+        expected_dependencies: Sequence[str] = (),
+    ) -> SpecValidationResult:
+        """Check artifact completeness without modifying the artifacts."""

--- a/src/spec_forms/base.py
+++ b/src/spec_forms/base.py
@@ -40,6 +40,10 @@ class SpecForm(ABC):
         """Return the specification artifacts adjacent to ``unit_file``."""
 
     @abstractmethod
+    def is_artifact_path(self, path: Path) -> bool:
+        """Return whether ``path`` is an artifact produced by this form."""
+
+    @abstractmethod
     def validate(
         self,
         unit_file: Path,

--- a/src/spec_forms/base.py
+++ b/src/spec_forms/base.py
@@ -22,6 +22,7 @@ class SpecValidationResult:
 
     ready: bool
     errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
 
 
 class SpecForm(ABC):
@@ -34,6 +35,21 @@ class SpecForm(ABC):
 
     id: str
     schema_version: str
+
+    @property
+    def unit_noun(self) -> str:
+        """Return the singular analysis-unit term used in batch prompts."""
+        return "function"
+
+    def batch_rules(self, language: str) -> Sequence[str]:
+        """Return form-specific behavioral rules for a batch prompt."""
+        del language
+        return (
+            "Describe WHAT the function guarantees, NOT HOW it implements it",
+            "Do NOT name internal helper calls, loop structure, or data layout decisions",
+            "Do NOT enumerate members of sets - describe the GOVERNING RULE",
+            "Specs describe INTENDED CORRECT behavior per the domain (see domain files)",
+        )
 
     @abstractmethod
     def artifact_paths(self, unit_file: Path) -> SpecArtifactPaths:

--- a/src/spec_forms/base.py
+++ b/src/spec_forms/base.py
@@ -67,3 +67,23 @@ class SpecForm(ABC):
     @abstractmethod
     def output_contract_prompt(self) -> str:
         """Render the form-specific output contract for a batch prompt."""
+
+    @abstractmethod
+    def system_prompt_path(self, script_dir: Path) -> Path:
+        """Return the source path for the form's staged system prompt."""
+
+    @abstractmethod
+    def workflow_prompt_path(self, script_dir: Path) -> Path:
+        """Return the source path for the form's staged workflow prompt."""
+
+    @abstractmethod
+    def generation_instruction(
+        self,
+        batch_prompt_rel: str,
+        attempt: int,
+    ) -> str:
+        """Render the agent instruction for one batch attempt."""
+
+    @abstractmethod
+    def trace_outputs(self, unit_files: Sequence[Path]) -> list[str]:
+        """Return the artifact paths expected from one traced batch."""

--- a/src/spec_forms/config.py
+++ b/src/spec_forms/config.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Iterator
 
 from .base import SpecForm
+from .software import SoftwareSpecForm
 
 
 @dataclass
@@ -82,4 +83,16 @@ def _validate_spec_generation_config(
     ):
         raise ValueError(
             "SpecForm.schema_version must be a non-empty string"
+        )
+    # The downstream parser is tied to SoftwareSpecForm's exact sidecar
+    # contract. Subclasses can override that contract, so isinstance() would
+    # claim compatibility that the reasoning backend does not actually have.
+    if (
+        config.enable_reasoning
+        and type(config.spec_form) is not SoftwareSpecForm
+    ):
+        raise ValueError(
+            "the current reasoning backend only supports the built-in "
+            "SoftwareSpecForm (.spec.json/.info.json); custom SpecForms "
+            "must set enable_reasoning=False"
         )

--- a/src/spec_forms/config.py
+++ b/src/spec_forms/config.py
@@ -1,0 +1,17 @@
+"""Runtime configuration for the built-in specification pipeline."""
+
+from dataclasses import dataclass
+
+from .base import SpecForm
+
+
+@dataclass
+class SpecGenerationConfig:
+    """Select the specification strategy and optional downstream reasoning."""
+
+    spec_form: SpecForm
+    enable_reasoning: bool = True
+
+    def should_run_reasoning(self, only_spec: bool) -> bool:
+        """Return whether reasoning and bug validation should run."""
+        return self.enable_reasoning and not only_spec

--- a/src/spec_forms/config.py
+++ b/src/spec_forms/config.py
@@ -1,6 +1,9 @@
 """Runtime configuration for the built-in specification pipeline."""
 
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
+from typing import Iterator
 
 from .base import SpecForm
 
@@ -15,3 +18,68 @@ class SpecGenerationConfig:
     def should_run_reasoning(self, only_spec: bool) -> bool:
         """Return whether reasoning and bug validation should run."""
         return self.enable_reasoning and not only_spec
+
+
+_CURRENT_SPEC_GENERATION_CONFIG: ContextVar[SpecGenerationConfig] = (
+    ContextVar("fm_agent_spec_generation_config")
+)
+
+
+@contextmanager
+def _bind_spec_generation_config(
+    config: SpecGenerationConfig,
+) -> Iterator[None]:
+    """Bind one pipeline run's configuration while its configure hook runs."""
+    token = _CURRENT_SPEC_GENERATION_CONFIG.set(config)
+    try:
+        yield
+    finally:
+        _CURRENT_SPEC_GENERATION_CONFIG.reset(token)
+
+
+def configure_current_spec_generation(
+    *,
+    spec_form: SpecForm,
+    enable_reasoning: bool,
+) -> None:
+    """Update the specification strategy for the active pipeline run."""
+    try:
+        config = _CURRENT_SPEC_GENERATION_CONFIG.get()
+    except LookupError as exc:
+        raise RuntimeError(
+            "configure_current_spec_generation() may only be called from "
+            "a plugin configure hook"
+        ) from exc
+
+    config.spec_form = spec_form
+    config.enable_reasoning = enable_reasoning
+
+
+def _validate_spec_generation_config(
+    config: SpecGenerationConfig,
+) -> None:
+    """Fail fast when a pipeline run has an invalid specification strategy."""
+    if not isinstance(config, SpecGenerationConfig):
+        raise ValueError(
+            "specification strategy must be a SpecGenerationConfig instance"
+        )
+    if not isinstance(config.spec_form, SpecForm):
+        raise ValueError(
+            "SpecGenerationConfig.spec_form must be a SpecForm instance"
+        )
+    if type(config.enable_reasoning) is not bool:
+        raise ValueError(
+            "SpecGenerationConfig.enable_reasoning must be bool"
+        )
+    if (
+        not isinstance(config.spec_form.id, str)
+        or not config.spec_form.id.strip()
+    ):
+        raise ValueError("SpecForm.id must be a non-empty string")
+    if (
+        not isinstance(config.spec_form.schema_version, str)
+        or not config.spec_form.schema_version.strip()
+    ):
+        raise ValueError(
+            "SpecForm.schema_version must be a non-empty string"
+        )

--- a/src/spec_forms/software.py
+++ b/src/spec_forms/software.py
@@ -37,6 +37,10 @@ class SoftwareSpecForm(SpecForm):
             dependency_info=Path(f"{unit_file}.info.json"),
         )
 
+    def is_artifact_path(self, path: Path) -> bool:
+        """Return whether ``path`` is a software specification sidecar."""
+        return str(path).endswith((".spec.json", ".info.json"))
+
     @staticmethod
     def is_valid_spec_data(data: object) -> bool:
         """Return whether data matches the exact software self-spec schema."""

--- a/src/spec_forms/software.py
+++ b/src/spec_forms/software.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Sequence
 
@@ -97,6 +98,131 @@ class SoftwareSpecForm(SpecForm):
             )
 
         return SpecValidationResult(ready=not errors, errors=tuple(errors))
+
+    def read_self_spec(self, unit_file: Path) -> str | None:
+        """Reproduce the current permissive caller self-spec rendering."""
+        spec = self._read_json(self.artifact_paths(unit_file).self_spec)
+        if not isinstance(spec, dict):
+            return None
+        return (
+            f"{spec.get('signature', '')}\n\n"
+            f"Pre-condition:\n{spec.get('pre_condition', '')}\n\n"
+            f"Post-condition:\n{spec.get('post_condition', '')}"
+        )
+
+    def read_info_data(self, unit_file: Path) -> dict | None:
+        """Return the current permissive caller dependency-info object."""
+        info = self._read_json(self.artifact_paths(unit_file).dependency_info)
+        return info if isinstance(info, dict) else None
+
+    @staticmethod
+    def dependency_match_names(
+        callee_fqn: str,
+        aliases: Sequence[str] = (),
+    ) -> list[str]:
+        """Return the existing FQN, short-name, and edge-alias candidates."""
+        names = [callee_fqn, callee_fqn.split("::")[-1]]
+        for alias in aliases:
+            if not alias:
+                continue
+            names.append(alias)
+            if "::" in alias:
+                names.append(alias.rsplit("::", 1)[-1])
+        return list(dict.fromkeys(names))
+
+    @staticmethod
+    def dependency_name_matches(recorded_name: str, candidate: str) -> bool:
+        """Reproduce the current dependency-name boundary matching."""
+        if not candidate:
+            return False
+        if "::" in candidate:
+            return candidate in recorded_name
+        return bool(
+            re.search(
+                rf"(?<![A-Za-z0-9_]){re.escape(candidate)}(?:\s*\(|\b)",
+                recorded_name,
+            )
+        )
+
+    def find_dependency_entry(
+        self,
+        info: dict,
+        callee_fqn: str,
+        aliases: Sequence[str] = (),
+    ) -> dict | None:
+        """Find the first callee entry matching any known dependency name."""
+        names = self.dependency_match_names(callee_fqn, aliases)
+        callees = info.get("callees", [])
+        if not isinstance(callees, list):
+            return None
+        for callee in callees:
+            if not isinstance(callee, dict):
+                continue
+            recorded_name = callee.get("name", "")
+            if not isinstance(recorded_name, str):
+                continue
+            if any(
+                self.dependency_name_matches(recorded_name, candidate)
+                for candidate in names
+            ):
+                return callee
+        return None
+
+    def read_dependency_expectation(
+        self,
+        caller_file: Path,
+        callee_fqn: str,
+        aliases: Sequence[str] = (),
+    ) -> str | None:
+        info = self.read_info_data(caller_file)
+        if info is None:
+            return None
+        entry = self.find_dependency_entry(info, callee_fqn, aliases)
+        if entry is None:
+            return None
+        return (
+            f"{entry.get('signature', '')}\n"
+            f"  Pre-condition: {entry.get('pre_condition', '')}\n"
+            f"  Post-condition: {entry.get('post_condition', '')}"
+        )
+
+    def batch_intro(self, language: str) -> str:
+        return (
+            f"Language: {language}. "
+            "Write specifications to adjacent .spec.json and .info.json files."
+        )
+
+    def output_contract_prompt(self) -> str:
+        return "\n".join([
+            "## SPEC FORMAT (write JSON files; do NOT modify source files)",
+            "",
+            "For each function file `<function-file>`, write TWO JSON files in the SAME "
+            "directory. `<function-file>` includes its original extension (for example, "
+            "`foo.py` must produce `foo.py.spec.json` and `foo.py.info.json`):",
+            "",
+            "`<function-file>.spec.json`:",
+            "```json",
+            '{"signature": "<FunctionName>(<params>) -> <ReturnType>", '
+            '"pre_condition": "...", "post_condition": "..."}',
+            "```",
+            "",
+            "`<function-file>.info.json`:",
+            "```json",
+            '{"callees": [{"name": "<callee_name>", "signature": "...", '
+            '"pre_condition": "...", "post_condition": "..."}]}',
+            "```",
+            "",
+            'If the function has no callees: write `{"callees": []}` to the .info.json file.',
+            "",
+            "## PROCESS",
+            "For each function:",
+            "1. Read the extracted file",
+            "2. Read caller expectations above - what do callers NEED from this function?",
+            "3. Write a behavioral spec describing WHAT it guarantees (not HOW)",
+            "4. Write the COMPLETE .spec.json and .info.json objects next to the UNCHANGED "
+            "source file",
+            "5. Use the Write tool to save both JSON files",
+        ])
 
 
 SOFTWARE_SPEC_FORM = SoftwareSpecForm()

--- a/src/spec_forms/software.py
+++ b/src/spec_forms/software.py
@@ -224,5 +224,45 @@ class SoftwareSpecForm(SpecForm):
             "5. Use the Write tool to save both JSON files",
         ])
 
+    def system_prompt_path(self, script_dir: Path) -> Path:
+        return Path(script_dir) / "md" / "system_prompt.md"
+
+    def workflow_prompt_path(self, script_dir: Path) -> Path:
+        return Path(script_dir) / "md" / "workflow_spec_step4_batch.md"
+
+    def generation_instruction(
+        self,
+        batch_prompt_rel: str,
+        attempt: int,
+    ) -> str:
+        fm_reminder = (
+            "IMPORTANT: fm_agent/ is your output workspace, not project source. "
+            "Do NOT modify any existing project files."
+        )
+        if attempt == 1:
+            return (
+                f"Process the batch prompt file at {batch_prompt_rel}. "
+                "Read it and fm_agent/spec_prompts/system_prompt.md, "
+                "generate behavioral specs for each function listed, "
+                "and write the .spec.json and .info.json files for each function. "
+                f"Do not modify the function source files. {fm_reminder}"
+            )
+        return (
+            f"Continue processing the batch prompt file at {batch_prompt_rel}. "
+            "Some functions may already have valid specs from a previous attempt. "
+            "Check each function listed in the batch prompt. Skip it only when both "
+            "its .spec.json and .info.json files contain valid JSON matching the "
+            "schemas in fm_agent/spec_prompts/system_prompt.md. If either sidecar "
+            "is missing, malformed, or schema-invalid, rewrite the complete "
+            ".spec.json and .info.json files for that function. "
+            f"Do not modify the function source files. {fm_reminder}"
+        )
+
+    def trace_outputs(self, unit_files: Sequence[Path]) -> list[str]:
+        paths = [self.artifact_paths(unit_file) for unit_file in unit_files]
+        return [str(path.self_spec) for path in paths] + [
+            str(path.dependency_info) for path in paths
+        ]
+
 
 SOFTWARE_SPEC_FORM = SoftwareSpecForm()

--- a/src/spec_forms/software.py
+++ b/src/spec_forms/software.py
@@ -1,0 +1,102 @@
+"""Pre-condition/post-condition JSON specification artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Sequence
+
+from .base import SpecArtifactPaths, SpecForm, SpecValidationResult
+
+
+_SPEC_FIELDS = frozenset({
+    "signature",
+    "pre_condition",
+    "post_condition",
+})
+
+_CALLEE_FIELDS = frozenset({
+    "name",
+    "signature",
+    "pre_condition",
+    "post_condition",
+})
+
+
+class SoftwareSpecForm(SpecForm):
+    """The existing software ``.spec.json`` / ``.info.json`` contract."""
+
+    id = "software"
+    schema_version = "V1"
+
+    def artifact_paths(self, unit_file: Path) -> SpecArtifactPaths:
+        unit_file = Path(unit_file)
+        return SpecArtifactPaths(
+            self_spec=Path(f"{unit_file}.spec.json"),
+            dependency_info=Path(f"{unit_file}.info.json"),
+        )
+
+    @staticmethod
+    def is_valid_spec_data(data: object) -> bool:
+        """Return whether data matches the exact software self-spec schema."""
+        if not isinstance(data, dict) or set(data) != _SPEC_FIELDS:
+            return False
+        return all(isinstance(data[field], str) for field in _SPEC_FIELDS)
+
+    @staticmethod
+    def is_valid_info_data(data: object) -> bool:
+        """Return whether data matches the exact dependency-info schema."""
+        if not isinstance(data, dict) or set(data) != {"callees"}:
+            return False
+
+        callees = data["callees"]
+        if not isinstance(callees, list):
+            return False
+
+        for callee in callees:
+            if not isinstance(callee, dict) or set(callee) != _CALLEE_FIELDS:
+                return False
+            if not all(
+                isinstance(callee[field], str)
+                for field in _CALLEE_FIELDS
+            ):
+                return False
+
+        return True
+
+    @staticmethod
+    def _read_json(path: Path) -> object | None:
+        try:
+            with path.open("r", encoding="utf-8") as file:
+                return json.load(file)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+
+    def validate(
+        self,
+        unit_file: Path,
+        expected_dependencies: Sequence[str] = (),
+    ) -> SpecValidationResult:
+        # Software readiness intentionally does not enforce static dependency
+        # coverage. Keep the argument for the common SpecForm contract.
+        del expected_dependencies
+        paths = self.artifact_paths(unit_file)
+        errors = []
+
+        spec = self._read_json(paths.self_spec)
+        if not self.is_valid_spec_data(spec):
+            errors.append(
+                f"missing or invalid software spec: {paths.self_spec}"
+            )
+
+        info = self._read_json(paths.dependency_info)
+        if not self.is_valid_info_data(info):
+            errors.append(
+                "missing or invalid software dependency info: "
+                f"{paths.dependency_info}"
+            )
+
+        return SpecValidationResult(ready=not errors, errors=tuple(errors))
+
+
+SOFTWARE_SPEC_FORM = SoftwareSpecForm()

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -22,6 +22,27 @@ from src.spec_forms import SpecForm, SpecGenerationConfig
 from src.verification import streaming_reasoner
 
 
+def stage_spec_generation_prompts(
+    *,
+    spec_form: SpecForm,
+    script_dir,
+    work_dir,
+    spec_prompts_dir,
+):
+    """Stage the active form's prompts before plugin stage hooks run."""
+    os.makedirs(spec_prompts_dir, exist_ok=True)
+    system_prompt_src = spec_form.system_prompt_path(Path(script_dir))
+    system_prompt_dst = os.path.join(spec_prompts_dir, "system_prompt.md")
+    shutil.copy2(system_prompt_src, system_prompt_dst)
+
+    workflow_prompt_src = spec_form.workflow_prompt_path(Path(script_dir))
+    workflow_prompt_dst = os.path.join(
+        work_dir,
+        "workflow_spec_step4_batch.md",
+    )
+    shutil.copy2(workflow_prompt_src, workflow_prompt_dst)
+
+
 def _get_pending_batches(
     batches,
     proj_dir,
@@ -121,15 +142,6 @@ def run_spec_generation_and_verification(
     # --- Stage 6: Execute spec generation workflow (per phase, per layer) ---
     spec_form = spec_generation_config.spec_form
     run_reasoning = spec_generation_config.should_run_reasoning(only_spec)
-
-    os.makedirs(spec_prompts_dir, exist_ok=True)
-    system_prompt_src = spec_form.system_prompt_path(Path(script_dir))
-    system_prompt_dst = os.path.join(spec_prompts_dir, "system_prompt.md")
-    shutil.copy2(system_prompt_src, system_prompt_dst)
-
-    batch_md_src = spec_form.workflow_prompt_path(Path(script_dir))
-    batch_md_dst = os.path.join(work_dir, "workflow_spec_step4_batch.md")
-    shutil.copy2(batch_md_src, batch_md_dst)
 
     all_processed = set()
     num_phases = len(phases_data["phases"])

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -138,7 +138,12 @@ def run_spec_generation_and_verification(
     for phase_info in sorted(phases_data["phases"], key=lambda p: p["phase"]):
         phase_num = phase_info["phase"]
         phase_name = phase_info["name"]
-        phase_files = _get_phase_files(phases_data, phase_num, input_dir)
+        phase_files = _get_phase_files(
+            phases_data,
+            phase_num,
+            input_dir,
+            spec_form=spec_form,
+        )
 
         if not phase_files:
             logging.info(f"Phase {phase_num} ({phase_name}): no extracted files, skipping.")
@@ -149,7 +154,12 @@ def run_spec_generation_and_verification(
             spec_prompts_dir, f"phase_{phase_num:02d}_topdown_layers.json"
         )
         if not os.path.exists(layers_json_path):
-            generate_topdown_layers(work_dir, [phase_num], extra_call_edges=extra_call_edges)
+            generate_topdown_layers(
+                work_dir,
+                [phase_num],
+                extra_call_edges=extra_call_edges,
+                spec_form=spec_form,
+            )
         with open(layers_json_path, "r") as f:
             layers_data = json.load(f)
         total_layers = layers_data.get("total_layers", 1)

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -48,23 +48,58 @@ def _get_pending_batches(
     proj_dir,
     spec_form: SpecForm,
     expected_dependencies_by_file,
+    *,
+    report_warnings=False,
 ):
-    """Return batches that still have at least one function without specs."""
+    """Return pending batches annotated with fresh per-unit validation errors."""
     pending = []
+    warning_lines = []
     for batch in batches:
+        validation_errors = {}
+        batch_is_pending = False
         for func_rel in batch.get("functions", []):
             full_path = os.path.normpath(os.path.join(proj_dir, func_rel))
             expected_dependencies = expected_dependencies_by_file.get(
                 full_path,
                 (),
             )
-            if not spec_form.validate(
+            result = spec_form.validate(
                 Path(full_path),
                 expected_dependencies=expected_dependencies,
-            ).ready:
-                pending.append(batch)
-                break
+            )
+            if result.warnings:
+                warning_lines.extend(
+                    f"{func_rel}: {warning}"
+                    for warning in result.warnings
+                )
+            if not result.ready:
+                batch_is_pending = True
+                validation_errors[func_rel] = list(result.errors)
+        if batch_is_pending:
+            pending_batch = dict(batch)
+            pending_batch["validation_errors"] = validation_errors
+            pending.append(pending_batch)
+    if report_warnings and warning_lines:
+        logging.warning(
+            "Specification validation advisories for this scan:\n- %s",
+            "\n- ".join(dict.fromkeys(warning_lines)),
+        )
     return pending
+
+
+def _format_validation_feedback(validation_errors):
+    """Render exact per-unit validation failures for the next batch attempt."""
+    if not validation_errors:
+        return ""
+    lines = [
+        "",
+        "The previous attempt produced artifacts that failed validation. Repair "
+        "every issue below; do not merely rename or delete the artifact:",
+    ]
+    for unit_file, errors in validation_errors.items():
+        lines.append(f"- {unit_file}")
+        lines.extend(f"  - {error}" for error in errors)
+    return "\n".join(lines)
 
 
 def _topdown_unit_path(proj_dir, work_dir, file_rel):
@@ -97,6 +132,10 @@ def _run_spec_generation_batch(
         for func_rel in function_files
     ]
     prompt = spec_form.generation_instruction(batch_prompt_rel, attempt)
+    if attempt > 1:
+        prompt += _format_validation_feedback(
+            batch_info.get("validation_errors", {})
+        )
     prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_spec_step4_batch.md")
     command = build_llm_cli_command(
         model=OPENCODE_SPEC_MODEL,
@@ -223,6 +262,7 @@ def run_spec_generation_and_verification(
                     proj_dir,
                     spec_form,
                     expected_dependencies_by_file,
+                    report_warnings=True,
                 )
                 if not pending_batches:
                     # All functions in this layer are specced. When downstream
@@ -317,15 +357,16 @@ def run_spec_generation_and_verification(
                         ),
                     ).ready
                 )
-                if specs_generated > 0 and not _get_pending_batches(
+                remaining_batches = _get_pending_batches(
                     all_batches,
                     proj_dir,
                     spec_form,
                     expected_dependencies_by_file,
-                ):
+                )
+                if specs_generated > 0 and not remaining_batches:
                     break
 
-                if specs_generated > 0:
+                if specs_generated > 0 and attempt < OPENCODE_MAX_RETRIES:
                     # Partial progress — retry remaining batches without delay
                     logging.info(
                         f"Phase {phase_num} Layer {layer_idx} attempt {attempt}: "
@@ -346,10 +387,15 @@ def run_spec_generation_and_verification(
                     )
                     time.sleep(delay)
                 else:
+                    remaining_units = sum(
+                        len(batch.get("validation_errors", {}))
+                        for batch in remaining_batches
+                    )
                     print(
                         f"[Pipeline] ERROR: Stage 6 Phase {phase_num} Layer {layer_idx} failed "
                         f"after {OPENCODE_MAX_RETRIES} attempts. "
-                        f"No specs were generated. "
+                        f"{remaining_units} {spec_form.unit_noun}(s) still have "
+                        "invalid or missing specs. "
                         f"Check {os.path.basename(proj_dir)}/fm_agent/trace/ for details."
                     )
                     sys.exit(1)

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -18,6 +18,7 @@ from src.generate_batch_prompts import generate_batch_prompts
 from src.generate_topdown_layers import generate_topdown_layers
 from src.llm_client import build_llm_cli_command
 from src.opencode_trace import function_id_from_extracted_path, run_opencode_traced
+from src.spec_forms import SOFTWARE_SPEC_FORM
 from src.verification import streaming_reasoner
 
 
@@ -153,12 +154,13 @@ def run_spec_generation_and_verification(
         for layer_idx in range(total_layers):
             print(f"[Pipeline] Stage 6/6: Phase {phase_num}/{num_phases} — {phase_name}, Layer {layer_idx}/{total_layers - 1}")
 
-            # Generate batch prompts for this layer. On resume, skip functions
-            # that were already specced in a previous run.
+            # Generate batch prompts in-process. Stage C will replace this
+            # temporary software form with the resolved Stage 6 strategy.
             manifest = generate_batch_prompts(
                 work_dir=Path(work_dir),
                 phase=phase_num,
                 layers_spec=str(layer_idx),
+                spec_form=SOFTWARE_SPEC_FORM,
                 output_dir=Path(batch_dir),
                 resume=resume,
             )

--- a/src/spec_generation_and_verification.py
+++ b/src/spec_generation_and_verification.py
@@ -13,25 +13,47 @@ from pathlib import Path
 
 from config import MAX_WORKERS, OPENCODE_MAX_RETRIES, OPENCODE_SPEC_MODEL
 from src.domain_knowledge import list_staged_domain_knowledge_relpaths
-from src.file_utils import _get_incomplete_verification_files, _get_phase_files, is_file_ready
+from src.file_utils import _get_incomplete_verification_files, _get_phase_files
 from src.generate_batch_prompts import generate_batch_prompts
 from src.generate_topdown_layers import generate_topdown_layers
 from src.llm_client import build_llm_cli_command
 from src.opencode_trace import function_id_from_extracted_path, run_opencode_traced
-from src.spec_forms import SOFTWARE_SPEC_FORM
+from src.spec_forms import SpecForm, SpecGenerationConfig
 from src.verification import streaming_reasoner
 
 
-def _get_pending_batches(batches, proj_dir):
+def _get_pending_batches(
+    batches,
+    proj_dir,
+    spec_form: SpecForm,
+    expected_dependencies_by_file,
+):
     """Return batches that still have at least one function without specs."""
     pending = []
     for batch in batches:
         for func_rel in batch.get("functions", []):
-            full_path = os.path.join(proj_dir, func_rel)
-            if not is_file_ready(full_path):
+            full_path = os.path.normpath(os.path.join(proj_dir, func_rel))
+            expected_dependencies = expected_dependencies_by_file.get(
+                full_path,
+                (),
+            )
+            if not spec_form.validate(
+                Path(full_path),
+                expected_dependencies=expected_dependencies,
+            ).ready:
                 pending.append(batch)
                 break
     return pending
+
+
+def _topdown_unit_path(proj_dir, work_dir, file_rel):
+    """Resolve a topdown unit path, including a tolerated fm_agent/ prefix."""
+    file_path = Path(file_rel)
+    if file_path.is_absolute():
+        return os.path.normpath(file_path)
+    if file_path.parts[:1] == (Path(work_dir).name,):
+        return os.path.normpath(Path(proj_dir) / file_path)
+    return os.path.normpath(Path(work_dir) / file_path)
 
 
 def _run_spec_generation_batch(
@@ -42,6 +64,7 @@ def _run_spec_generation_batch(
     layer_idx,
     batch_rel_dir,
     batch_info,
+    spec_form: SpecForm,
 ):
     # Run one batch end-to-end so the executor can refill slots as soon as a
     # batch finishes, instead of waiting for a whole chunk barrier.
@@ -52,27 +75,7 @@ def _run_spec_generation_batch(
         function_id_from_extracted_path(func_rel)
         for func_rel in function_files
     ]
-    fm_reminder = ("IMPORTANT: fm_agent/ is your output workspace, not project source. "
-                    "Do NOT modify any existing project files.")
-    if attempt == 1:
-        prompt = (
-            f"Process the batch prompt file at {batch_prompt_rel}. "
-            f"Read it and fm_agent/spec_prompts/system_prompt.md, "
-            f"generate behavioral specs for each function listed, "
-            f"and write the .spec.json and .info.json files for each function. "
-            f"Do not modify the function source files. {fm_reminder}"
-        )
-    else:
-        prompt = (
-            f"Continue processing the batch prompt file at {batch_prompt_rel}. "
-            f"Some functions may already have valid specs from a previous attempt. "
-            f"Check each function listed in the batch prompt. Skip it only when both "
-            f"its .spec.json and .info.json files contain valid JSON matching the "
-            f"schemas in fm_agent/spec_prompts/system_prompt.md. If either sidecar "
-            f"is missing, malformed, or schema-invalid, rewrite the complete "
-            f".spec.json and .info.json files for that function. "
-            f"Do not modify the function source files. {fm_reminder}"
-        )
+    prompt = spec_form.generation_instruction(batch_prompt_rel, attempt)
     prompt_file = os.path.join(proj_dir, "fm_agent", "workflow_spec_step4_batch.md")
     command = build_llm_cli_command(
         model=OPENCODE_SPEC_MODEL,
@@ -93,13 +96,9 @@ def _run_spec_generation_batch(
                 "fm_agent/spec_prompts/system_prompt.md",
                 *list_staged_domain_knowledge_relpaths(work_dir),
             ],
-            output_files=[
-                f"{function_file}.spec.json"
-                for function_file in function_files
-            ] + [
-                f"{function_file}.info.json"
-                for function_file in function_files
-            ],
+            output_files=spec_form.trace_outputs(
+                [Path(function_file) for function_file in function_files]
+            ),
             summary=f"OpenCode spec generation for {batch_file}",
             metadata={
                 "attempt": attempt,
@@ -115,11 +114,20 @@ def _run_spec_generation_batch(
 
 def run_spec_generation_and_verification(
     proj_dir, work_dir, input_dir, output_dir, script_dir, spec_prompts_dir,
-    phases_data, resume=False, extra_call_edges=None, only_spec=False,
-    bug_validator_path=None, all_bugs=False,
+    phases_data, spec_generation_config: SpecGenerationConfig, resume=False,
+    extra_call_edges=None, only_spec=False, bug_validator_path=None,
+    all_bugs=False,
 ):
-    # --- Stage 4: Execute spec generation workflow (per phase, per layer) ---
-    batch_md_src = os.path.join(script_dir, "md", "workflow_spec_step4_batch.md")
+    # --- Stage 6: Execute spec generation workflow (per phase, per layer) ---
+    spec_form = spec_generation_config.spec_form
+    run_reasoning = spec_generation_config.should_run_reasoning(only_spec)
+
+    os.makedirs(spec_prompts_dir, exist_ok=True)
+    system_prompt_src = spec_form.system_prompt_path(Path(script_dir))
+    system_prompt_dst = os.path.join(spec_prompts_dir, "system_prompt.md")
+    shutil.copy2(system_prompt_src, system_prompt_dst)
+
+    batch_md_src = spec_form.workflow_prompt_path(Path(script_dir))
     batch_md_dst = os.path.join(work_dir, "workflow_spec_step4_batch.md")
     shutil.copy2(batch_md_src, batch_md_dst)
 
@@ -145,6 +153,13 @@ def run_spec_generation_and_verification(
         with open(layers_json_path, "r") as f:
             layers_data = json.load(f)
         total_layers = layers_data.get("total_layers", 1)
+        expected_dependencies_by_file = {
+            _topdown_unit_path(proj_dir, work_dir, fn["file"]): tuple(
+                fn.get("all_callees", ())
+            )
+            for layer in layers_data.get("layers", [])
+            for fn in layer.get("functions", [])
+        }
 
         batch_dir = os.path.join(
             spec_prompts_dir,
@@ -154,13 +169,11 @@ def run_spec_generation_and_verification(
         for layer_idx in range(total_layers):
             print(f"[Pipeline] Stage 6/6: Phase {phase_num}/{num_phases} — {phase_name}, Layer {layer_idx}/{total_layers - 1}")
 
-            # Generate batch prompts in-process. Stage C will replace this
-            # temporary software form with the resolved Stage 6 strategy.
             manifest = generate_batch_prompts(
                 work_dir=Path(work_dir),
                 phase=phase_num,
                 layers_spec=str(layer_idx),
-                spec_form=SOFTWARE_SPEC_FORM,
+                spec_form=spec_form,
                 output_dir=Path(batch_dir),
                 resume=resume,
             )
@@ -183,11 +196,16 @@ def run_spec_generation_and_verification(
 
             for attempt in range(1, OPENCODE_MAX_RETRIES + 1):
                 # Find batches with unspecced functions
-                pending_batches = _get_pending_batches(all_batches, proj_dir)
+                pending_batches = _get_pending_batches(
+                    all_batches,
+                    proj_dir,
+                    spec_form,
+                    expected_dependencies_by_file,
+                )
                 if not pending_batches:
-                    # All functions in this layer are specced. In only-spec mode
-                    # we stop here without running the reasoner/bug validation.
-                    if not only_spec:
+                    # All functions in this layer are specced. When downstream
+                    # reasoning is disabled, there is no further layer work.
+                    if run_reasoning:
                         incomplete_verification = _get_incomplete_verification_files(
                             layer_files,
                             input_dir,
@@ -239,6 +257,7 @@ def run_spec_generation_and_verification(
                                 layer_idx,
                                 batch_rel_dir,
                                 batch_info,
+                                spec_form,
                             )
                         )
 
@@ -247,7 +266,7 @@ def run_spec_generation_and_verification(
                         f"submitted {len(spec_futures)} spec-generation batch tasks "
                         f"(max_workers={MAX_WORKERS}, total_pending_batches={len(pending_batches)})"
                     )
-                    if spec_futures and not only_spec:
+                    if spec_futures and run_reasoning:
                         newly_processed = streaming_reasoner(
                             input_dir, output_dir, file_list=layer_files,
                             proj_dir=proj_dir, work_dir=work_dir,
@@ -268,9 +287,20 @@ def run_spec_generation_and_verification(
                 # Check if any files in this layer received specs
                 specs_generated = sum(
                     1 for rel in layer_files
-                    if is_file_ready(os.path.join(input_dir, rel))
+                    if spec_form.validate(
+                        Path(os.path.normpath(os.path.join(input_dir, rel))),
+                        expected_dependencies=expected_dependencies_by_file.get(
+                            os.path.normpath(os.path.join(input_dir, rel)),
+                            (),
+                        ),
+                    ).ready
                 )
-                if specs_generated > 0 and not _get_pending_batches(all_batches, proj_dir):
+                if specs_generated > 0 and not _get_pending_batches(
+                    all_batches,
+                    proj_dir,
+                    spec_form,
+                    expected_dependencies_by_file,
+                ):
                     break
 
                 if specs_generated > 0:

--- a/tools/chisel-circt/CMakeLists.txt
+++ b/tools/chisel-circt/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.20.0)
+project(fm-agent-chisel-circt LANGUAGES CXX C)
+
+set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  find_package(CIRCT REQUIRED CONFIG)
+
+  message(STATUS "Using CIRCTConfig.cmake in: ${CIRCT_DIR}")
+  message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+  set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
+  set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
+  set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
+
+  list(APPEND CMAKE_MODULE_PATH "${CIRCT_CMAKE_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+
+  include(TableGen)
+  include(AddLLVM)
+  include(AddMLIR)
+  include(AddCIRCT)
+  include(HandleLLVMOptions)
+endif()
+
+set(FM_AGENT_CHISEL_CIRCT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(FM_AGENT_CHISEL_CIRCT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(${CIRCT_INCLUDE_DIRS})
+include_directories(${FM_AGENT_CHISEL_CIRCT_SOURCE_DIR}/include)
+include_directories(${FM_AGENT_CHISEL_CIRCT_BINARY_DIR}/include)
+link_directories(${LLVM_BUILD_LIBRARY_DIR})
+link_directories(${CIRCT_LIBRARY_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
+
+add_subdirectory(include)
+add_subdirectory(lib)
+add_subdirectory(plugin)

--- a/tools/chisel-circt/README.md
+++ b/tools/chisel-circt/README.md
@@ -1,0 +1,33 @@
+# FM-Agent Chisel CIRCT pass
+
+This directory builds a `firtool` pass plugin that emits the elaborated FIRRTL
+module and instantiation graph as JSON. It does not emit or parse Verilog.
+
+Build it against the same CIRCT tree that supplies `firtool`:
+
+```sh
+cmake -G Ninja -S tools/chisel-circt -B tools/chisel-circt/build \
+  -DCIRCT_DIR=/path/to/circt/build/lib/cmake/circt \
+  -DMLIR_DIR=/path/to/circt/build/lib/cmake/mlir \
+  -DLLVM_DIR=/path/to/circt/build/lib/cmake/llvm
+ninja -C tools/chisel-circt/build FMAgentChiselCirctPlugin
+```
+
+Alternatively, `./install.sh --with-chisel` builds `firtool` and the plugin in
+`$FM_AGENT_CIRCT_ROOT` (default: `~/.cache/fm-agent/circt`) and installs them
+under `~/.local`. The installer pins a tested CIRCT commit; set
+`FM_AGENT_CIRCT_REVISION` to intentionally test another revision and
+`FM_AGENT_CIRCT_JOBS` to control build parallelism.
+
+The Chisel handler enables the direct backend when
+`FM_AGENT_CHISEL_CIRCT_INPUT` points to an elaborated `.fir` or `.mlir` file.
+The remaining settings are optional:
+
+- `FM_AGENT_CHISEL_CIRCT_COMMAND`: `firtool` command, including fixed arguments.
+- `FM_AGENT_CHISEL_CIRCT_PLUGIN`: exact plugin library path.
+- `FM_AGENT_CHISEL_CIRCT_TIMEOUT_SECONDS`: execution timeout; default `180`.
+
+The pass output uses schema version 1 and contains `top`, `modules`, and
+caller-to-callee `edges`. FM-Agent stores the successful, fingerprinted result
+as `fm_agent/chisel_circt_module_graph.json`. Tool discovery or execution
+failures are diagnostic-only and fall back to Chisel source analysis.

--- a/tools/chisel-circt/include/CMakeLists.txt
+++ b/tools/chisel-circt/include/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(FMAgentChiselCirct)

--- a/tools/chisel-circt/include/FMAgentChiselCirct/CMakeLists.txt
+++ b/tools/chisel-circt/include/FMAgentChiselCirct/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls)
+add_public_tablegen_target(FMAgentChiselCirctPassesIncGen)

--- a/tools/chisel-circt/include/FMAgentChiselCirct/Passes.h
+++ b/tools/chisel-circt/include/FMAgentChiselCirct/Passes.h
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+
+#ifndef FM_AGENT_CHISEL_CIRCT_PASSES_H
+#define FM_AGENT_CHISEL_CIRCT_PASSES_H
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+#include <string>
+
+namespace circt {
+namespace firrtl {
+class CircuitOp;
+} // namespace firrtl
+} // namespace circt
+
+namespace fm_agent {
+namespace chisel_circt {
+
+#define GEN_PASS_DECL
+#include "FMAgentChiselCirct/Passes.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "FMAgentChiselCirct/Passes.h.inc"
+
+std::unique_ptr<mlir::Pass> createEmitModuleGraphPass(std::string outputFile);
+
+} // namespace chisel_circt
+} // namespace fm_agent
+
+#endif // FM_AGENT_CHISEL_CIRCT_PASSES_H

--- a/tools/chisel-circt/include/FMAgentChiselCirct/Passes.td
+++ b/tools/chisel-circt/include/FMAgentChiselCirct/Passes.td
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+
+#ifndef FM_AGENT_CHISEL_CIRCT_PASSES
+#define FM_AGENT_CHISEL_CIRCT_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def EmitModuleGraph
+    : Pass<"fm-agent-emit-chisel-module-graph", "circt::firrtl::CircuitOp"> {
+  let summary = "Emit a Chisel module graph JSON file from FIRRTL";
+  let description = [{
+    Walks FIRRTL modules and instances, builds a module-level instantiation
+    graph, and writes a JSON manifest with module symbols, source locations,
+    instance edges, and the circuit top module.
+  }];
+  let options = [
+    Option<"outputFile", "output-file", "std::string", "\"\"",
+           "Path of the JSON graph file to write">
+  ];
+  let dependentDialects = ["::circt::firrtl::FIRRTLDialect"];
+}
+
+#endif // FM_AGENT_CHISEL_CIRCT_PASSES

--- a/tools/chisel-circt/lib/CMakeLists.txt
+++ b/tools/chisel-circt/lib/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_circt_library(FMAgentChiselCirct
+  EmitModuleGraph.cpp
+
+  DEPENDS
+  FMAgentChiselCirctPassesIncGen
+
+  LINK_LIBS PUBLIC
+  CIRCTFIRRTL
+  MLIRIR
+  MLIRPass
+  LLVMSupport
+)

--- a/tools/chisel-circt/lib/EmitModuleGraph.cpp
+++ b/tools/chisel-circt/lib/EmitModuleGraph.cpp
@@ -1,0 +1,186 @@
+//===----------------------------------------------------------------------===//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+
+#include "FMAgentChiselCirct/Passes.h"
+
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/SymbolTable.h"
+
+#include <optional>
+#include <string>
+#include <system_error>
+#include <utility>
+
+namespace fm_agent {
+namespace chisel_circt {
+
+#define GEN_PASS_DEF_EMITMODULEGRAPH
+#include "FMAgentChiselCirct/Passes.h.inc"
+
+namespace {
+
+struct SourceLocation {
+  std::string file;
+  unsigned line = 0;
+  unsigned column = 0;
+};
+
+static std::optional<SourceLocation> findSourceLocation(mlir::Location loc) {
+  if (auto fileLoc = llvm::dyn_cast<mlir::FileLineColLoc>(loc))
+    return SourceLocation{fileLoc.getFilename().str(), fileLoc.getLine(),
+                          fileLoc.getColumn()};
+  if (auto nameLoc = llvm::dyn_cast<mlir::NameLoc>(loc))
+    return findSourceLocation(nameLoc.getChildLoc());
+  if (auto callLoc = llvm::dyn_cast<mlir::CallSiteLoc>(loc)) {
+    if (auto result = findSourceLocation(callLoc.getCallee()))
+      return result;
+    return findSourceLocation(callLoc.getCaller());
+  }
+  if (auto fusedLoc = llvm::dyn_cast<mlir::FusedLoc>(loc)) {
+    for (mlir::Location child : fusedLoc.getLocations())
+      if (auto result = findSourceLocation(child))
+        return result;
+  }
+  return std::nullopt;
+}
+
+static std::string operationSymbol(mlir::Operation *op) {
+  if (auto symbol = op->getAttrOfType<mlir::StringAttr>(
+          mlir::SymbolTable::getSymbolAttrName()))
+    return symbol.getValue().str();
+  if (auto name = op->getAttrOfType<mlir::StringAttr>("name"))
+    return name.getValue().str();
+  return {};
+}
+
+static std::string referencedModule(mlir::Operation *op) {
+  for (llvm::StringRef attrName : {"moduleName", "module_name", "module"}) {
+    if (auto reference =
+            op->getAttrOfType<mlir::FlatSymbolRefAttr>(attrName))
+      return reference.getValue().str();
+    if (auto text = op->getAttrOfType<mlir::StringAttr>(attrName))
+      return text.getValue().str();
+  }
+  return {};
+}
+
+static llvm::json::Object locationJson(mlir::Location loc) {
+  llvm::json::Object result;
+  if (auto source = findSourceLocation(loc)) {
+    result["file"] = source->file;
+    result["line"] = static_cast<int64_t>(source->line);
+    result["column"] = static_cast<int64_t>(source->column);
+  }
+  return result;
+}
+
+class EmitModuleGraphPass
+    : public impl::EmitModuleGraphBase<EmitModuleGraphPass> {
+public:
+  using Base::Base;
+
+  explicit EmitModuleGraphPass(std::string path) {
+    outputFile = std::move(path);
+  }
+
+  void runOnOperation() override {
+    if (outputFile.empty()) {
+      getOperation().emitError("output-file must not be empty");
+      signalPassFailure();
+      return;
+    }
+
+    llvm::json::Array modules;
+    llvm::StringMap<llvm::StringSet<>> edgeSets;
+    std::string top = operationSymbol(getOperation().getOperation());
+
+    mlir::Region &body = getOperation().getOperation()->getRegion(0);
+    if (body.empty()) {
+      getOperation().emitError("FIRRTL circuit has no body");
+      signalPassFailure();
+      return;
+    }
+
+    for (mlir::Operation &moduleOp : body.front()) {
+      llvm::StringRef operationName = moduleOp.getName().getStringRef();
+      if (operationName != "firrtl.module" &&
+          operationName != "firrtl.extmodule" &&
+          operationName != "firrtl.intmodule")
+        continue;
+
+      std::string symbol = operationSymbol(&moduleOp);
+      if (symbol.empty())
+        continue;
+
+      llvm::json::Object module;
+      module["name"] = symbol;
+      module["symbol"] = symbol;
+      module["kind"] = operationName.drop_front(7).str();
+      llvm::json::Object location = locationJson(moduleOp.getLoc());
+      module["location"] = location.empty()
+                               ? llvm::json::Value(nullptr)
+                               : llvm::json::Value(std::move(location));
+      modules.push_back(std::move(module));
+
+      moduleOp.walk([&](mlir::Operation *nested) {
+        if (nested->getName().getStringRef() != "firrtl.instance")
+          return;
+        std::string callee = referencedModule(nested);
+        if (!callee.empty() && callee != symbol)
+          edgeSets[symbol].insert(callee);
+      });
+    }
+
+    llvm::json::Object edges;
+    for (auto &entry : edgeSets) {
+      llvm::json::Array callees;
+      for (auto &callee : entry.getValue())
+        callees.push_back(callee.getKey().str());
+      edges[entry.getKey()] = std::move(callees);
+    }
+
+    llvm::json::Object document;
+    document["schema_version"] = 1;
+    document["top"] = top;
+    document["modules"] = std::move(modules);
+    document["edges"] = std::move(edges);
+    document["source"] = "direct-pass";
+
+    std::error_code error;
+    llvm::raw_fd_ostream output(outputFile, error, llvm::sys::fs::OF_Text);
+    if (error) {
+      getOperation().emitError("cannot open graph output file: ")
+          << error.message();
+      signalPassFailure();
+      return;
+    }
+    output << llvm::formatv("{0:2}\n", llvm::json::Value(std::move(document)));
+    output.flush();
+    if (output.has_error()) {
+      getOperation().emitError("failed to write graph output file");
+      signalPassFailure();
+      return;
+    }
+    markAllAnalysesPreserved();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass>
+createEmitModuleGraphPass(std::string outputFile) {
+  return std::make_unique<EmitModuleGraphPass>(std::move(outputFile));
+}
+
+} // namespace chisel_circt
+} // namespace fm_agent

--- a/tools/chisel-circt/plugin/CMakeLists.txt
+++ b/tools/chisel-circt/plugin/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_llvm_library(FMAgentChiselCirctPlugin
+  MODULE BUILDTREE_ONLY
+  FMAgentChiselCirctPlugin.cpp
+
+  DEPENDS
+  FMAgentChiselCirctPassesIncGen
+
+  PLUGIN_TOOL
+  firtool
+
+  LINK_LIBS
+  FMAgentChiselCirct
+)

--- a/tools/chisel-circt/plugin/FMAgentChiselCirctPlugin.cpp
+++ b/tools/chisel-circt/plugin/FMAgentChiselCirctPlugin.cpp
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+
+#include "FMAgentChiselCirct/Passes.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/Support/Compiler.h"
+#include "mlir/Tools/Plugins/PassPlugin.h"
+
+extern "C" LLVM_ATTRIBUTE_WEAK mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return {
+      MLIR_PLUGIN_API_VERSION,
+      "FMAgentChiselCirctPasses",
+      LLVM_VERSION_STRING,
+      []() { fm_agent::chisel_circt::registerPasses(); },
+  };
+}


### PR DESCRIPTION
## Summary

This PR builds on #209, which provides the plugin-configurable
specification-generation foundation, and takes ownership of the relevant
earlier hardware-language work from #130 and the upstream `chip`.

It adds plugin-driven hardware-language support through the built-in `chip`
plugin. The plugin runs the standard six-stage pipeline for Chisel and
Verilog/SystemVerilog projects and generates standalone module-level
specification artifacts.

This PR completes the hardware-language integration requested by #181.

## Relationship to prior work

The implementation builds on three earlier lines of work:

- #209 introduced the
  plugin-configurable specification-generation foundation in the current architecture.
- #130 introduced
  conservative Chisel module-only extraction and CIRCT-backed module graph
  support.
- The upstream `chip` extended the hardware flow with Chisel/Verilog specification
  generation and artifact validation.

This PR integrates and refactors the relevant functionality into the current
plugin-driven pipeline. It unifies both dialects under `--plugin chip`,
introduces shared hardware specification forms and persisted dialect context,
and replaces the earlier branch-specific entry points with standard pipeline
hooks and validation contracts.

## What changed

- Added the `chip` pipeline plugin with persisted, run-scoped dialect detection.
- Added Chisel support:
  - source-backed module extraction and dependency analysis;
  - optional direct CIRCT module/instance graph analysis;
  - source-analysis fallback when CIRCT is unavailable;
  - optional pinned CIRCT toolchain installation via `install.sh --with-chisel`.
- Added Verilog/SystemVerilog support:
  - Verible-backed module extraction and instantiation analysis;
  - conservative source-scanner fallback;
  - module-level dependency edges with stable extracted-unit identities;
  - filtering for testbench and simulation-only source directories.
- Added hardware specification forms for Chisel and Verilog:
  - sibling `<Module>_spec.md` and `<Module>_info.md` artifacts;
  - structured `<FG-*>`, `<FC-*>`, and `<CK-*>` coverage tags;
  - mandatory `<FG-API>` coverage;
  - dependency coverage validation;
  - validation feedback and retry handling for incomplete artifacts.
- Added scope-aware dialect detection and phase planning for `--submodule`.
- Integrated hardware-specific Stage 1/2 workflow resources and prompt rules.
- Added documentation for plugin usage, configuration, CIRCT, Verible,
  artifact contracts, validation behavior, and current limitations.

## Validation

The implementation was validated against real hardware repositories:

- `schoeberl/chisel-examples`
  - Chisel source-analysis pipeline: successful
  - Chisel CIRCT pipeline: successful
- `ucb-bar/riscv-mini`
  - Chisel source-analysis pipeline: successful
  - Chisel CIRCT pipeline: successful
- `ucb-bar/chipyard`
  - `fpga/src/main/scala`: successful
  - `generators/chipyard/src/main/scala`: successful
  - `generators/chipyard/src/main/resources/vsrc`: successful
- `alexforencich/verilog-uart`
  - Verible pipeline: successful
  - Source-fallback pipeline: successful

Additional local checks:

- `python main.py --list-plugin`
- Python syntax parsing for all Python files
- `git diff --check`

No permanent test suite was added, following the repository's existing convention.
Validation was performed through real-project pipeline runs and temporary local
checks.

## Limitations

- Hardware runs currently generate and validate hardware specifications only;
  the existing software-oriented reasoning and bug-validation backend is not
  enabled for the custom hardware specification forms.
- Chisel source analysis may not fully capture dynamic elaboration; CIRCT should
  be used when an elaborated input is available.
- Exact cycle-level and protocol claims in generated specifications should still
  be reviewed against the RTL source.

Related to #181