### PR TITLE
chore(codegraph): bump pinned build to v1.6.0-fmagent.1

### DIFF
--- a/config.py
+++ b/config.py
@@ -157,7 +157,7 @@ class CodegraphCfg(_Section):
     repo: str = "fmagent-project/codegraph"
     # fm-agent.toml is the authoritative source; this default is only the fallback
     # when the toml is absent. Keep it in sync when bumping the pinned version.
-    version: str = "v1.5.0-fmagent.2"
+    version: str = "v1.6.0-fmagent.1"
     bin_dir: str = "~/.local/bin"  # launcher location; install and run must agree
 
 

--- a/fm-agent.toml
+++ b/fm-agent.toml
@@ -35,12 +35,12 @@ timeout_s = 180     # ELP_TIMEOUT_SECONDS
 # The pinned codegraph build. install.sh reads these to install it, and the
 # runtime invokes that pinned binary — so this is the single place that decides
 # "which codegraph": bump `version` (and `repo`), then re-run ./install.sh to
-# switch. This maintenance-fork build is based on upstream main at c6aaa20 (past
-# v1.5.0, which is why the marker still reads 1.5.0-fmagent.N) and carries one
-# patch of its own: FM-Agent's work directory is excluded from the index by
-# default, so an analysed project is not indexed with a second copy of every
+# switch. This maintenance-fork build re-hosts upstream v1.6.0, which carries the
+# Rust field-receiver and generic-impl fixes and Erlang per-arity identity, and
+# adds one patch of its own: FM-Agent's work directory is excluded from the index
+# by default, so an analysed project is not indexed with a second copy of every
 # function this tool extracted from it. The fork build's updater points back at
 # the fork, so `codegraph upgrade` won't self-replace it with the upstream build.
 repo    = "fmagent-project/codegraph"   # CODEGRAPH_REPO
-version = "v1.5.0-fmagent.2"            # CODEGRAPH_VERSION
+version = "v1.6.0-fmagent.1"            # CODEGRAPH_VERSION
 bin_dir = "~/.local/bin"                # CODEGRAPH_BIN_DIR — where the codegraph launcher is installed and invoked from


### PR DESCRIPTION
Points the pinned build at [`v1.6.0-fmagent.1`](https://github.com/fmagent-project/codegraph/releases/tag/v1.6.0-fmagent.1), which re-hosts upstream `v1.6.0`. See [fmagent-project/codegraph#10](https://github.com/fmagent-project/codegraph/issues/10) for what the sync brings and why.

Relevant to how FM-Agent reads the graph:

- a Rust method call on a struct field resolves on the field's declared type instead of the nearest same-named method, which removes call edges that were never in the source — including self-recursion invented on the calling method itself ([#1585](https://github.com/colbymchenry/codegraph/issues/1585))
- methods of a generic `impl` are recorded under the implementing type rather than the trait, so they are reachable by type and no longer collide with the trait's own declaration ([#1588](https://github.com/colbymchenry/codegraph/issues/1588))
- Erlang functions sharing a name but differing in arity are separate nodes with `module:fun/arity` identity ([#1610](https://github.com/colbymchenry/codegraph/issues/1610)) — FM-Agent routes Erlang through ELP, so this changes nothing here today
- deeply nested C/C++ files no longer kill indexing, and a `.h` whose only C++ construct is `struct Derived : Base` is classified as C++ rather than C

`config.py`'s fallback default is bumped alongside the toml, as on the previous two bumps.

**Re-indexing is required** — the Rust and Erlang node identities both changed, so an existing `.codegraph/` predating this build will not match. `codegraph status` flags it.
